### PR TITLE
Support for PCM5122 GPIOs 

### DIFF
--- a/config/common/buttons.yaml
+++ b/config/common/buttons.yaml
@@ -36,7 +36,7 @@ binary_sensor:
     id: line_out_sensor
     pin:
       pcm5122: 
-      pin: 3
+      pin: 4
       inverted: false
     name: "line-out jack"
     icon: "mdi:audio-input-stereo-minijack"

--- a/config/common/buttons.yaml
+++ b/config/common/buttons.yaml
@@ -30,7 +30,17 @@ event:
       - triple_press
       - long_press
 
+
 binary_sensor:
+  - platform: gpio
+    id: line_out_sensor
+    pin:
+      pcm5122: 
+      pin: 3
+      inverted: false
+    name: "line-out jack"
+    icon: "mdi:audio-input-stereo-minijack"
+  
   - platform: gpio
     id: btn_up
     pin:

--- a/esphome/components/pcm5122/audio_dac.py
+++ b/esphome/components/pcm5122/audio_dac.py
@@ -3,13 +3,29 @@ from esphome.components import i2c
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components.audio_dac import AudioDac, audio_dac_ns
-from esphome.const import CONF_ID, CONF_MODE
+from esphome.const import ( 
+    CONF_ID, 
+    CONF_MODE,
+    CONF_PIN,
+    CONF_OUTPUT,
+    CONF_INPUT,
+    CONF_INVERTED
+)
+from esphome import pins
 
 CODEOWNERS = ["@gnumpi"]
 DEPENDENCIES = ["i2c"]
 
 pcm5122_ns = cg.esphome_ns.namespace("pcm5122")
 PCM5122 = pcm5122_ns.class_("PCM5122", AudioDac, cg.Component, i2c.I2CDevice)
+CONF_PCM5122 = "pcm5122"
+
+
+PCMGPIOPin = pcm5122_ns.class_( 
+    "PCMGPIOPin", 
+    cg.GPIOPin, 
+    cg.Parented.template(PCM5122)
+)
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -22,6 +38,40 @@ CONFIG_SCHEMA = (
 )
 
 
