### PR TITLE
Restructure base config files in order to support dashboard imports

### DIFF
--- a/config/common/wifi_improv.yaml
+++ b/config/common/wifi_improv.yaml
@@ -7,7 +7,6 @@ globals:
 wifi:
   id: wifi_id
   on_connect:
-    - delay: 5s  # Gives time for improv results to be transmitted
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
   on_disconnect:

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -62,22 +62,16 @@ esphome:
 external_components:
   - source:
       type: git
-      url: https://github.com/gnumpi/nabu-voice-kit
-      ref: dev
-    components: [ audio_dac, media_player ]
-
-  - source:
-      type: git
-      url: https://github.com/esphome/voice-kit
-      ref: 24.10.17
-    components: [ microphone, micro_wake_word, voice_assistant ]
+      url: https://github.com/FutureProofHomes/home-assistant-voice-pe
+      ref: satellite1
+    components: [ microphone, voice_assistant, audio_dac, media_player, nabu, micro_wake_word ]
 
 ota:
   - platform: esphome
     id: ota_esphome
 
 dashboard_import:
-  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml@175-bug-finalize-esphome-dashboard-import-url
+  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml@develop
 
 
 packages:

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -12,8 +12,7 @@ substitutions:
   project_name: Satellite1
   component_name: Core
   
-  esp32_fw_version: "v2.0.0-alpha.8"
-  xmos_fw_version: "v1.0.1-alpha.33"
+  xmos_fw_version: "v1.0.1-alpha.39"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
 

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -73,6 +73,9 @@ external_components:
       ref: 24.10.17
     components: [ microphone, micro_wake_word, voice_assistant, nabu ]
 
+ota:
+  - platform: esphome
+    id: ota_esphome
 
 dashboard_import:
   package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml@175-bug-finalize-esphome-dashboard-import-url

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -42,10 +42,6 @@ esphome:
   friendly_name: ${friendly_name}
   min_version: 2024.11.2
   
-  project:
-    name: ${company_name}.${project_name}
-    version: dev
-  
   on_boot:
     - priority: 375
       then:
@@ -62,16 +58,6 @@ esphome:
             then:
               - lambda: id(init_in_progress) = false;
               - script.execute: control_leds
-    
-
-logger:
-  deassert_rts_dtr: true
-  hardware_uart : USB_SERIAL_JTAG
-  level: debug
-
-
-dashboard_import:
-  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml
 
 
 external_components:
@@ -83,15 +69,13 @@ external_components:
 
   - source:
       type: git
-      url: https://github.com/FutureProofHomes/Satellite1-ESPHome
-      ref: develop
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
-  
-  - source:
-      type: git
       url: https://github.com/esphome/voice-kit
       ref: 24.10.17
     components: [ microphone, micro_wake_word, voice_assistant, nabu ]
+
+
+dashboard_import:
+  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml@175-bug-finalize-esphome-dashboard-import-url
 
 
 packages:
@@ -105,13 +89,7 @@ packages:
   timer: !include common/timer.yaml
   led_ring: !include common/led_ring.yaml 
     
-  #OPTIONAL COMPONENTS 
-  # mmwave_ld2410: !include common/mmwave_ld2410.yaml
-  # debug: !include common/debug.yaml
-
-ota:
-  - platform: esphome
-    id: ota_esphome
+  
 
 http_request:
 

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -12,7 +12,7 @@ substitutions:
   project_name: Satellite1
   component_name: Core
   
-  xmos_fw_version: "v1.0.1-alpha.39"
+  xmos_fw_version: "v1.0.1-alpha.40"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
 
@@ -70,7 +70,7 @@ external_components:
       type: git
       url: https://github.com/esphome/voice-kit
       ref: 24.10.17
-    components: [ microphone, micro_wake_word, voice_assistant, nabu ]
+    components: [ microphone, micro_wake_word, voice_assistant ]
 
 ota:
   - platform: esphome

--- a/config/satellite1.dashboard.yaml
+++ b/config/satellite1.dashboard.yaml
@@ -13,7 +13,7 @@ substitutions:
   component_name: Core
   
   esp32_fw_version: "v2.0.0-alpha.8"
-  xmos_fw_version: "v1.0.1-alpha.40"
+  xmos_fw_version: "v1.0.1-alpha.33"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
 
@@ -71,20 +71,27 @@ logger:
 
 
 dashboard_import:
-  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.dashboard.yaml@175-bug-finalize-esphome-dashboard-import-url
+  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.yaml
 
 
 external_components:
   - source:
-      type: local
-      path: ../esphome/components
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b, nabu ]
+      type: git
+      url: https://github.com/gnumpi/nabu-voice-kit
+      ref: dev
+    components: [ audio_dac, media_player ]
+
+  - source:
+      type: git
+      url: https://github.com/FutureProofHomes/Satellite1-ESPHome
+      ref: develop
+    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
   
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: 24.12.3
-    components: [ microphone, micro_wake_word, voice_assistant, media_player ]
+      ref: 24.10.17
+    components: [ microphone, micro_wake_word, voice_assistant, nabu ]
 
 
 packages:

