### PR TITLE
Bump XMOS firmware to 1.0.2-beta.1

### DIFF
--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -13,7 +13,7 @@ substitutions:
   component_name: Core
   
   esp32_fw_version: dev
-  xmos_fw_version: "v1.0.1"
+  xmos_fw_version: "v1.0.2-beta.1"
   built_for_core_hw_version: "v1.0.0-beta.1"
   built_for_hat_hw_version: "v1.0.0-beta.1"
 

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: satellite1
   friendly_name: Satellite1
-  xmos_fw_version: "v1.0.1"
+  xmos_fw_version: "v1.0.2-beta.1"
   
   # OPTIONALLY, set the log level to debug, info, warn, error
   log_level: debug


### PR DESCRIPTION
## XMOS - Changes 
* Python based versioning by @gnumpi in https://github.com/FutureProofHomes/Satellite1-XMOS/pull/81
* Remove unused legacy code by @gnumpi in https://github.com/FutureProofHomes/Satellite1-XMOS/pull/82
* Introduce watchdog by @gnumpi in https://github.com/FutureProofHomes/Satellite1-XMOS/pull/83
* Bump to XTC-15.3 by @gnumpi in https://github.com/FutureProofHomes/Satellite1-XMOS/pull/87
* Usb upgrades for next release by @gnumpi in https://github.com/FutureProofHomes/Satellite1-XMOS/pull/89
* Prepare for 1.0.2 release by @gnumpi in https://github.com/FutureProofHomes/Satellite1-XMOS/pull/90
* GHA: updated venv creation for xmos-ai-tools dependency by @gnumpi in https://github.com/FutureProofHomes/Satellite1-XMOS/pull/92