+def _validate_pin_mode(value):
+    if not (value[CONF_INPUT] or value[CONF_OUTPUT]):
+        raise cv.Invalid("Mode must be either input or output")
+    if value[CONF_INPUT] and value[CONF_OUTPUT]:
+        raise cv.Invalid("Mode must be either input or output")
+    return value
+
+
+PIN_SCHEMA = cv.All(
+    {
+        cv.GenerateID(): cv.declare_id(PCMGPIOPin),
+        cv.Required(CONF_PCM5122): cv.use_id(PCM5122),
+        cv.Required(CONF_PIN): cv.int_range(min=1, max=5),
+        cv.Optional(CONF_MODE, default=CONF_OUTPUT): cv.All(
+            {
+                cv.Optional(CONF_INPUT, default=False): cv.boolean,
+                cv.Optional(CONF_OUTPUT, default=False): cv.boolean,
+            },
+            _validate_pin_mode,
+        ),
+        cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+    }
+)
+
+
+@pins.PIN_SCHEMA_REGISTRY.register(CONF_PCM5122, PIN_SCHEMA)
+async def pcm5122_pin_to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_parented(var, config[CONF_PCM5122])
+
+    cg.add(var.set_pin(config[CONF_PIN]))
+    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
+    return var
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/pcm5122/audio_dac.py
+++ b/esphome/components/pcm5122/audio_dac.py
@@ -50,7 +50,7 @@ PIN_SCHEMA = cv.All(
     {
         cv.GenerateID(): cv.declare_id(PCMGPIOPin),
         cv.Required(CONF_PCM5122): cv.use_id(PCM5122),
-        cv.Required(CONF_PIN): cv.int_range(min=1, max=5),
+        cv.Required(CONF_PIN): cv.int_range(min=3, max=6),
         cv.Optional(CONF_MODE, default=CONF_OUTPUT): cv.All(
             {
                 cv.Optional(CONF_INPUT, default=False): cv.boolean,

--- a/esphome/components/pcm5122/pcm5122.cpp
+++ b/esphome/components/pcm5122/pcm5122.cpp
@@ -9,9 +9,10 @@ namespace pcm5122 {
 
 static const char *const TAG = "pcm5122";
 
-static const uint8_t PCM5122_REG00_PAGE_SELECT = 0x00;        // Page Select
+static const uint8_t PCM5122_REG00_PAGE_SELECT = 0x00; // Page Select
 
 void PCM5122::setup(){
+  ESP_LOGCONFIG(TAG, "Setting up PCM5122...");
   // select page 0
   this->reg(PCM5122_REG00_PAGE_SELECT) = 0x00;
    
@@ -19,33 +20,31 @@ void PCM5122::setup(){
   uint8_t chd2 = this->reg(0x10).get();
   if( chd1 == 0x00 && chd2 == 0x00 ){
     ESP_LOGD(TAG, "PCM5122 chip found.");
-  }
-  else
-  {
+  } else {
     ESP_LOGD(TAG, "PCM5122 chip not found.");
     this->mark_failed();
     return;
   }
 
-  //RESET
+  // RESET
   this->reg(0x01) = 0x10;
   delay(20);
   this->reg(0x01) = 0x00;
 
   uint8_t err_detect = this->reg(0x25).get();
-  //set 'Ignore Clock Halt Detection'
-  err_detect |=  (1 << 3);
-  //enable Clock Divider Autoset
+  // set 'Ignore Clock Halt Detection'
+  err_detect |= (1 << 3);
+  // enable Clock Divider Autoset
   err_detect &= ~(1 << 1);
   this->reg(0x25) = err_detect;
   
-  //set 32bit - I2S
-  this->reg(0x28) = 3; //32bits
+  // set 32bit - I2S
+  this->reg(0x28) = 3; // 32bits
 
-  //001: The PLL reference clock is BCK
+  // 001: The PLL reference clock is BCK
   uint8_t pll_ref = this->reg(0x0D).get();
   pll_ref &= ~(7 << 4); 
-  pll_ref |=  (1 << 4);  
+  pll_ref |=  (1 << 4);
   this->reg(0x0D) = pll_ref;
 }
 
@@ -77,14 +76,35 @@ float PCM5122::volume() {
 }
 
 bool PCM5122::write_mute_() {
+  ESP_LOGD(TAG, "DEBUG TEST is_muted_ is %d", is_muted());
+  uint8_t mute_byte = this->is_muted() ? 0x11 : 0x00;
+  if (!this->write_byte(PCM5122_REG00_PAGE_SELECT, 0x00) ||
+      !this->write_byte(0x03, mute_byte)) {
+    ESP_LOGE(TAG, "Writing mute failed");
+    return false;
+  }
   return true;
 }
 
 bool PCM5122::write_volume_() {
+  const uint8_t dvc_min_byte = 0x00; // check for pcm5122
+  const uint8_t dvc_max_byte = 0xFF;
+
+  // uint8_t volume_byte =
+  // dvc_min_byte + (this->volume_ * (dvc_max_byte - dvc_min_byte));
+  // volume_byte = clamp<uint8_t>(volume_byte, dvc_min_byte, dvc_max_byte);
+  uint8_t volume_byte = 0xFF - this->volume_ * 0xFF;
+
+  ESP_LOGD(TAG, "Setting volume to 0x%.2x", volume_byte & 0xFF);
+
+  if ((!this->write_byte(PCM5122_REG00_PAGE_SELECT, 0x00)) ||
+      (!this->write_byte(0x3D, volume_byte)) ||
+      (!this->write_byte(0x3E, volume_byte))) {
+    ESP_LOGE(TAG, "Writing volume failed");
+    return false;
+  }
   return true;
 }
 
-
-
-}
-}
+} // namespace pcm5122
+} // namespace esphome

--- a/esphome/components/pcm5122/pcm5122.h
+++ b/esphome/components/pcm5122/pcm5122.h
@@ -9,7 +9,9 @@
 namespace esphome {
 namespace pcm5122 {
 
-class PCM5122 : public audio_dac::AudioDac, public Component, public i2c::I2CDevice {
+class PCM5122 : public audio_dac::AudioDac,
+                public Component,
+                public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
@@ -29,5 +31,5 @@ class PCM5122 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
   float volume_{0};
 };
 
-}
-}
+} // namespace pcm5122
+} // namespace esphome

