### PR TITLE
Using ESPHome 2024.11.2's LED "initial_state" prop

### DIFF
--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -75,7 +75,7 @@ jobs:
     uses: esphome/workflows/.github/workflows/build.yml@main
     with:
       files: ${{ fromJSON(needs.build-list.outputs.build_cfg_files) }}
-      esphome-version: 2024.10.0
+      esphome-version: 2024.11.2
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -78,7 +78,7 @@ jobs:
     uses: esphome/workflows/.github/workflows/build.yml@main
     with:
       files: ${{ fromJSON(needs.prepare.outputs.build_cfg_files) }}
-      esphome-version: 2024.10.0
+      esphome-version: 2024.11.2
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
   push-tag:

--- a/config/common/buttons.yaml
+++ b/config/common/buttons.yaml
@@ -213,7 +213,7 @@ binary_sensor:
                     id: play_sound
                     priority: false
                     sound_file: !lambda return id(center_button_long_press_sound);
-                - light.turn_off: satellite1_led_ring
+                - light.turn_off: voice_assistant_leds
                 - event.trigger:
                     id: action_button_press_event
                     event_type: "long_press"
@@ -229,7 +229,7 @@ binary_sensor:
               then:
                 - light.turn_on:
                     brightness: 100%
-                    id: satellite1_led_ring
+                    id: voice_assistant_leds
                     effect: "Factory Reset Coming Up"
                 - script.execute:
                     id: play_sound
@@ -237,7 +237,7 @@ binary_sensor:
                     sound_file: !lambda return id(factory_reset_initiated_sound);
                 - wait_until:
                     binary_sensor.is_off: btn_action
-                - light.turn_off: satellite1_led_ring
+                - light.turn_off: voice_assistant_leds
                 - script.execute:
                     id: play_sound
                     priority: true

--- a/config/common/led_ring.yaml
+++ b/config/common/led_ring.yaml
@@ -8,32 +8,34 @@ globals:
     restore_value: no
     initial_value: '0'
 
-light:  
- -  platform: esp32_rmt_led_strip
+light:
+  # Hardware LED ring. Not used because remapping needed
+  - platform: esp32_rmt_led_strip
+    id: leds_internal
     pin: GPIO21
     rmt_channel: 1
     num_leds: 24
     rgb_order: GRB
     chipset: WS2812
-    id: satellite1_led_ring
-    name: LED Ring
-    entity_category: config
-    icon: "mdi:dots-circle"
     default_transition_length: 0ms
