### PR TITLE
FUSB302b: Move IRQ handler to core 1

### DIFF
--- a/esphome/components/fusb302b/fusb302b.cpp
+++ b/esphome/components/fusb302b/fusb302b.cpp
@@ -55,8 +55,10 @@ static void msg_reader_task(void *params){
   
   PDEventInfo event_info;
   PDMsg &msg = event_info.msg;
-  
+ #if FUSB_DEBUG_PRINT 
   printf("MSG READER TASK STARTED \n");
+ #endif 
+  
   fusb302b->enable_auto_crc();
   fusb302b->fusb_reset_();
   
@@ -68,13 +70,16 @@ static void msg_reader_task(void *params){
         while( !(regs.status1 & FUSB_STATUS1_RX_EMPTY) ){
           if( fusb302b->read_message_(msg) ){
             xQueueSend(pd_message_queue, &event_info, 0);
-          } else {
+          } 
+#if FUSB_DEBUG_PRINT           
+          else {
             printf("Reading failed\n");    
           }
+#endif
           fusb302b->read_status_register(FUSB_STATUS1, regs.status1);
         }
     } 
-    
+#if FUSB_DEBUG_PRINT    
     if ( regs.interrupta &  FUSB_INTERRUPTA_I_HARDRST){
         event_info.event = PD_EVENT_HARD_RESET;
         printf(">>>FUSB_STATUS0A_HARDRST<<<\n");
@@ -86,7 +91,8 @@ static void msg_reader_task(void *params){
     {
       event_info.event = PD_EVENT_SENDING_MSG_FAILED;
       printf("Message did not get acknowledged.\n");
-    } 
+    }
+#endif 
   }
   fusb302b->disable_auto_crc();
 
@@ -99,6 +105,23 @@ static void trigger_task(void *params){
 
   pd_message_queue = xQueueCreate( 5, sizeof(PDEventInfo));
   
+  gpio_num_t irq_gpio_pin = static_cast<gpio_num_t>(fusb302b->irq_pin_);
+
+  gpio_config_t io_conf;
+  io_conf.pin_bit_mask = (1ULL << irq_gpio_pin);
+  io_conf.mode = GPIO_MODE_INPUT;
+  io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+  io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  io_conf.intr_type = GPIO_INTR_NEGEDGE	;
+
+  gpio_config(&io_conf);
+
+  // Install ISR service and attach the ISR handler
+  gpio_set_intr_type((gpio_num_t) irq_gpio_pin , GPIO_INTR_NEGEDGE	);
+  gpio_install_isr_service(0);
+  gpio_isr_handler_add( irq_gpio_pin, fusb302b_isr_handler, NULL);
+  
+  
   // Create the task that will wait for notifications
   xTaskCreatePinnedToCore( msg_reader_task, "fusb3202b_read_task", 4096, fusb302b, configMAX_PRIORITIES/2, &xReaderTaskHandle, 1 );
   PDEventInfo event_info;
@@ -106,7 +129,7 @@ static void trigger_task(void *params){
   while(true){
     if( xQueueReceive(pd_message_queue, &event_info, portMAX_DELAY) == pdTRUE ){
        //delay needed for getting fusb302b ready for receiving i2c again, is this the right place though?
-       vTaskDelay(pdMS_TO_TICKS(1));
+       //vTaskDelay(pdMS_TO_TICKS(1));
        void taskENTER_CRITICAL( void );
        PDMsg &msg = event_info.msg;
        //printf( "PD-Received new message with id: %d (%d, %d) [%u].\n", msg.id, msg.type, msg.num_of_obj, millis());
@@ -278,24 +301,8 @@ void FUSB302B::check_status_(){
         ESP_LOGD(TAG, "Statup delay reached!");
         this->startup_delay_ = 0;
 
-        gpio_num_t irq_gpio_pin = static_cast<gpio_num_t>(this->irq_pin_);
-
-        gpio_config_t io_conf;
-        io_conf.pin_bit_mask = (1ULL << irq_gpio_pin);
-        io_conf.mode = GPIO_MODE_INPUT;
-        io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
-        io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-        io_conf.intr_type = GPIO_INTR_NEGEDGE	;
-
-        gpio_config(&io_conf);
-
-        // Install ISR service and attach the ISR handler
-        gpio_set_intr_type((gpio_num_t) irq_gpio_pin , GPIO_INTR_NEGEDGE	);
-        gpio_install_isr_service(0);
-        gpio_isr_handler_add( irq_gpio_pin, fusb302b_isr_handler, NULL);
-
         // Create the task that will wait for notifications
-        xTaskCreatePinnedToCore(trigger_task, "fusb3202b_task", 4096, this , configMAX_PRIORITIES, &xProcessTaskHandle, 0);
+        xTaskCreatePinnedToCore(trigger_task, "fusb3202b_task", 4096, this , 18 , &xProcessTaskHandle, 1);
         delay(1);
       } else {
         this->enable_auto_crc();
@@ -328,7 +335,7 @@ void FUSB302B::check_status_(){
         }
         get_src_cap_retry_count_++;
         get_src_cap_time_stamp_ = millis();
-        if( get_src_cap_retry_count_ < 4){
+        if( get_src_cap_retry_count_ < 2){
           /* clear interrupts */
           this->read_status();
           this->send_message_(PDMsg( pd_control_msg_type::PD_CNTRL_GET_SOURCE_CAP));
@@ -496,9 +503,11 @@ bool FUSB302B::send_message_(const PDMsg &msg){
   
   
   int err = this->write_register( FUSB_FIFOS, buf, pbuf - buf);
+  #if FUSB_DEBUG_PRINT
   if( err != i2c::ERROR_OK ){
     printf("Sending Message (%d) failed err: %d.\n", (int) msg.type, err );
   } 
+  #endif
   // else {
   //    printf("Sent Message (%d) id: %d. [%d] \n", (int) msg.type, msg.id, millis() );
   // }

--- a/esphome/components/fusb302b/fusb302b.h
+++ b/esphome/components/fusb302b/fusb302b.h
@@ -67,7 +67,7 @@ public:
   uint32_t startup_delay_{0};
   
   
-  
+int irq_pin_{0};  
 
 protected:
   void publish_() override {
@@ -78,7 +78,7 @@ protected:
   
   SemaphoreHandle_t i2c_lock_;
 
-  int irq_pin_{0};
+  
 };
 
 }


### PR DESCRIPTION
It appears we are nearing the limit of available interrupts supported by the ESP32 interrupt matrix per CPU.

According to the documentation:

    "... 26 peripheral interrupts to CPU0 and 26 peripheral interrupts to CPU1 as output. Note that the remaining six CPU0 interrupts and six CPU1 interrupts are internal interrupts."

To conserve interrupts for other components that we cannot control, the interrupt handling for the FUSB302b should be moved to Core 1.