### PR TITLE
Change action button to esp gpio 0

### DIFF
--- a/config/common/buttons.yaml
+++ b/config/common/buttons.yaml
@@ -83,9 +83,7 @@ binary_sensor:
   - platform: gpio
     id: btn_action
     pin:
-      satellite1: 
-      port: INPUT_A
-      pin: 1
+      number: 0
       inverted: true
     name: "Button Right (Action)"
     icon: "mdi:gesture-tap"


### PR DESCRIPTION
The action button is directly wired to GPIO pin of the ESP.
To be able to use the action button also without a xmos firmware, we change to read from that pin.