### PR TITLE
Optional LD2410 MMWave

### DIFF
--- a/config/common/mmwave_ld2410.yaml
+++ b/config/common/mmwave_ld2410.yaml
@@ -1,0 +1,20 @@
+ld2410:
+
+uart:
+  tx_pin: GPIO43
+  rx_pin: GPIO44
+  baud_rate: 256000
+  parity: NONE
+  stop_bits: 1
+
+binary_sensor:
+  - platform: ld2410
+    has_target:
+      name: Room Presence
+      id: room_presence
+    has_moving_target:
+      name: Moving Target
+    has_still_target:
+      name: Still Target
+    out_pin_presence_status:
+      name: out pin presence status

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -101,7 +101,6 @@ external_components:
 packages:
   core_board: !include common/core_board.yaml
   wifi: !include common/wifi_improv.yaml
-  
   sensors: !include common/hat_sensors.yaml
   buttons: !include common/buttons.yaml
   ha: !include common/home_assistant.yaml
@@ -111,8 +110,9 @@ packages:
   timer: !include common/timer.yaml
   led_ring: !include common/led_ring.yaml 
     
-  
-  #debug: !include common/debug.yaml
+  #OPTIONAL COMPONENTS 
+  # mmwave_ld2410: !include common/mmwave_ld2410.yaml
+  # debug: !include common/debug.yaml
 
 ota:
   - platform: satellite1


### PR DESCRIPTION
- Default is turned to off
- Customer can uncomment the code to enable the sensor and it will just work.