### PR TITLE
Enable debg log-level by default

### DIFF
--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -112,6 +112,10 @@ external_components:
 logger:
   deassert_rts_dtr: true
   hardware_uart : USB_SERIAL_JTAG
-  level: warn
+  level: debug
+  logs:
+    ltr_als_ps: WARN
+    
+
 
 


### PR DESCRIPTION
- global log-level set to debug
- ltr_als_ps log-level left at WARN

closes #276 