### PR TITLE
GH-Workflows: hardcoded list of config files that get built

### DIFF
--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -14,67 +14,12 @@ env:
   DEFAULT_PYTHON: "3.9"
 
 jobs:
-  build-list:    
-    runs-on: ubuntu-latest
-    outputs:
-      build_firmware:  ${{ steps.final_list.outputs.build_firmware }} 
-      build_cfg_files: ${{ steps.final_list.outputs.files }}
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.6  
-      
-      - name: Find all YAML satellite files
-        id: all-satellite-files
-        run: |
-          echo "matrix=$(ls config/satellite*.yaml | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
-          echo "all_files=$(ls config/satellite*.yaml | jq --slurp --raw-input )" >> $GITHUB_OUTPUT
-      
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v44
-        with:
-          # Avoid using single or double quotes for multiline patterns
-          files_yaml: |
-            core:
-             - config/satellite*.yaml
-            includes:
-              - config/common/*.yaml
-
-      - name: create actual list
-        id: final_list
-        env:
-          INCLUDES_CHANGED: ${{ steps.changed-files.outputs.includes_any_changed }}
-          CORE_HAS_CHANGED:   ${{ steps.changed-files.outputs.core_any_changed }}
-          CHANGED_CORE_FILES: ${{ steps.changed-files.outputs.core_all_changed_files }}
-          EVENT: ${{github.event_name}}
-        run: |
-          if [[ ${INCLUDES_CHANGED} == "true" || $EVENT == "release" ]]; then
-            echo "build_firmware=true" >> $GITHUB_OUTPUT
-            echo "matrix=$(ls config/satellite*.yaml | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
-            echo "files=$(ls config/satellite*.yaml | jq --slurp --raw-input )" >> $GITHUB_OUTPUT
-          elif [[ ${CORE_HAS_CHANGED} == "true" ]]; then
-            ARR=()
-            for file in ${CHANGED_CORE_FILES}; do
-              echo "$file was changed"
-              ARR+=($file)
-            done
-            echo "build_firmware=true" >> $GITHUB_OUTPUT
-            echo "matrix=$( printf '%s\n' "${ARR[@]}" | jq --slurp --raw-input)" >> $GITHUB_OUTPUT
-            echo "files=$( printf '%s\n' "${ARR[@]}" | jq --slurp --raw-input)" >> $GITHUB_OUTPUT
-          else
-            echo "build_firmware=false" >> $GITHUB_OUTPUT
-            echo "matrix=''" >> $GITHUB_OUTPUT
-            echo "files=''" >> $GITHUB_OUTPUT
-          fi
- 
+  
   build-firmware:
-    if: needs.build-list.outputs.build_firmware == 'true'
-    name: Build Firmware
-    needs:
-      - build-list
     uses: esphome/workflows/.github/workflows/build.yml@main
     with:
-      files: ${{ fromJSON(needs.build-list.outputs.build_cfg_files) }}
+      files: |
+        config/satellite1.yaml
       esphome-version: 2024.11.2
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -21,7 +21,6 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      build_cfg_files: ${{ steps.dump.outputs.files }} # list of files separated by \n
       commit_id: ${{ steps.dump.outputs.commit }}
       previous_tag: ${{ steps.dump.outputs.previous_tag }}
       next_tag: ${{ steps.set_release_tag.outputs.release_tag }}
@@ -69,7 +68,7 @@ jobs:
           echo "long_version=${{ steps.set_release_tag.outputs.release_tag }}_$(date +%Y-%m-%d)_$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "label_version=$(echo "${{ steps.set_release_tag.outputs.release_tag }}" | sed 's/\./dot/g' | sed 's/-/dash/g')" >> $GITHUB_OUTPUT
           echo "previous_tag=$(git describe --abbrev=0 --tags)" >> $GITHUB_OUTPUT
-          echo "files=$(ls config/satellite*.yaml | jq --slurp --raw-input )" >> $GITHUB_OUTPUT
+          
 
   build-firmware:
     name: Build Firmware
@@ -77,7 +76,8 @@ jobs:
       - prepare
     uses: esphome/workflows/.github/workflows/build.yml@main
     with:
-      files: ${{ fromJSON(needs.prepare.outputs.build_cfg_files) }}
+      files: |
+        config/satellite1.yaml
       esphome-version: 2024.11.2
       release-version: ${{ needs.prepare.outputs.next_tag }}
 


### PR DESCRIPTION
As we skipped the support for multiple firmware revisions we don't longer need to check which revisions got changed in order to save computation time. 

This PR uses a hard coded list of config files that get built:
Currently only config/satellite1.yaml get's built.

closes #97 
