### PR TITLE
Bump ESPHome to 2024.12.2

### DIFF
--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -16,7 +16,7 @@ jobs:
     with:
       files: |
         config/satellite1.factory.yaml
-      esphome-version: 2024.12.1
+      esphome-version: 2024.12.2
       release-summary: develop-branch
       release-url:
       release-version:

--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -16,7 +16,7 @@ jobs:
     with:
       files: |
         config/satellite1.factory.yaml
-      esphome-version: 2024.11.2
+      esphome-version: 2024.12.1
       release-summary: develop-branch
       release-url:
       release-version:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -89,7 +89,7 @@ jobs:
     with:
       files: |
         config/satellite1.factory.yaml
-      esphome-version: 2024.11.2
+      esphome-version: 2024.12.1
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
   push-tag:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -89,7 +89,7 @@ jobs:
     with:
       files: |
         config/satellite1.factory.yaml
-      esphome-version: 2024.12.1
+      esphome-version: 2024.12.2
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
   push-tag:

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -39,7 +39,7 @@ esphome:
   name: ${node_name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2024.12.1
+  min_version: 2024.12.2
   
   on_boot:
     - priority: 375

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -39,7 +39,7 @@ esphome:
   name: ${node_name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2024.11.2
+  min_version: 2024.12.1
   
   on_boot:
     - priority: 375

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2024.12.1
+esphome==2024.12.2
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2024.11.2
+esphome==2024.12.1
 setuptools


### PR DESCRIPTION
Bump to newest ESPHome version which fixes the ring_buffer race condition which occasionally leads to reboots during music playback. 