### PR TITLE
Debug-Config: Adds the version text sensor and a xmos hardware reset button.

### DIFF
--- a/config/common/debug.yaml
+++ b/config/common/debug.yaml
@@ -1,3 +1,10 @@
+external_components:  
+  - source:
+      type: git
+      url: https://github.com/FutureProofHomes/Satellite1-ESPHome
+      ref: develop
+    components: [ version ]
+
 debug:
   update_interval: 5s
 
@@ -31,6 +38,11 @@ text_sensor:
     icon: "mdi:chip"
     lambda: |-
       return std::string("${built_for_hat_hw_version}");
+  
+  - platform: version
+    name: "Firmware Version"
+    hide_timestamp: true
+
 
 sensor:
   - platform: debug
@@ -56,6 +68,14 @@ button:
   - platform: safe_mode
     name: "Restart Sat1 (Safe Mode)"
     entity_category: diagnostic
+  
+  - platform: template
+    id: xmos_hardware_reset
+    name: "XMOS Hardware Reset"
+    entity_category: diagnostic
+    on_press:
+      then:
+        - satellite1.xmos_hardware_reset
 
   # Flashes Sat1 HAT with specific XMOS firmware
   - platform: template

--- a/esphome/components/satellite1/automation.h
+++ b/esphome/components/satellite1/automation.h
@@ -6,6 +6,16 @@
 namespace esphome {
 namespace satellite1 {
 
+template<typename... Ts> 
+class XMOSHardwareResetAction : public Action<Ts...>, public Parented<Satellite1> {
+ public:
+  void play(Ts... x) override {
+    this->parent_->xmos_hardware_reset();
+  }
+};
+
+
+
 template<Satellite1State State> class Satellite1StateTrigger : public Trigger<> {
  public:
   explicit Satellite1StateTrigger(Satellite1 *sat1) {

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -184,6 +184,13 @@ bool Satellite1::check_for_xmos_(){
   return ( memcmp(this->xmos_fw_version, compare_zeros, 5) != 0 );
 }
 
+void Satellite1::xmos_hardware_reset(){
+  this->xmos_rst_pin_->digital_write(1);
+  delay(100);
+  this->xmos_rst_pin_->digital_write(0);
+  delay(100);
+}
+
 
 }
 }

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -161,6 +161,9 @@ class Satellite1 : public Component,
     this->state_callback_.add(std::move(callback));
   }
 
+  void xmos_hardware_reset(); 
+
+
 protected:
   bool dfu_get_fw_version_();
   bool check_for_xmos_();

--- a/esphome/components/satellite1/satellite1.py
+++ b/esphome/components/satellite1/satellite1.py
@@ -10,16 +10,21 @@ namespace = cg.esphome_ns.namespace("satellite1")
 Satellite1 = namespace.class_("Satellite1", SPIDevice, cg.Component)
 Satellite1SPIService = namespace.class_("Satellite1SPIService", cg.Parented.template(Satellite1))
 
+
+XMOSHardwareResetAction = namespace.class_(
+    "XMOSHardwareResetAction", automation.Action
+)
+
 XMOSConnectedStateTrigger = namespace.class_(
-    "XMOSConnectedStateTrigger", automation.Action
+    "XMOSConnectedStateTrigger", automation.Trigger
 )
 
 FlashConnectedStateTrigger = namespace.class_(
-    "FlashConnectedStateTrigger", automation.Action
+    "FlashConnectedStateTrigger", automation.Trigger
 )
 
 XMOSNoResponseStateTrigger = namespace.class_(
-    "XMOSNoResponseStateTrigger", automation.Action
+    "XMOSNoResponseStateTrigger", automation.Trigger
 )
 
 
@@ -70,3 +75,19 @@ async def register_satellite1(config) :
          await automation.build_automation(trigger, [], conf)
     
     return var
+
+
+RESET_XMOS_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(CONF_SATELLITE1): cv.use_id(Satellite1)
+    }
+)
+@automation.register_action(
+    "satellite1.xmos_hardware_reset", 
+    XMOSHardwareResetAction, 
+    RESET_XMOS_ACTION_SCHEMA)
+async def erase_memory_action_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_SATELLITE1])
+    return var
+


### PR DESCRIPTION
Could give insights into this issue : https://github.com/FutureProofHomes/Satellite1-ESPHome/issues/248

Let's test if resetting the xmos without re-flashing also helps to get out of the non-responding state.