### PR TITLE
Save .elf file in release

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - staging
+  
+  pull_request:
+  
   workflow_dispatch:
     inputs:
       tag:
@@ -149,7 +152,9 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: build/*.bin
+          files: |
+            build/*.bin
+            build/*.elf
           generate_release_notes: true
           append_body: true
           body: ${{ needs.push-tag.outputs.changelog }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -148,6 +148,7 @@ jobs:
           mkdir -p build
           echo "Copying all files to build directory"
           find files -name "*.bin" -exec cp {} build/ \;
+          find files -name "*.elf" -exec cp {} build/ \;
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -6,8 +6,6 @@ on:
       - main
       - staging
   
-  pull_request:
-  
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
This PR adds the .elf file to a release. This file is needed for decoding back trace addresses reported by the customer.