--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -17,9 +17,13 @@ packages:
         - wait_until:
             not: memory_flasher.in_progress
         - delay: 2s
+    
     wifi:
       on_disconnect:
         - ble.enable:
+      on_connect:
+        - delay: 5s  # Gives time for improv results to be transmitted
+        - ble.disable:
     
     satellite1:
       on_xmos_no_response:
@@ -44,34 +48,15 @@ packages:
               then:
                 - memory_flasher.write_embedded_image:
 
-  home-assistant-voice: !include satellite1.yaml
+  home-assistant-voice: !include satellite1.base.yaml
+
 
 esphome:
   project:
     name: ${company_name}.${project_name}
-    version: dev
+    version: ${esp32_fw_version}
 
-ota:
-  - platform: http_request
-    id: ota_http_request
 
-http_request:
-
-update:
-  - platform: http_request
-    name: None
-    id: update_http_request
-    # source: https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json
-    source: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifest.json
-
-wifi:
-  enable_on_boot: true
-  on_connect:
-    - delay: 5s  # Gives time for improv results to be transmitted
-    - ble.disable:
-    - script.execute: control_leds
-
-improv_serial:
 
 esp32_improv:
   authorizer: btn_action
@@ -85,6 +70,21 @@ esp32_improv:
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
 
+
+
+http_request:
+
+ota:
+  - platform: http_request
+    id: ota_http_request
+
+update:
+  - platform: http_request
+    name: None
+    id: update_http_request
+    source: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifest.json
+
+
 switch:
   - platform: template
     id: beta_firmware
@@ -95,9 +95,22 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     on_turn_on:
       - logger.log: "OTA updates set to use Beta firmware"
-      # - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest-beta.json");
       - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifest-beta.json");
     on_turn_off:
       - logger.log: "OTA updates set to use Production firmware"
-      # - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json");
       - lambda: id(update_http_request).set_source_url("https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifest.json");
+
+
+external_components:
+  - source:
+      type: local
+      path: ../esphome/components
+    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
+
+
+logger:
+  deassert_rts_dtr: true
+  hardware_uart : USB_SERIAL_JTAG
+  level: warn
+
+

--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -105,7 +105,7 @@ external_components:
   - source:
       type: local
       path: ../esphome/components
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b, nabu ]
+    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
 
 
 logger:

--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -105,7 +105,7 @@ external_components:
   - source:
       type: local
       path: ../esphome/components
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
+    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b, nabu ]
 
 
 logger:

--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -64,10 +64,6 @@ update:
     # source: https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json
     source: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/manifest.json
 
-dashboard_import:
-  # package_import_url: github://esphome/home-assistant-voice-pe/home-assistant-voice.yaml
-  package_import_url: github://FutureProofHomes/Satellite1-ESPHome/config/satellite1.yaml
-
 wifi:
   enable_on_boot: true
   on_connect:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -22,7 +22,7 @@ external_components:
       type: git
       url: https://github.com/FutureProofHomes/Satellite1-ESPHome
       ref: develop
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b, nabu ]
+    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
   
 logger:
   deassert_rts_dtr: true

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -22,7 +22,7 @@ external_components:
       type: git
       url: https://github.com/FutureProofHomes/Satellite1-ESPHome
       ref: develop
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
+    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b, nabu ]
   
 logger:
   deassert_rts_dtr: true

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -1,185 +1,30 @@
 substitutions:
-  #Change to any preferred name
-  friendly_name: "Satellite1"  
-
-  #Change to calibrate your temperature/humidity sensor readings
-  temp_offset: "-3"
-  humidity_offset: "5"
-
-  #Recommend leaving the following unchanged
-  node_name: satellite1
   company_name: FutureProofHomes
   project_name: Satellite1
-  component_name: Core
   
