### PR TITLE
Bump to XMOS firmware v1.0.1-alpha.28 (use fixed_delay pipeline)

### DIFF
--- a/config/common/home_assistant.yaml
+++ b/config/common/home_assistant.yaml
@@ -39,8 +39,8 @@ button:
         - lambda: id(xmos_flashing_started) = true;
         - script.execute: control_leds
         - ota.satellite1.flash:
-            url: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_adec.factory.bin
-            md5_url: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_adec.factory.md5
+            url: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.bin
+            md5_url: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.md5
 
 
 switch:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -9,7 +9,7 @@ substitutions:
   component_name: Core
   
   esp32_fw_version: "v2.0.0-alpha.8"
-  xmos_fw_version: "v1.0.1-alpha.27"
+  xmos_fw_version: "v1.0.1-alpha.28"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
 


### PR DESCRIPTION
The XMOS firmware v1.0.1-alpha.28 builds these variants:
- bypass
- adec
- fixed_delay

This PR sets to use fixed_delay pipeline