### PR TITLE
Set persistent tag for ha-voice-kit reference and update XMOS to v1.0.1

### DIFF
--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -9,7 +9,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: recommended
+    version: 4.4.8
+    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -12,7 +12,7 @@ substitutions:
   project_name: Satellite1
   component_name: Core
   
-  xmos_fw_version: "v1.0.1-alpha.40"
+  xmos_fw_version: "v1.0.1"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
 
@@ -63,7 +63,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/FutureProofHomes/home-assistant-voice-pe
-      ref: satellite1
+      ref: 2024.12.3-fph.0
     components: [ microphone, voice_assistant, audio_dac, media_player, nabu, micro_wake_word ]
 
 ota:


### PR DESCRIPTION
makes sure that the ha-voice-kit dependency points to a tag instead of a branch  