### PR TITLE
Enabling safe mode

### DIFF
--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -115,6 +115,8 @@ ota:
 
 http_request:
 
+safe_mode:
+
 status_led:
   pin: GPIO45
 


### PR DESCRIPTION
- Enables device to fallback into safemode (necessary because we have manual safemode button already in fw).