### PR TITLE
Adding Sat1 to ESPHome Dashboard

### DIFF
--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -75,6 +75,10 @@ logger:
   level: debug
 
 
+dashboard_import:
+  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml
+
+
 external_components:
   - source:
       type: git


### PR DESCRIPTION
- enables customer to adopt the sat1 to their ESPHome dashboard and then to modify the code from there.