### PR TITLE
Enable pull-up for GPIO0 (boot/action button)

### DIFF
--- a/config/common/buttons.yaml
+++ b/config/common/buttons.yaml
@@ -93,6 +93,9 @@ binary_sensor:
     pin:
       number: 0
       inverted: true
+      mode:
+        input: true
+        pullup: true
       ignore_strapping_warning: true
     name: "Button Right (Action)"
     icon: "mdi:gesture-tap"


### PR DESCRIPTION
If the HAT is not connected to the core, the value of the gpio pin for the action/boot button is floating.
When the HAT is connected, the pull-up from the XMOS is used.

This PR enables the internal pull-up for pin 0 on the ESP32-S3.