-    restore_mode: RESTORE_DEFAULT_OFF
-    #TODO: Need to wait for latest version of esphome to introduce the `initial_state` property
-    # initial_state:
-    #   color_mode: rgb
-    #   brightness: 66%
-    #   red: 9.4%
-    #   green: 73.3%
-    #   blue: 94.9%
+    # power_supply: led_power
+
+  # Voice Assistant LED ring. Remapping of the internal LED.
+  # This light is not exposed. The device controls it
+  - platform: partition
+    id: voice_assistant_leds
+    internal: true
+    default_transition_length: 0ms
+    segments:
+      - id: leds_internal
+        from: 0
+        to: 23
     effects:
       - addressable_lambda:
           name: "Waiting for Command"
           update_interval: 100ms
           lambda: |-
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             for (int i = 0; i < 24; i++) {
@@ -58,7 +60,7 @@ light:
           name: "Listening For Command"
           update_interval: 50ms
           lambda: |-
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             for (int i = 0; i < 24; i++) {
@@ -90,7 +92,7 @@ light:
               brightness_step = 0;
               brightness_decreasing = true;
             }
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             for (int i = 0; i < 24; i++) {
@@ -115,7 +117,7 @@ light:
           update_interval: 50ms
           lambda: |-
             id(global_led_animation_index) = (24 + id(global_led_animation_index) - 1) % 24;
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             for (int i = 0; i < 24; i++) {
@@ -141,7 +143,7 @@ light:
           lambda: |-
             static int8_t index = 0;
             Color muted_color(255, 0, 0);
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             for (int i = 0; i < 24; i++) {
@@ -152,23 +154,46 @@ light:
               }
             }
             if ( id(master_mute_switch).state ) {
-              it[2] = Color::BLACK;
-              it[3] = muted_color;
-              it[4] = Color::BLACK;
-              it[8] = Color::BLACK;
-              it[9] = muted_color;
-              it[10] = Color::BLACK;
-            }
-            if ( id(nabu_media_player).volume == 0.0f || id(nabu_media_player).is_muted() ) {
+              it[23] = Color::BLACK;
+              it[0] = muted_color;
+              it[1] = Color::BLACK;
               it[5] = Color::BLACK;
               it[6] = muted_color;
               it[7] = Color::BLACK;
+              it[11] = Color::BLACK;
+              it[12] = muted_color;
+              it[13] = Color::BLACK;
+              it[17] = Color::BLACK;
+              it[18] = muted_color;
+              it[19] = Color::BLACK;
+            }
+            if ( id(nabu_media_player).volume == 0.0f || id(nabu_media_player).is_muted() ) {
+              it[1] = Color::BLACK;
+              it[2] = muted_color;
+              it[3] = muted_color;
+              it[4] = muted_color;
+              it[5] = Color::BLACK;
+              it[7] = Color::BLACK;
+              it[8] = muted_color;
+              it[9] = muted_color;
+              it[10] = muted_color;
+              it[11] = Color::BLACK;
+              it[13] = Color::BLACK;
+              it[14] = muted_color;
+              it[15] = muted_color;
+              it[16] = muted_color;
+              it[17] = Color::BLACK;
+              it[19] = Color::BLACK;
+              it[20] = muted_color;
+              it[21] = muted_color;
+              it[22] = muted_color;
+              it[23] = Color::BLACK;
             }
       - addressable_lambda:
           name: "Volume Display"
           update_interval: 50ms
           lambda: |-
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             Color silenced_color(255, 0, 0);
@@ -189,14 +214,14 @@ light:
           lambda: |-
             if (initial_run) {
               // set voice_assistant_leds light to colors based on led_ring
-              auto led_ring_cv = id(satellite1_led_ring).current_values;
-              auto va_leds_call = id(satellite1_led_ring).make_call();
+              auto led_ring_cv = id(led_ring).current_values;
+              auto va_leds_call = id(voice_assistant_leds).make_call();
               va_leds_call.from_light_color_values(led_ring_cv);
-              va_leds_call.set_brightness( min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f ) );
+              va_leds_call.set_brightness( min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f ) );
               va_leds_call.set_state(true);
               va_leds_call.perform();
             }
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(voice_assistant_leds).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             for (int i = 0; i < 24; i++) {
@@ -281,7 +306,7 @@ light:
               brightness_step = 0;
               brightness_decreasing = true;
             }
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             Color muted_color(255, 0, 0);
@@ -304,7 +329,7 @@ light:
           name: "Timer Tick"
           update_interval: 100ms
           lambda: |-
-            auto light_color = id(satellite1_led_ring).current_values;
+            auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             Color muted_color(255, 0, 0);
@@ -389,7 +414,7 @@ light:
               if (initial_run) {
                 index = 0;
               }
-              auto light_color = id(satellite1_led_ring).current_values;
+              auto light_color = id(led_ring).current_values;
               Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                     light_color.get_blue() * 255);
               if (index <= 12) {
@@ -412,7 +437,7 @@ light:
               if (initial_run) {
                 index = 0;
               }
-              auto light_color = id(satellite1_led_ring).current_values;
+              auto light_color = id(led_ring).current_values;
               Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                     light_color.get_blue() * 255);
               if (index <= 12) {
@@ -428,7 +453,29 @@ light:
               }
               index = (index + 1);
 
