### PR TITLE
Update build workflow and add developer build script

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -44,7 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # To create a major bump add #major to commit message
-          DEFAULT_BUMP: ${{ github.ref_name == 'main' && 'minor' || github.ref_name == 'staging' && 'minor' || 'patch' }}
+          DEFAULT_BUMP: 'patch'
           WITH_V: true
           PRERELEASE: ${{ github.ref_name != 'main' }}
           PRERELEASE_SUFFIX: ${{ github.ref_name == 'staging' && 'beta' || 'alpha' }}
@@ -102,7 +102,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # To create a major bump add #major to commit message
-          DEFAULT_BUMP: ${{ github.ref_name == 'main' && 'minor' || github.ref_name == 'staging' && 'minor' || 'patch' }}
+          DEFAULT_BUMP: 'patch'
           WITH_V: true
           PRERELEASE: ${{ github.ref_name != 'main' }}
           PRERELEASE_SUFFIX: ${{ github.ref_name == 'staging' && 'beta' || 'alpha' }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -49,7 +49,7 @@ jobs:
           PRERELEASE: ${{ github.ref_name != 'main' }}
           PRERELEASE_SUFFIX: ${{ github.ref_name == 'staging' && 'beta' || 'alpha' }}
           DRY_RUN: true # Prevent action from pushing the tag.
-          INITIAL_VERSION: 1.0.0
+          INITIAL_VERSION: 0.0.0
 
       - name: Set tag for release
         if: ${{ steps.set_tag.outputs.manual_tag || steps.bump.outputs.tag }}
@@ -107,7 +107,7 @@ jobs:
           PRERELEASE: ${{ github.ref_name != 'main' }}
           PRERELEASE_SUFFIX: ${{ github.ref_name == 'staging' && 'beta' || 'alpha' }}
           DRY_RUN: false # Set the tag to the commit.
-          INITIAL_VERSION: 1.0.0
+          INITIAL_VERSION: 0.0.0
 
       - name: Release Changelog Builder
         id: changelog
@@ -117,6 +117,8 @@ jobs:
 
   create_release:
     name: Create Release
+    # only build release for staging and main branches
+    if: github.ref_name == 'main' || github.ref_name == 'staging' 
     needs:
       - push-tag
       - prepare
@@ -132,12 +134,11 @@ jobs:
           mkdir -p build
           echo "Copying all files to build directory"
           find files -name "*.bin" -exec cp {} build/ \;
-          zip -r build.zip build
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: build.zip
+          files: build/*.bin
           generate_release_notes: true
           append_body: true
           body: ${{ needs.push-tag.outputs.changelog }}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+esphome_version=dev
+
+if [ -z "$2" ]; then
+    echo "Usage: ./build.sh <esphome_version> <yaml_file>"
+    exit 1
+fi
+yaml_file=$2
+
+
+docker run --rm -it\
+  -v "$(pwd)":"/config" \
+  -v "$HOME:$HOME" \
+  -e HOME \
+  --user $(id -u):$(id -g) \
+  esphome/esphome:$esphome_version compile $yaml_file


### PR DESCRIPTION
Refine the workflow to build only for staging and main branches, and update the file upload process for releases. Introduce a new script for developer builds.