### PR TITLE
Set device_class for temperature offset

### DIFF
--- a/config/common/hat_sensors.yaml
+++ b/config/common/hat_sensors.yaml
@@ -31,7 +31,7 @@ number:
   - platform: template
     name: "Offset Temperature"
     id: temp_offset_ui
-    unit_of_measurement: "°C"
+    device_class: temperature
     min_value: -20
     max_value: 20
     step: 0.1


### PR DESCRIPTION
Currently the temperature offset number uses the unit_of_mesaurement attribute, which is hardcoded to celsius. 

This PR changes this to adapt to the local settings.

closes #231