### PR TITLE
Fix for develop/version sensor, sets NoGit if not called within a repo.

### DIFF
--- a/esphome/components/version/text_sensor.py
+++ b/esphome/components/version/text_sensor.py
@@ -42,4 +42,4 @@ async def to_code(config):
     var = await text_sensor.new_text_sensor(config)
     await cg.register_component(var, config)
     cg.add(var.set_hide_timestamp(config[CONF_HIDE_TIMESTAMP]))
-    cg.add(var.set_git_commit(get_current_commit_hash()))
+    cg.add(var.set_git_commit(get_current_commit_hash() or "NoGit"))


### PR DESCRIPTION
Building the firmware with the develop options enabled fails in the current version if the build process is not called within a git repository. This is for example the case when trying to build the firmware via the ESPhome Dashboard Builder.

This PR fixes this by setting the git commit hash to "NoGit" in such cases.