### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ sdkconfig.esp32-s3-idf
 
 /testdata
 /wake-word-benchmark/
+/Docker/firmware_server/shared-folder
+
+**/.DS_Store


### PR DESCRIPTION
adds to .gitignore 

- temporary directories for binary files
- Apples .DS_Store