### PR TITLE
Expose ESP32 Internal temperature to Debug

### DIFF
--- a/config/common/debug.yaml
+++ b/config/common/debug.yaml
@@ -50,6 +50,10 @@ sensor:
     name: "Wi-Fi Signal Strength"
     entity_category: "diagnostic"
     update_interval: 60s
+  - platform: internal_temperature
+    name: "Internal Temperature"
+    entity_category: "diagnostic"
+    update_interval: 60s
 
 button:
   # Restarts Sat1 to safe mode


### PR DESCRIPTION
Add the sensor to the Debug window in HA to show the Internal temperature of the ESP32-S3 module

This has been useful for stress testing the unit to monitor reboots at diffferent temperatures.