### PR TITLE
Adjust led brightness for the 'waiting for wifi' status 

### DIFF
--- a/config/common/led_ring.yaml
+++ b/config/common/led_ring.yaml
@@ -589,7 +589,7 @@ script:
                 effect: "Twinkle"
           else:
             - light.turn_on:
-                brightness: 66%
+                brightness: 33%
                 red: 100%
                 green: 89%
                 blue: 71%


### PR DESCRIPTION
Sets the brightness to 33%. This reduces the power consumption during wifi scanning/connecting.