### PR TITLE
Memory Optimized "factory firmware" with BLE improv for Rev4

### DIFF
--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -12,6 +12,9 @@ esp32:
     version: recommended
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
+      CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: "y"
+      CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST: "y"
+      CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY: "y"
 
 psram:
   mode: octal

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -101,7 +101,6 @@ voice_assistant:
   auto_gain: 0 dbfs
   volume_multiplier: 1
   on_client_connected:
-    - delay: 2s
     - lambda: id(init_in_progress) = false;
     - micro_wake_word.start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};

--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -1,0 +1,81 @@
+substitutions:
+  company_name: FutureProofHomes
+  project_name: Satellite1
+
+  #set this version by GHA at build time
+  esp32_fw_version: "v2.0.0-alpha.32"
+
+packages:
+  # This is an inline package to prefix the on_client_connected with the wait_until action
+  # It must appear before the actual package so it becomes the orignal config and the
+  # on_client_connected list from the package config is appended onto this one.
+  va_connected_wait_for_ble:
+    voice_assistant:
+      on_client_connected:
+        - wait_until:
+            not: ble.enabled
+        - delay: 2s
+    wifi:
+      on_disconnect:
+        - ble.enable:
+  home-assistant-voice: !include satellite1.yaml
+
+esphome:
+  project:
+    name: ${company_name}.${project_name}
+    version: dev
+
+ota:
+  - platform: http_request
+    id: ota_http_request
+
+http_request:
+
+update:
+  - platform: http_request
+    name: None
+    id: update_http_request
+    # source: https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json
+    source: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/simulating-latest-manifest-json-http-endpoint/manifests/latest/satellite1-esp32s3.manifest.json
+
+dashboard_import:
+  # package_import_url: github://esphome/home-assistant-voice-pe/home-assistant-voice.yaml
+  package_import_url: github://FutureProofHomes/Documentation/simulating-latest-manifest-json-http-endpoint/manifests/latest/satellite1.yaml
+
+wifi:
+  on_connect:
+    - delay: 5s  # Gives time for improv results to be transmitted
+    - ble.disable:
+    - script.execute: control_leds
+
+improv_serial:
+
+esp32_improv:
+  authorizer: btn_action
+  on_start:
+    - lambda: id(improv_ble_in_progress) = true;
+    - script.execute: control_leds
+  on_provisioned:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_leds
+  on_stop:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_leds
+
+switch:
+  - platform: template
+    id: beta_firmware
+    name: Beta firmware
+    icon: "mdi:test-tube"
+    disabled_by_default: true
+    entity_category: diagnostic
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    on_turn_on:
+      - logger.log: "OTA updates set to use Beta firmware"
+      # - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest-beta.json");
+      - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/simulating-latest-manifest-json-http-endpoint/manifests/latest/satellite1-beta-esp32s3.manifest.json");
+    on_turn_off:
+      - logger.log: "OTA updates set to use Production firmware"
+      # - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json");
+      - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/simulating-latest-manifest-json-http-endpoint/manifests/latest/satellite1-esp32s3.manifest.json");

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -110,7 +110,6 @@ packages:
   ha: !include common/home_assistant.yaml
   mp: !include common/media_player.yaml
   va: !include common/voice_assistant.yaml
-  # timer requires voice_assistant.yaml
   timer: !include common/timer.yaml
   led_ring: !include common/led_ring.yaml 
     
@@ -123,6 +122,7 @@ ota:
     id: ota_satellite1_xmos
   
   - platform: esphome
+    id: ota_esphome
 
 http_request:
 
@@ -140,9 +140,3 @@ satellite1:
   data_rate: 8000000
   spi_mode: MODE3
   xmos_rst_pin: GPIO4
-  
-
-
-   
-
-


### PR DESCRIPTION
- With proper SDKConfigs (thanks to Kevin @ Nabu for tips) we can now have BLE improv safely in our firmware while still having enough memory for optimal user-experience
- This PR replaces the previous outdated PR #105 
- After cold boot + wakeword and tts response + streaming music we still have plenty of memory available! 
![image](https://github.com/user-attachments/assets/7190ca33-adf1-4a05-8cfc-4acff0d12d5c)
