### PR TITLE
Integrate tas2780 triggered on PD contract.

### DIFF
--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -2,6 +2,8 @@
 audio_dac:
   - platform: pcm5122
     address: 0x4D
+  - platform: tas2780
+    address: 0x3F
 
 fusb302b:
   id: pd_fusb302b
@@ -16,10 +18,12 @@ fusb302b:
       - text_sensor.template.publish:
           id: pd_state_text
           state: !lambda 'return id(pd_fusb302b).contract;'
-  on_disconnect:
-      - text_sensor.template.publish:
-          id: pd_state_text
-          state: "Disconnected"
+      - if:
+          condition:
+            lambda: |-
+              return id(pd_fusb302b).contract_voltage >= 9;
+          then:
+            - tas2780.activate:
 
 
 media_player:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -93,7 +93,7 @@ external_components:
   - source:
       type: local
       path: ../esphome/components
-    components: [ i2s_audio, satellite1, pcm5122, fusb302b ]
+    components: [ i2s_audio, satellite1, pcm5122, tas2780, fusb302b ]
   
   - source:
       type: git

--- a/esphome/components/tas2780/audio_dac.py
+++ b/esphome/components/tas2780/audio_dac.py
@@ -11,6 +11,21 @@ DEPENDENCIES = ["i2c"]
 tas2780_ns = cg.esphome_ns.namespace("tas2780")
 tas2780 = tas2780_ns.class_("TAS2780", AudioDac, cg.Component, i2c.I2CDevice)
 
+
+RestAction = tas2780_ns.class_(
+    "ResetAction", automation.Action, cg.Parented.template(tas2780)
+)
+
+ActivateAction = tas2780_ns.class_(
+    "ActivateAction", automation.Action, cg.Parented.template(tas2780)
+)
+
+DeactivateAction = tas2780_ns.class_(
+    "DeactivateAction", automation.Action, cg.Parented.template(tas2780)
+)
+
+
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -21,6 +36,16 @@ CONFIG_SCHEMA = (
     .extend(i2c.i2c_device_schema(0x18))
 )
 
