### PR TITLE
Suppress error LEDs when two devices wake simultaneously

### DIFF
--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -114,7 +114,9 @@ voice_assistant:
   on_error:
     - if:
         condition:
-          lambda: return !id(init_in_progress);
+          and:
+            - lambda: return !id(init_in_progress);
+            - lambda: return code != "duplicate_wake_up_detected";
         then:
           - lambda: id(voice_assistant_phase) = ${voice_assist_error_phase_id};
           - script.execute: control_leds


### PR DESCRIPTION
- Previously when two Sat1s hear the wake word and race to respond one of them would show red LEDs.

- We are now suppressing the error LEDs on the device that came in second place.

- This matches Nabu's user experience.