--- a/esphome/components/pcm5122/pcm_gpio.cpp
+++ b/esphome/components/pcm5122/pcm_gpio.cpp
@@ -15,6 +15,13 @@ void PCMGPIOPin::setup(){
         this->parent_->reg(0x08) = curr | (1 << (this->pin_ - 1));
         // set pin to be used as GPIO
         this->parent_->reg(0x50 + (this->pin_ - 1)) = 0x02;  
+        // set / clear inversion bit
+        curr = this->parent_->reg(0x57).get();
+        if( this->inverted_ ){
+            this->parent_->reg(0x57) = curr | (1 << (this->pin_ - 1)); 
+        } else {
+            this->parent_->reg(0x57) = curr & ~(1 << (this->pin_ - 1)); 
+        }
     }
 
 }

--- a/esphome/components/pcm5122/pcm_gpio.cpp
+++ b/esphome/components/pcm5122/pcm_gpio.cpp
@@ -30,8 +30,7 @@ void PCMGPIOPin::digital_write(bool value) {
 
 bool PCMGPIOPin::digital_read() {
     uint8_t reg_val = this->parent_->reg(0x77).get();
-    //ESP_LOGD(TAG, "Current value for reg 0x77: %d", reg_val);
-    return !!(reg_val & (1 << this->pin_)) != this->inverted_;
+    return !!(reg_val & (1 << (this->pin_ - 1))) != this->inverted_;
 
 }
 

--- a/esphome/components/pcm5122/pcm_gpio.cpp
+++ b/esphome/components/pcm5122/pcm_gpio.cpp
@@ -1,0 +1,39 @@
+#include "pcm_gpio.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace pcm5122 {
+
+static const char *TAG = "PCM-GPIOs";
+
+void PCMGPIOPin::setup(){
+    // set input/output mode for pin in register 0x08
+    uint8_t curr = this->parent_->reg(0x08).get();
+    if( this->flags_ & gpio::FLAG_INPUT ){
+        this->parent_->reg(0x08) = curr & ~(1 << (this->pin_ - 1));
+    } else if( this->flags_ & gpio::FLAG_OUTPUT ){
+        this->parent_->reg(0x08) = curr | (1 << (this->pin_ - 1));
+        // set pin to be used as GPIO
+        this->parent_->reg(0x50 + (this->pin_ - 1)) = 0x02;  
+    }
+
+}
+
+void PCMGPIOPin::digital_write(bool value) {
+    uint8_t curr = this->parent_->reg(0x56).get();
+    if( value ){
+        this->parent_->reg(0x56) = curr | (1 << (this->pin_ - 1));
+    } else {
+        this->parent_->reg(0x56) = curr & ~(1 << (this->pin_ - 1));
+    }
+}
+
+bool PCMGPIOPin::digital_read() {
+    uint8_t reg_val = this->parent_->reg(0x77).get();
+    //ESP_LOGD(TAG, "Current value for reg 0x77: %d", reg_val);
+    return !!(reg_val & (1 << this->pin_)) != this->inverted_;
+
+}
+
+} // namespace pcm5122
+} // namespace esphome

--- a/esphome/components/pcm5122/pcm_gpio.h
+++ b/esphome/components/pcm5122/pcm_gpio.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/core/gpio.h"
+
+#include "pcm5122.h"
+
+namespace esphome {
+namespace pcm5122 {
+
+class PCMGPIOPin : public GPIOPin, public Parented<PCM5122> {
+public:
+  void setup() override;
+  void pin_mode(gpio::Flags flags) override {}
+  bool digital_read() override;
+  void digital_write(bool value) override;
+  std::string dump_summary() const override { return ""; };
+
+  void set_pin(uint8_t pin) { this->pin_ = pin; }
+  void set_inverted(bool inverted) { this->inverted_ = inverted; }
+  void set_flags(gpio::Flags flags) { this->flags_ = flags; }
+
+protected:
+  uint8_t pin_;
+  bool inverted_;
+  gpio::Flags flags_;
+};
+
+} // namespace pcm5122
+} // namespace esphome


### PR DESCRIPTION
- add the support of PCM5122 GPIOs as 'virtual' ESPHome pins
- adds new binary sensor which indicates whether a cable is plugged into the line-out jack