+  # User facing LED ring. Remapping of the internal LEDs.
+  # Exposed to be used by the user.
+  - platform: partition
+    id: led_ring
+    name: LED Ring
+    entity_category: config
+    icon: "mdi:dots-circle"
+    default_transition_length: 0ms
+    restore_mode: RESTORE_DEFAULT_OFF
+    initial_state:
+      color_mode: rgb
+      brightness: 66%
+      red: 9.4%
+      green: 73.3%
+      blue: 94.9%
+    segments:
+      - id: leds_internal
+        from: 0
+        to: 23
 
+# power_supply:
+#   - id: led_power
+#     pin: GPIO45
 
 script:
   # Master script controlling the LEDs, based on different conditions : initialization in progress, wifi and api connected and voice assistant phase.
@@ -488,7 +535,7 @@ script:
           red: 100%
           green: 89%
           blue: 71%
-          id: satellite1_led_ring
+          id: voice_assistant_leds
           effect: "Twinkle"
 
   # Script executed during initialization
@@ -504,7 +551,7 @@ script:
                 red: 9.4%
                 green: 73.3%
                 blue: 94.9%
-                id: satellite1_led_ring
+                id: voice_assistant_leds
                 effect: "Twinkle"
           else:
             - light.turn_on:
@@ -512,7 +559,7 @@ script:
                 red: 100%
                 green: 89%
                 blue: 71%
-                id: satellite1_led_ring
+                id: voice_assistant_leds
                 effect: "none"
 
   # Script executed when the device has no connection to Home Assistant
@@ -524,27 +571,27 @@ script:
           red: 1
           green: 0
           blue: 0
-          id: satellite1_led_ring
+          id: voice_assistant_leds
           effect: "Twinkle"
 
   # Script executed when the voice assistant is idle (waiting for a wake word)
   # Nothing (Either LED ring off or LED ring on if the user decided to turn the user facing LED ring on)
   - id: control_leds_voice_assistant_idle_phase
     then:
-      - light.turn_off: satellite1_led_ring
+      - light.turn_off: voice_assistant_leds
       - if:
           condition:
-            light.is_on: ${led_ring_id}
+            light.is_on: led_ring
           then:
-            light.turn_on: ${led_ring_id}
+            light.turn_on: led_ring
 
   # Script executed when the voice assistant is waiting for a command (After the wake word)
   # Slow clockwise spin of the LED ring.
   - id: control_leds_voice_assistant_waiting_for_command_phase
     then:
       - light.turn_on:
-          brightness: !lambda return max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f );
-          id: satellite1_led_ring
+          brightness: !lambda return max( id(led_ring).current_values.get_brightness() , 0.2f );
+          id: voice_assistant_leds
           effect: "Waiting for Command"
 
   # Script executed when the voice assistant is listening to a command
@@ -552,8 +599,8 @@ script:
   - id: control_leds_voice_assistant_listening_for_command_phase
     then:
       - light.turn_on:
-          brightness: !lambda return max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f );
-          id: satellite1_led_ring
+          brightness: !lambda return max( id(led_ring).current_values.get_brightness() , 0.2f );
+          id: voice_assistant_leds
           effect: "Listening For Command"
 
   # Script executed when the voice assistant is thinking to a command
@@ -561,8 +608,8 @@ script:
   - id: control_leds_voice_assistant_thinking_phase
     then:
       - light.turn_on:
-          brightness: !lambda return max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f );
-          id: satellite1_led_ring
+          brightness: !lambda return max( id(led_ring).current_values.get_brightness() , 0.2f );
+          id: voice_assistant_leds
           effect: "Thinking"
 
   # Script executed when the voice assistant is thinking to a command
@@ -570,8 +617,8 @@ script:
   - id: control_leds_voice_assistant_replying_phase
     then:
       - light.turn_on:
-          brightness: !lambda return max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f );
-          id: satellite1_led_ring
+          brightness: !lambda return max( id(led_ring).current_values.get_brightness() , 0.2f );
+          id: voice_assistant_leds
           effect: "Replying"
 
   # Script executed when the voice assistant is in error
@@ -579,11 +626,11 @@ script:
   - id: control_leds_voice_assistant_error_phase
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
           red: 1
           green: 0
           blue: 0
-          id: satellite1_led_ring
+          id: voice_assistant_leds
           effect: "Error"
       - delay: 2s
       - lambda: id(volume_buttons_touched) = false;
@@ -594,11 +641,11 @@ script:
   - id: control_leds_warning
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
           red: 1
           green: 0
           blue: 0
-          id: satellite1_led_ring
+          id: voice_assistant_leds
           effect: "Warning"
       - delay: 2s
       - lambda: id(warning) = false;
@@ -609,8 +656,8 @@ script:
   - id: control_leds_muted_or_silent
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
-          id: satellite1_led_ring
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          id: voice_assistant_leds
           effect: "Muted or Silent"
 
   # Script executed when the voice assistant is not ready
@@ -621,7 +668,7 @@ script:
           red: 1
           green: 0
           blue: 0
-          id: satellite1_led_ring
+          id: voice_assistant_leds
           effect: "Twinkle"
 
   # Script executed when the volume button is touched
@@ -629,8 +676,8 @@ script:
   - id: control_leds_volume_buttons_touched
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
-          id: satellite1_led_ring
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          id: voice_assistant_leds
           effect: "Volume Display"  
 
   # Script executed when the jack has just been unplugged
@@ -638,8 +685,8 @@ script:
   - id: control_leds_jack_unplugged_recently
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
-          id: satellite1_led_ring
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          id: voice_assistant_leds
           effect: "Jack Unplugged"
 
   # Script executed when the jack has just been plugged
@@ -647,8 +694,8 @@ script:
   - id: control_leds_jack_plugged_recently
     then:
       - light.turn_on:
-          brightness: 100%
-          id: satellite1_led_ring
+          brightness: !lambda return max( id(led_ring).current_values.get_brightness() , 0.2f );
+          id: voice_assistant_leds
           effect: "Jack Plugged"
 
   # Script executed when the center button is touched
@@ -656,8 +703,8 @@ script:
   - id: control_leds_action_button_touched
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
-          id: satellite1_led_ring
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          id: voice_assistant_leds
           effect: "Action Button Touched"
 
   # Script executed when the timer is ringing, to control the LEDs
@@ -665,8 +712,8 @@ script:
   - id: control_leds_timer_ringing
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
-          id: satellite1_led_ring
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          id: voice_assistant_leds
           effect: "Timer Ring"
 
   # Script executed when the timer is ticking, to control the LEDs
@@ -674,8 +721,8 @@ script:
   - id: control_leds_timer_ticking
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
-          id: satellite1_led_ring
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          id: voice_assistant_leds
           effect: "Timer tick"
 
   # Script executed when the timer is ticking, to control the LEDs
@@ -683,8 +730,6 @@ script:
   - id: control_leds_xmos_flashing_started
     then:
       - light.turn_on:
-          brightness: !lambda return min ( max( id(satellite1_led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
-          id: satellite1_led_ring
+          brightness: !lambda return min ( max( id(led_ring).current_values.get_brightness() , 0.2f ) + 0.1f , 1.0f );
+          id: voice_assistant_leds
           effect: "Flashing XMOS"
-
-  


### PR DESCRIPTION
- Building firmware via new ESPHome version 2024.11.2 that gives us the "initial_state" prop which now boots the device using the correct blue color
- Now we have user-facing LED colors the customer can set while still maintaining the appropriate colors in our LED animations
- Fixes the volume mute, hardware mute & software mute LED animations
- Stops error LED animation from overwriting the customer's chosen color theme