### PR TITLE
Introducing developer.yaml

### DIFF
--- a/config/common/debug.yaml
+++ b/config/common/debug.yaml
@@ -8,6 +8,19 @@ external_components:
 debug:
   update_interval: 5s
 
+logger:
+  deassert_rts_dtr: true
+  hardware_uart : USB_SERIAL_JTAG
+  level: debug
+
+# # OPTIONAL Persist logs to a an MQTT broker so you can go back in time and inspect them.  Read more here: https://esphome.io/components/mqtt.html
+# mqtt:
+#   broker: homeassistant.local
+#   port: 1883
+#   username: <mqtt_username_here>
+#   password: <mqtt_password_here>
+#   # topic_prefix: <set_this_if_you_are_logging_multiple_satellite1_devices>
+
 text_sensor:
   - platform: debug
     device:

--- a/config/common/developer.yaml
+++ b/config/common/developer.yaml
@@ -1,0 +1,70 @@
+# This is a developer configuration that enables the UDP stream component and adds switches to toggle between the ASR and Comm microphones.
+# You can read more about how to use this configuration here: https://github.com/FutureProofHomes/Satellite1-ESPHome/tree/develop/tests/mic_streaming
+
+external_components:  
+  - source:
+      type: local
+      path: ../esphome/components
+    components: [ udp_stream ]
+
+
+# Separate UDP Stream configurations for each microphone
+udp_stream:
+  id: udp_streamer
+  microphone: asr_mic  # Default microphone to prevent validation errors
+
+
+# Switches to toggle between ASR and Comm microphones
+switch:
+  - platform: template
+    name: "UDP Stream ASR Mic"
+    entity_category: "diagnostic"
+    id: use_asr_mic
+    icon: mdi:microphone
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - logger.log: "Switching to ASR Mic for UDP stream"
+      - lambda: |-
+          if (id(udp_streamer).is_running()) {
+            id(udp_streamer).request_stop();  // Stop current stream
+            delay(500);  // Wait for stream to stop
+          }
+          id(udp_streamer).set_microphone(id(asr_mic));  // Set ASR mic
+          id(udp_streamer).request_start(true);  // Start stream with ASR mic
+      - switch.turn_off: use_comm_mic         # Turn off the other switch
+
+    on_turn_off:
+      - logger.log: "Turning off ASR Mic UDP stream"
+      - lambda: |-
+          if (id(udp_streamer).is_running()) {
+            id(udp_streamer).request_stop();  // Stop the stream when ASR mic is turned off
+          }
+  - platform: template
+    name: "UDP Stream Comm Mic"
+    entity_category: "diagnostic"
+    id: use_comm_mic
+    icon: mdi:microphone
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - logger.log: "Switching to Comm Mic for UDP stream"
+      - micro_wake_word.stop:
+      - delay: 500ms
+      - lambda: |-
+          if (id(udp_streamer).is_running()) {
+            id(udp_streamer).request_stop();  // Stop current stream
+            delay(500);  // Wait for stream to stop
+          }
+          id(udp_streamer).set_microphone(id(comm_mic));  // Set Comm mic
+          id(udp_streamer).request_start(true);  // Start stream with Comm mic
+      - switch.turn_off: use_asr_mic           # Turn off the other switch
+
+    on_turn_off:
+      - logger.log: "Turning off Comm Mic UDP stream"
+      - lambda: |-
+          if (id(udp_streamer).is_running()) {
+            id(udp_streamer).request_stop();  // Stop the stream when Comm mic is turned off
+          }
+      - delay: 500ms
+      - micro_wake_word.start:

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -85,7 +85,10 @@ packages:
   timer: !include common/timer.yaml
   led_ring: !include common/led_ring.yaml 
     
-  
+  ## OPTIONAL COMPONENTS 
+  # mmwave_ld2410: !include common/mmwave_ld2410.yaml
+  # debug: !include common/debug.yaml
+  # developer: !include common/developer.yaml
 
 http_request:
 

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -6,10 +6,6 @@ substitutions:
 
 packages:
   fph-satellite1: !include satellite1.base.yaml
-  
-  #OPTIONAL COMPONENTS 
-  # mmwave_ld2410: !include common/mmwave_ld2410.yaml
-  # debug: !include common/debug.yaml
 
 esphome:
   project:


### PR DESCRIPTION
- adding optional developer.yaml
- gives access to tools to UDP stream microphone for quality testing
- optionally emit logs to MQTT server
- moves optional packages to satellite1.base