-  esp32_fw_version: "v2.0.0-alpha.8"
-  xmos_fw_version: "v1.0.1-alpha.40"
-  built_for_core_hw_version: "v1.0.0-beta.1"
-  built_for_hat_hw_version: "v1.0.0-beta.1"
-
-
-globals:
-  # Global initialisation variable. Initialized to true and set to false once everything is connected. Only used to have a smooth "plugging" experience
-  - id: init_in_progress
-    type: bool
-    restore_value: no
-    initial_value: 'true'
-  # Global variable storing if user action causes warning
-  - id: warning
-    type: bool
-    restore_value: no
-    initial_value: 'false'
-  # Global variable tracking the XMOS flasher status.
-  - id: xmos_flashing_state
-    type: int
-    restore_value: no
-    initial_value: '0'
-
-
-esphome:
-  name: ${node_name}
-  name_add_mac_suffix: true
-  friendly_name: ${friendly_name}
-  min_version: 2024.11.2
-  
-  project:
-    name: ${company_name}.${project_name}
-    version: dev
-  
-  on_boot:
-    - priority: 375
-      then:
-        - logger.log: "${company_name} ${project_name} ${component_name} version ${built_for_core_hw_version} running ESP firmware: ${esp32_fw_version} and XMOS firmware: ${xmos_fw_version}"
-        # Run the script to refresh the LED status
-        - script.execute: control_leds
-        - delay: 1s
-        
-        # If after 10 minutes, the device is still initializing (It did not yet connect to Home Assistant), turn off the init_in_progress variable and run the script to refresh the LED status
-        - delay: 10min
-        - if:
-            condition:
-              lambda: return id(init_in_progress);
-            then:
-              - lambda: id(init_in_progress) = false;
-              - script.execute: control_leds
-    
-
-logger:
-  deassert_rts_dtr: true
-  hardware_uart : USB_SERIAL_JTAG
-  level: debug
-
-
-dashboard_import:
-  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.dashboard.yaml@175-bug-finalize-esphome-dashboard-import-url
-
-
-external_components:
-  - source:
-      type: local
-      path: ../esphome/components
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b, nabu ]
-  
-  - source:
-      type: git
-      url: https://github.com/esphome/voice-kit
-      ref: 24.12.3
-    components: [ microphone, micro_wake_word, voice_assistant, media_player ]
-
+  esp32_fw_version: dev
 
 packages:
-  core_board: !include common/core_board.yaml
-  wifi: !include common/wifi_improv.yaml
-  sensors: !include common/hat_sensors.yaml
-  buttons: !include common/buttons.yaml
-  ha: !include common/home_assistant.yaml
-  mp: !include common/media_player.yaml
-  va: !include common/voice_assistant.yaml
-  timer: !include common/timer.yaml
-  led_ring: !include common/led_ring.yaml 
-    
+  fph-satellite1: !include satellite1.base.yaml
+  
   #OPTIONAL COMPONENTS 
   # mmwave_ld2410: !include common/mmwave_ld2410.yaml
   # debug: !include common/debug.yaml
 
-ota:
-  - platform: esphome
-    id: ota_esphome
-
-http_request:
-
-safe_mode:
-
-status_led:
-  pin:
-    number: GPIO45
-    ignore_strapping_warning: true
+esphome:
+  project:
+    name: ${company_name}.${project_name}
+    version: ${esp32_fw_version}
 
 
-satellite1:
-  id: satellite1_id
-  spi_id: spi_0
-  cs_pin: GPIO10
-  data_rate: 8000000
-  spi_mode: MODE3
-  xmos_rst_pin: GPIO4
+external_components:
+  - source:
+      type: git
+      url: https://github.com/FutureProofHomes/Satellite1-ESPHome
+      ref: develop
+    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
   
-  on_xmos_no_response:
-    then:
-      - text_sensor.template.publish:
-          id: xmos_firmware_version_text
-          state: !lambda 'return id(satellite1_id).status_string();'
-  
-  on_xmos_connected:
-    then:
-      - text_sensor.template.publish:
-          id: xmos_firmware_version_text
-          state: !lambda 'return id(satellite1_id).status_string();'
-      
-
-memory_flasher:
-  - platform: satellite1
-    id: xflash
-    embed_flash_image:
-      image_version: ${xmos_fw_version}
-      image_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.bin
-      md5_file: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.md5
-
-    on_flashing_start:    
-      then:
-        - lambda: id(xmos_flashing_state) = 1;
-        - script.execute: control_leds
-    
-    on_progress_update:
-      then:
-        - lambda: id(global_led_animation_index) = id(xflash).flashing_progress * 24 / 100;
-        - script.execute: control_leds
-    
-    on_flashing_success:
-      then:
-        - logger.log: "success called"
-        - lambda: id(xmos_flashing_state) = 2;
-        - script.execute: control_leds
-        - lambda: id(xmos_flashing_state) = 0;
-        - if:
-            condition:
-              lambda: |-
-                return id(pd_fusb302b).contract_voltage >= 9;
-            then:
-              - tas2780.activate:
-
-    on_flashing_failed:
-      then:
-        - logger.log: "failed called"
-        - lambda: id(xmos_flashing_state) = 3;
-        - script.execute: control_leds
-        - lambda: id(xmos_flashing_state) = 0;
-    
-    on_erasing_done:
-      then:
-        - if:
-            condition: 
-              lambda: return id(factory_reset_requested);
-            then:
-              - button.press: factory_reset_button
-
+logger:
+  deassert_rts_dtr: true
+  hardware_uart : USB_SERIAL_JTAG
+  level: debug


### PR DESCRIPTION
When the config file is imported by ESPHome-Dashboard the external components need to point to the public repository instead to a local path.

For now we always include the external satellite1 components from the develop branch.

To be able to test this PR the factory config points to the dashboard file in the `175-bug-finalize-esphome-dashboard-import-url` branch.

**Before merging we want to change the reference from `175-bug-finalize-esphome-dashboard-import-url` to `develop`**

