### PR TITLE
ensure output of wake word testing is ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ sdkconfig.esp32-s3-idf
 **/secrets.yaml
 
 /testdata
+/wake-word-benchmark/


### PR DESCRIPTION
- remove /wake-word-benchmark/ from version control