### PR TITLE
Change to local led control via esp32_rmt_led_strip component

### DIFF
--- a/config/common/led_ring.yaml
+++ b/config/common/led_ring.yaml
@@ -8,8 +8,13 @@ globals:
     restore_value: no
     initial_value: '0'
 
-light:
-  - platform: ${led_ring_platform}
+light:  
+ -  platform: esp32_rmt_led_strip
+    pin: GPIO21
+    rmt_channel: 1
+    num_leds: 24
+    rgb_order: GRB
+    chipset: WS2812
     id: satellite1_led_ring
     name: LED Ring
     entity_category: config

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -109,11 +109,8 @@ packages:
   va: !include common/voice_assistant.yaml
   # timer requires voice_assistant.yaml
   timer: !include common/timer.yaml
-  
-  led_ring: !include 
-    file: common/led_ring.yaml
-    vars:
-      led_ring_platform: satellite1
+  led_ring: !include common/led_ring.yaml 
+    
   
   #debug: !include common/debug.yaml
 


### PR DESCRIPTION
With hardware rev4 we are able to control the led-ring directly from the ESP32-S3.

This PR changes the light (led-ring) platform to esp32_rmt_led_strip.

This removes the dependency on the XMOS firmware for controlling the LEDs which is a requirement for using the LED ring as a visual progress status while flashing the XMOS.

closes #40
