### PR TITLE
Enable Improv

### DIFF
--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -87,6 +87,9 @@ voice_assistant:
   auto_gain: 0 dbfs
   volume_multiplier: 1
   on_client_connected:
+    - wait_until:
+        not: ble.enabled
+    - delay: 2s
     - lambda: id(init_in_progress) = false;
     - micro_wake_word.start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};

--- a/config/common/wifi_improv.yaml
+++ b/config/common/wifi_improv.yaml
@@ -6,13 +6,25 @@ globals:
 
 wifi:
   id: wifi_id
-  ap:
   on_connect:
+    - delay: 5s  # Gives time for improv results to be transmitted
+    - ble.disable:
+    - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
   on_disconnect:
+    - ble.enable:
     - script.execute: control_leds
 
 improv_serial:
 
-#esp32_improv:
-#  authorizer: none
+esp32_improv:
+  authorizer: btn_action
+  on_start:
+    - lambda: id(improv_ble_in_progress) = true;
+    - script.execute: control_leds
+  on_provisioned:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_leds
+  on_stop:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_leds


### PR DESCRIPTION
- If device is not connected to Wifi then bluetooth is enabled to allow for easy onboarding
- LEDs indicate status or improv
- removed wifi access point