### PR TITLE
Adding Optional Developer.yaml

### DIFF
--- a/config/common/developer.yaml
+++ b/config/common/developer.yaml
@@ -1,0 +1,66 @@
+external_components:  
+  - source:
+      type: local
+      path: ../esphome/components
+    components: [ udp_stream ]
+
+
+# Separate UDP Stream configurations for each microphone
+udp_stream:
+  id: udp_streamer
+  microphone: asr_mic  # Default microphone to prevent validation errors
+
+# Switches to toggle between ASR and Comm microphones
+switch:
+  - platform: template
+    name: "UDP Stream ASR Mic"
+    entity_category: "diagnostic"
+    id: use_asr_mic
+    icon: mdi:microphone
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - logger.log: "Switching to ASR Mic for UDP stream"
+      - lambda: |-
+          if (id(udp_streamer).is_running()) {
+            id(udp_streamer).request_stop();  // Stop current stream
+            delay(500);  // Wait for stream to stop
+          }
+          id(udp_streamer).set_microphone(id(asr_mic));  // Set ASR mic
+          id(udp_streamer).request_start(true);  // Start stream with ASR mic
+      - switch.turn_off: use_comm_mic         # Turn off the other switch
+
+    on_turn_off:
+      - logger.log: "Turning off ASR Mic UDP stream"
+      - lambda: |-
+          if (id(udp_streamer).is_running()) {
+            id(udp_streamer).request_stop();  // Stop the stream when ASR mic is turned off
+          }
+  - platform: template
+    name: "UDP Stream Comm Mic"
+    entity_category: "diagnostic"
+    id: use_comm_mic
+    icon: mdi:microphone
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - logger.log: "Switching to Comm Mic for UDP stream"
+      - micro_wake_word.stop:
+      - delay: 500ms
+      - lambda: |-
+          if (id(udp_streamer).is_running()) {
+            id(udp_streamer).request_stop();  // Stop current stream
+            delay(500);  // Wait for stream to stop
+          }
+          id(udp_streamer).set_microphone(id(comm_mic));  // Set Comm mic
+          id(udp_streamer).request_start(true);  // Start stream with Comm mic
+      - switch.turn_off: use_asr_mic           # Turn off the other switch
+
+    on_turn_off:
+      - logger.log: "Turning off Comm Mic UDP stream"
+      - lambda: |-
+          if (id(udp_streamer).is_running()) {
+            id(udp_streamer).request_stop();  // Stop the stream when Comm mic is turned off
+          }
+      - delay: 500ms
+      - micro_wake_word.start:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -107,6 +107,7 @@ packages:
   #OPTIONAL COMPONENTS 
   # mmwave_ld2410: !include common/mmwave_ld2410.yaml
   # debug: !include common/debug.yaml
+  # developer: !include common/developer.yaml
 
 ota:
   - platform: esphome


### PR DESCRIPTION
- uncomment `developer.yaml` to get access to toggle switches that enabled/disable realtime UDP streaming of Sat1 microphones to a UDP server.