### PR TITLE
Update XMOS version reading and flash automatically

### DIFF
--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -36,6 +36,13 @@ packages:
         then:
           - delay: 1s
           - script.execute: control_leds
+          - if: 
+              condition:
+                - lambda: return id(init_in_progress);
+                - lambda: return id(xflash).has_image_embedded();
+                - lambda: return !id(xflash).match_embedded( id(satellite1_id).xmos_fw_version );
+              then:
+                - memory_flasher.write_embedded_image:
 
   home-assistant-voice: !include satellite1.yaml
 

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -13,7 +13,7 @@ substitutions:
   component_name: Core
   
   esp32_fw_version: "v2.0.0-alpha.8"
-  xmos_fw_version: "v1.0.1-alpha.33"
+  xmos_fw_version: "v1.0.1-alpha.35"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
 
@@ -106,7 +106,7 @@ packages:
     
   #OPTIONAL COMPONENTS 
   # mmwave_ld2410: !include common/mmwave_ld2410.yaml
-  # debug: !include common/debug.yaml
+  debug: !include common/debug.yaml
 
 ota:
   - platform: esphome
@@ -148,8 +148,10 @@ memory_flasher:
     id: xflash
     embed_flash_image:
       image_version: ${xmos_fw_version}
-      image_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.bin
-      md5_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.md5
+      image_file: /Users/mischa/Projects/FutureProofHomes/Satellite1-XMOS/build/satellite1_firmware_fixed_delay.factory.bin
+      md5_file: /Users/mischa/Projects/FutureProofHomes/Satellite1-XMOS/build/satellite1_firmware_fixed_delay.factory.md5
+      #image_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.bin
+      #md5_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.md5
 
     on_flashing_start:    
       then:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -13,7 +13,7 @@ substitutions:
   component_name: Core
   
   esp32_fw_version: "v2.0.0-alpha.8"
-  xmos_fw_version: "v1.0.1-alpha.35"
+  xmos_fw_version: "v1.0.1-alpha.39"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
 
@@ -106,7 +106,7 @@ packages:
     
   #OPTIONAL COMPONENTS 
   # mmwave_ld2410: !include common/mmwave_ld2410.yaml
-  debug: !include common/debug.yaml
+  # debug: !include common/debug.yaml
 
 ota:
   - platform: esphome
@@ -148,10 +148,8 @@ memory_flasher:
     id: xflash
     embed_flash_image:
       image_version: ${xmos_fw_version}
-      image_file: /Users/mischa/Projects/FutureProofHomes/Satellite1-XMOS/build/satellite1_firmware_fixed_delay.factory.bin
-      md5_file: /Users/mischa/Projects/FutureProofHomes/Satellite1-XMOS/build/satellite1_firmware_fixed_delay.factory.md5
-      #image_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.bin
-      #md5_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.md5
+      image_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.bin
+      md5_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.md5
 
     on_flashing_start:    
       then:

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -60,6 +60,7 @@ static std::string prerelease_str(uint8_t pre_idx ){
         case 1: return "alpha";
         case 2: return "beta";
         case 3: return "rc";
+        case 4: return "dev";
         case 0: // fallthrough
         default: return "";
     }
@@ -71,7 +72,7 @@ std::string Satellite1::status_string(){
       return "XMOS not responding";
     
     case SAT_XMOS_CONNECTED_STATE:
-      return  (   "v" + std::to_string(this->xmos_fw_version[0])
+      return  (    "v" + std::to_string(this->xmos_fw_version[0])
                 +  "." + std::to_string(this->xmos_fw_version[1]) 
                 +  "." + std::to_string(this->xmos_fw_version[2])
                 +  ( this->xmos_fw_version[3] ? "-" + prerelease_str(this->xmos_fw_version[3]) : "")
@@ -163,15 +164,15 @@ void Satellite1::set_spi_flash_direct_access_mode(bool enable){
 }
 
 bool Satellite1::dfu_get_fw_version_(){
-  uint8_t version_resp[3];
-  if( !this->transfer(DC_RESOURCE::DFU_CONTROLLER, DC_DFU_CMD::GET_VERSION, version_resp, 3 ) ){
+  uint8_t version_resp[5];
+  if( !this->transfer(DC_RESOURCE::DFU_CONTROLLER, DC_DFU_CMD::GET_VERSION, version_resp, 5 ) ){
     ESP_LOGW(TAG, "Requesting XMOS version failed");
     return false;    
   }
-
-  ESP_LOGI(TAG, "XMOS Firmware Version: %u.%u.%u", version_resp[0], version_resp[1], version_resp[2]);
-  memcpy( this->xmos_fw_version, version_resp, 3);
-
+  
+  memcpy( this->xmos_fw_version, version_resp, 5);
+  ESP_LOGI(TAG, "XMOS Firmware Version: %s ", this->status_string().c_str() );
+  
   return true;
 }
 


### PR DESCRIPTION
- reads xmos version as 5 byte string now (this includes pre-release info)
- bump xmos version to v1.01-apha.39
- automatically flash the embedded firmware if installed version differs from embedded one

closes #186 