### PR TITLE
Fix: In duplex mode i2s reports wrong driver status

### DIFF
--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -92,10 +92,10 @@ bool I2SAudioComponent::install_i2s_driver_(i2s_driver_config_t i2s_cfg, uint8_t
         this->installed_cfg_ = i2s_cfg;
       }
     }
-  } else if (this->access_mode_ == I2SAccessMode::DUPLEX && (this->access_state_ & access) == 0){
+  } else if (this->access_mode_ == I2SAccessMode::DUPLEX && this->driver_loaded_ ){
     success = this->validate_cfg_for_duplex_(i2s_cfg);
-    if(success){
-      this->access_state_ |= access;
+    if (!success ){
+      ESP_LOGE(TAG, "incompatible i2s settings for duplex mode, access_state: %d", this->access_state_);
     }
   }
   this->unlock();


### PR DESCRIPTION
When running I2S in duplex mode and one of the component tries to install the driver while it has been already installed by the other component, installing the driver was reported as failed. It should return success though as it is already running.

This PR fixes this.

Closes #92. 