### PR TITLE
Incomplete - Introducing Factory Firmware

### DIFF
--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -32,5 +32,3 @@ spi:
     mosi_pin: GPIO39
     miso_pin: GPIO41
     interface: SPI3
-
-

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -87,9 +87,6 @@ voice_assistant:
   auto_gain: 0 dbfs
   volume_multiplier: 1
   on_client_connected:
-    - wait_until:
-        not: ble.enabled
-    - delay: 2s
     - lambda: id(init_in_progress) = false;
     - micro_wake_word.start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};

--- a/config/common/wifi_improv.yaml
+++ b/config/common/wifi_improv.yaml
@@ -6,6 +6,8 @@ globals:
 
 wifi:
   id: wifi_id
+  #TODO: For some reason our FW needs this when Nabu doesn't.  AP should not be necessary.
+  ap:
   on_connect:
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds

--- a/config/common/wifi_improv.yaml
+++ b/config/common/wifi_improv.yaml
@@ -7,24 +7,7 @@ globals:
 wifi:
   id: wifi_id
   on_connect:
-    - delay: 5s  # Gives time for improv results to be transmitted
-    - ble.disable:
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
   on_disconnect:
-    - ble.enable:
-    - script.execute: control_leds
-
-improv_serial:
-
-esp32_improv:
-  authorizer: btn_action
-  on_start:
-    - lambda: id(improv_ble_in_progress) = true;
-    - script.execute: control_leds
-  on_provisioned:
-    - lambda: id(improv_ble_in_progress) = false;
-    - script.execute: control_leds
-  on_stop:
-    - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds

--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -3,7 +3,7 @@ substitutions:
   project_name: Satellite1
 
   #set this version by GHA at build time
-  esp32_fw_version: "v2.0.0-alpha.26"
+  esp32_fw_version: "v2.0.0-alpha.32"
 
 packages:
   # This is an inline package to prefix the on_client_connected with the wait_until action
@@ -36,10 +36,11 @@ update:
     name: None
     id: update_http_request
     # source: https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json
-    source: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifests/${esp32_fw_version}/satellite1-r3-esp32s3.manifest.json
+    source: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/simulating-latest-manifest-json-http-endpoint/manifests/latest/satellite1-esp32s3.manifest.json
 
 dashboard_import:
-  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml
+  # package_import_url: github://esphome/home-assistant-voice-pe/home-assistant-voice.yaml
+  package_import_url: github://FutureProofHomes/Documentation/simulating-latest-manifest-json-http-endpoint/manifests/latest/satellite1.yaml
 
 wifi:
   on_connect:
@@ -73,8 +74,8 @@ switch:
     on_turn_on:
       - logger.log: "OTA updates set to use Beta firmware"
       # - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest-beta.json");
-      - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifests/${esp32_fw_version}/satellite1-r3-esp32s3.manifest.json");
+      - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/simulating-latest-manifest-json-http-endpoint/manifests/latest/satellite1-beta-esp32s3.manifest.json");
     on_turn_off:
       - logger.log: "OTA updates set to use Production firmware"
       # - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json");
-      - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifests/${esp32_fw_version}/satellite1-r3-esp32s3.manifest.json");
+      - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/simulating-latest-manifest-json-http-endpoint/manifests/latest/satellite1-esp32s3.manifest.json");

--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -1,0 +1,80 @@
+substitutions:
+  company_name: FutureProofHomes
+  project_name: Satellite1
+
+  #set this version by GHA at build time
+  esp32_fw_version: "v2.0.0-alpha.26"
+
+packages:
+  # This is an inline package to prefix the on_client_connected with the wait_until action
+  # It must appear before the actual package so it becomes the orignal config and the
+  # on_client_connected list from the package config is appended onto this one.
+  va_connected_wait_for_ble:
+    voice_assistant:
+      on_client_connected:
+        - wait_until:
+            not: ble.enabled
+        - delay: 2s
+    wifi:
+      on_disconnect:
+        - ble.enable:
+  home-assistant-voice: !include satellite1.yaml
+
+esphome:
+  project:
+    name: ${company_name}.${project_name}
+    version: dev
+
+ota:
+  - platform: http_request
+    id: ota_http_request
+
+http_request:
+
+update:
+  - platform: http_request
+    name: None
+    id: update_http_request
+    # source: https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json
+    source: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifests/${esp32_fw_version}/satellite1-r3-esp32s3.manifest.json
+
+dashboard_import:
+  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml
+
+wifi:
+  on_connect:
+    - delay: 5s  # Gives time for improv results to be transmitted
+    - ble.disable:
+    - script.execute: control_leds
+
+improv_serial:
+
+esp32_improv:
+  authorizer: btn_action
+  on_start:
+    - lambda: id(improv_ble_in_progress) = true;
+    - script.execute: control_leds
+  on_provisioned:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_leds
+  on_stop:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_leds
+
+switch:
+  - platform: template
+    id: beta_firmware
+    name: Beta firmware
+    icon: "mdi:test-tube"
+    disabled_by_default: true
+    entity_category: diagnostic
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    on_turn_on:
+      - logger.log: "OTA updates set to use Beta firmware"
+      # - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest-beta.json");
+      - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifests/${esp32_fw_version}/satellite1-r3-esp32s3.manifest.json");
+    on_turn_off:
+      - logger.log: "OTA updates set to use Production firmware"
+      # - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json");
+      - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifests/${esp32_fw_version}/satellite1-r3-esp32s3.manifest.json");

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -3,12 +3,12 @@ substitutions:
   friendly_name: "Satellite1"  
 
   #Recommend leaving the following unchanged
-  node_name: satellite1-r3
+  node_name: satellite1
   company_name: FutureProofHomes
   project_name: Satellite1
   component_name: Core
   
-  esp32_fw_version: "v2.0.0-alpha.8"
+  esp32_fw_version: "v2.0.0-alpha.26"
   xmos_fw_version: "v1.0.1-alpha.28"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
@@ -75,10 +75,6 @@ logger:
   level: debug
 
 
-dashboard_import:
-  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml
-
-
 external_components:
   - source:
       type: git
@@ -114,8 +110,8 @@ packages:
 ota:
   - platform: satellite1
     id: ota_satellite1_xmos
-  
   - platform: esphome
+    id: ota_esphome
 
 http_request:
 


### PR DESCRIPTION
- The factory firmware contains a BLE improv implementation (which is a memory hog).
- When the customer onboards the device to their Home Assistant it should update & re-flash the device with the "non-factory" firmware (which does not contain BLE improv) and therefore frees up memory on the device.
- Currently the update and reflashing is not happening exactly as it does on Nabu devices because I think we need to properly merge voice-kit into our product. Ticket #38
- For some reason our FW needs an Wifi Access Point to be defined in order to compile in our GHA w/ ESPhome v2024.10.0.  I am temporarily adding this but we should remove it.