### PR TITLE
Remove flash_accessible check from flashing on no_response condition.

### DIFF
--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -31,7 +31,6 @@ packages:
           - if:
               condition:
                 - lambda: return id(init_in_progress);
-                - lambda: return id(xflash).flash_accessible();
                 - lambda: return id(xflash).has_image_embedded();
               then:
                 - memory_flasher.write_embedded_image:


### PR DESCRIPTION
As it is not necessarily needed, remove this check to prevent race-conditions while XMOS in reset mode.