+
+TAS2780_ACTION_SCHEMA = automation.maybe_simple_id({cv.GenerateID(): cv.use_id(tas2780)})
+
+@automation.register_action("tas2780.deactivate", DeactivateAction, TAS2780_ACTION_SCHEMA)
+@automation.register_action("tas2780.activate", ActivateAction, TAS2780_ACTION_SCHEMA)
+@automation.register_action("tas2780.reset", RestAction, TAS2780_ACTION_SCHEMA)
+async def tas2780_action(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
 
 
 async def to_code(config):

--- a/esphome/components/tas2780/automation.h
+++ b/esphome/components/tas2780/automation.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "tas2780.h"
+
+namespace esphome {
+
+namespace tas2780 {
+
+template< typename... Ts>
+class ResetAction : public Action<Ts...>, public Parented<TAS2780> {
+ public:
+  void play(Ts... x) override { this->parent_->reset(); }
+};
+
+template< typename... Ts>
+class ActivateAction : public Action<Ts...>, public Parented<TAS2780> {
+ public:
+  void play(Ts... x) override { this->parent_->activate(); }
+};
+
+template< typename... Ts>
+class DeactivateAction : public Action<Ts...>, public Parented<TAS2780> {
+ public:
+  void play(Ts... x) override { this->parent_->deactivate(); }
+};
+
+
+}
+}

--- a/esphome/components/tas2780/tas2780.cpp
+++ b/esphome/components/tas2780/tas2780.cpp
@@ -9,11 +9,26 @@ namespace tas2780 {
 
 static const char *const TAG = "tas2780";
 
-static const uint8_t TAS2780_REG00_PAGE_SELECT = 0x00;        // Page Select
+static const uint8_t TAS2780_PAGE_SELECT = 0x00;        // Page Select
+
+static const uint8_t TAS2780_MODE_CTRL = 0x02;        
+static const uint8_t TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO  = 0x80;
+static const uint8_t TAS2780_MODE_CTRL_MODE_MASK  = 0x07;
+static const uint8_t TAS2780_MODE_CTRL_MODE__ACTIVE  = 0x00;
+static const uint8_t TAS2780_MODE_CTRL_MODE__ACTIVE_MUTED  = 0x01;
+static const uint8_t TAS2780_MODE_CTRL_MODE__SFTW_SHTDWN  = 0x02;
+
+static const uint8_t TAS2780_INT_MASK0 = 0x3b;
+static const uint8_t TAS2780_INT_MASK1 = 0x3c;
+static const uint8_t TAS2780_INT_MASK4 = 0x3d;
+static const uint8_t TAS2780_INT_MASK2 = 0x40;
+static const uint8_t TAS2780_INT_MASK3 = 0x41;
+
+
 
 void TAS2780::setup(){
   // select page 0
-  this->reg(TAS2780_REG00_PAGE_SELECT) = 0x00;
+  this->reg(TAS2780_PAGE_SELECT) = 0x00;
    
   // software reset
   this->reg(0x01) = 0x01;
@@ -34,52 +49,135 @@ void TAS2780::setup(){
     return;
   }
   
-  this->reg(TAS2780_REG00_PAGE_SELECT) = 0x00;
+  this->reg(TAS2780_PAGE_SELECT) = 0x00;
   this->reg(0x0e) = 0x44;
   this->reg(0x0f) = 0x40;
 
+  this->reg(0x0a) = (2 << 4) | (3 << 2) | 2 ;
 
-  this->reg(TAS2780_REG00_PAGE_SELECT) = 0x01;
+  this->reg(TAS2780_PAGE_SELECT) = 0x01;
   this->reg(0x17) = 0xc0;
   this->reg(0x19) = 0x00;
   this->reg(0x21) = 0x00;
   this->reg(0x35) = 0x74;
 
-  this->reg(TAS2780_REG00_PAGE_SELECT) = 0xFD;
+  this->reg(TAS2780_PAGE_SELECT) = 0xFD;
   this->reg(0x0d) = 0x0d;
   this->reg(0x3e) = 0x4a;
   this->reg(0x0d) = 0x00;
 
 
-  this->reg(TAS2780_REG00_PAGE_SELECT) = 0x00;
+  this->reg(TAS2780_PAGE_SELECT) = 0x00;
   //Power Mode 2 (no external VBAT)
-  this->reg(0x03) = 0xe8;
+  //this->reg(0x03) = 0xe8;
+  this->reg(0x03) = 0xa8;
   this->reg(0x04) = 0xa1;
   this->reg(0x71) = 0x12; 
   
-    // activate 
-  //uint8_t reg2 = this->reg(0x02).get();
-  this->reg(0x02) = 0x80;
 
+  //Set interrupt masks
+  this->reg(TAS2780_PAGE_SELECT) = 0x00;
+  //mask VBAT1S Under Voltage
+  this->reg(TAS2780_INT_MASK4) = 0xFF;
+  //mask all PVDD and VBAT1S interrupts
+  this->reg(TAS2780_INT_MASK2) = 0xFF;
+  this->reg(TAS2780_INT_MASK3) = 0xFF;
+  this->reg(TAS2780_INT_MASK1) = 0xFF;
+  
+  
+  // set interrupt to trigger For 
+  // 0h : On any unmasked live interrupts
+  // 3h : 2 - 4 ms every 4 ms on any unmasked latched
+  uint8_t reg_0x5c = this->reg(0x5c).get();
+  this->reg(0x5c) = (reg_0x5c & ~0x03) | 0x00;   
+
+  //set to software shutdown
+  this->reg(TAS2780_MODE_CTRL) = (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__SFTW_SHTDWN;
   }
 
-void TAS2780::loop(){
-#if 1  
-  uint8_t reg2 = this->reg(0x02).get();
-  ESP_LOGD(TAG, "Reg 0x02: %d.", reg2 );
 
-  reg2 = this->reg(0x49).get();
-  ESP_LOGD(TAG, "Reg 0x49: %d.", reg2 );
-  reg2 = this->reg(0x4A).get();
-  ESP_LOGD(TAG, "Reg 0x4A: %d.", reg2 );
-  reg2 = this->reg(0x4B).get();
-  ESP_LOGD(TAG, "Reg 0x4B: %d.", reg2 );
-  reg2 = this->reg(0x4F).get();
-  ESP_LOGD(TAG, "Reg 0x4F: %d.", reg2 );
-  reg2 = this->reg(0x50).get();
-  ESP_LOGD(TAG, "Reg 0x50: %d.\n", reg2 );
-  delay(5);
-#endif
+void TAS2780::activate(){
+  ESP_LOGD(TAG, "Activating TAS2780");
+  // clear interrupt latches
+    this->reg(0x5c) = 0x19 | (1 << 2);
+  // activate 
+  this->reg(TAS2780_MODE_CTRL) = (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__ACTIVE;
+}
+
+void TAS2780::deactivate(){
+  ESP_LOGD(TAG, "Dectivating TAS2780");
+  //set to software shutdown
+  this->reg(TAS2780_MODE_CTRL) = (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__SFTW_SHTDWN;
+}
+
+
+void TAS2780::reset(){
+  // select page 0
+  this->reg(TAS2780_PAGE_SELECT) = 0x00;
+   
+  // software reset
+  this->reg(0x01) = 0x01;
+  
+  uint8_t chd1 = this->reg(0x05).get();
+  uint8_t chd2 = this->reg(0x68).get();
+  uint8_t chd3 = this->reg(0x02).get();
+
+  if( chd1 == 0x41 ){
+    ESP_LOGD(TAG, "TAS2780 chip found.");
+    ESP_LOGD(TAG, "Reg 0x68: %d.", chd2 );
+    ESP_LOGD(TAG, "Reg 0x02: %d.", chd3 );
+  }
+  else
+  {
+    ESP_LOGD(TAG, "TAS2780 chip not found.");
+    this->mark_failed();
+    return;
+  }
+  
+  this->reg(TAS2780_PAGE_SELECT) = 0x00;
+  this->reg(0x0e) = 0x44;
+  this->reg(0x0f) = 0x40;
+  this->reg(0x0a) = (2 << 4) | (3 << 2) | 2 ;
+
+  this->reg(TAS2780_PAGE_SELECT) = 0x01;
+  this->reg(0x17) = 0xc0;
+  this->reg(0x19) = 0x00;
+  this->reg(0x21) = 0x00;
+  this->reg(0x35) = 0x74;
+
+  this->reg(TAS2780_PAGE_SELECT) = 0xFD;
+  this->reg(0x0d) = 0x0d;
+  this->reg(0x3e) = 0x4a;
+  this->reg(0x0d) = 0x00;
+
+
+  this->reg(TAS2780_PAGE_SELECT) = 0x00;
+  //Power Mode 2 (no external VBAT)
+  this->reg(0x03) = 0xa8;
+  this->reg(0x04) = 0xa1;
+  this->reg(0x71) = 0x12; 
+  
+
+  //Set interrupt masks
+  this->reg(TAS2780_PAGE_SELECT) = 0x00;
+  //mask VBAT1S Under Voltage
+  this->reg(0x3d) = 0xFF;
+  //mask all PVDD and VBAT1S interrupts
+  this->reg(0x40) = 0xFF;
+  this->reg(0x41) = 0xFF;
+  
+  
+  // set interrupt to trigger For 
+  // 0h : On any unmasked live interrupts
+  // 3h : 2 - 4 ms every 4 ms on any unmasked latched
+  uint8_t reg_0x5c = this->reg(0x5c).get();
+  this->reg(0x5c) = (reg_0x5c & ~0x03) | 0x00;   
+
+  this->activate();
+}
+
+
+void TAS2780::loop() {
 }
 
 

--- a/esphome/components/tas2780/tas2780.h
+++ b/esphome/components/tas2780/tas2780.h
@@ -16,6 +16,10 @@ class TAS2780 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
   float get_setup_priority() const override { return setup_priority::DATA; }
   void loop() override;
   
+  void reset();
+  void activate();
+  void deactivate();
+
   bool set_mute_off() override;
   bool set_mute_on() override;
   bool set_volume(float volume) override;


### PR DESCRIPTION
- upgrade tas2780 component to always use first SPI/TDM channel 0 (independent of i2c address)
- set i2c address to rev4 hardware
- tas2780 gets activated by a 9V power delivery contract trigger