### PR TITLE
Adapt to breaking changes of ESPHome 2025.X

### DIFF
--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -16,7 +16,7 @@ jobs:
     with:
       files: |
         config/satellite1.factory.yaml
-      esphome-version: 2024.12.2
+      esphome-version: 2025.3.3
       release-summary: develop-branch
       release-url:
       release-version:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -90,7 +90,7 @@ jobs:
     with:
       files: |
         config/satellite1.factory.yaml
-      esphome-version: 2024.12.2
+      esphome-version: 2025.3.3
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
   push-tag:

--- a/config/common/buttons.yaml
+++ b/config/common/buttons.yaml
@@ -136,10 +136,10 @@ binary_sensor:
                     else:
                       - if:
                           condition:
-                            lambda: return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+                            lambda: return id(external_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
                           then:
                             - lambda: |
-                                id(nabu_media_player)
+                                id(external_media_player)
                                   ->make_call()
                                   .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
                                   .set_announcement(true)

--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -9,8 +9,7 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 4.4.8
-    platform_version: 5.4.0
+    version: recommended
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"

--- a/config/common/led_ring.yaml
+++ b/config/common/led_ring.yaml
@@ -21,7 +21,6 @@ light:
   - platform: esp32_rmt_led_strip
     id: hw_led_ring
     pin: GPIO21
-    rmt_channel: 1
     num_leds: 24
     rgb_order: GRB
     chipset: WS2812

--- a/config/common/led_ring.yaml
+++ b/config/common/led_ring.yaml
@@ -192,7 +192,7 @@ light:
               it[18] = muted_color;
               it[19] = Color::BLACK;
             }
-            if ( id(nabu_media_player).volume == 0.0f || id(nabu_media_player).is_muted() ) {
+            if ( id(external_media_player).volume == 0.0f || id(external_media_player).is_muted() ) {
               it[1] = Color::BLACK;
               it[2] = muted_color;
               it[3] = muted_color;
@@ -222,7 +222,7 @@ light:
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             Color silenced_color(255, 0, 0);
-            auto volume_ratio = 24.0f * id(nabu_media_player).volume;
+            auto volume_ratio = 24.0f * id(external_media_player).volume;
             for (int i = 0; i < 24; i++) {
               if (i <= volume_ratio) {
                 it[(0+i)%24] = color * min( 255.0f * (volume_ratio - i) , 255.0f ) ;
@@ -230,7 +230,7 @@ light:
                 it[(0+i)%24] = Color::BLACK;
               }
             }
-            if (id(nabu_media_player).volume == 0.0f) {
+            if (id(external_media_player).volume == 0.0f) {
               it[0] = silenced_color;
             }
       - addressable_lambda:
@@ -553,7 +553,7 @@ script:
             id(control_leds_timer_ticking).execute();
           } else if (id(master_mute_switch).state) {
             id(control_leds_muted_or_silent).execute();
-          } else if (id(nabu_media_player).volume == 0.0f || id(nabu_media_player).is_muted()) {
+          } else if (id(external_media_player).volume == 0.0f || id(external_media_player).is_muted()) {
             id(control_leds_muted_or_silent).execute();
           } else if (id(voice_assistant_phase) == ${voice_assist_idle_phase_id}) {
             id(control_leds_voice_assistant_idle_phase).execute();

--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -30,7 +30,7 @@ audio_dac:
           volume: !lambda return id(dac_proxy).volume();
       - lambda: |
            if( id(dac_proxy).is_muted() ){
-              id(nabu_media_player)->make_call()
+              id(external_media_player)->make_call()
                 .set_command(MEDIA_PLAYER_COMMAND_MUTE)
                 .perform();
            }
@@ -98,38 +98,74 @@ fusb302b:
             - tas2780.activate:
 speaker:
   - platform: i2s_audio
+    id: i2s_audio_speaker
     sample_rate: 48000
     i2s_clock_mode: external
     i2s_dout_pin: GPIO9
     bits_per_sample: 32bit
     i2s_audio_id: i2s_shared
     dac_type: external
-    channel: right_left
+    channel: stereo
     timeout: never
     #buffer_duration: 100ms
 
+# Virtual speakers to combine the announcement and media streams together into one output
+  - platform: mixer
+    id: mixing_speaker
+    output_speaker: i2s_audio_speaker
+    num_channels: 2
+    source_speakers:
+      - id: announcement_mixing_input
+        timeout: never
+      - id: media_mixing_input
+        timeout: never
+
+  # Vritual speakers to resample each pipelines' audio, if necessary, as the mixer speaker requires the same sample rate
+  - platform: resampler
+    id: announcement_resampling_speaker
+    output_speaker: announcement_mixing_input
+    sample_rate: 48000
+    bits_per_sample: 16
+  - platform: resampler
+    id: media_resampling_speaker
+    output_speaker: media_mixing_input
+    sample_rate: 48000
+    bits_per_sample: 16
+
+
 
 media_player:
-  - platform: nabu
-    id: nabu_media_player
+  - platform: speaker
+    id: external_media_player
     name: Sat1 Media Player
-    sample_rate: 48000
     internal: false
-    speaker:
-    audio_dac: dac_proxy
     volume_increment: 0.05
     volume_min: 0.1
     volume_max: 1.
+    announcement_pipeline:
+      speaker: announcement_resampling_speaker
+      format: FLAC     # FLAC is the least processor intensive codec
+      num_channels: 1  # Stereo audio is unnecessary for announcements
+      sample_rate: 48000
+    media_pipeline:
+      speaker: media_resampling_speaker
+      format: FLAC     # FLAC is the least processor intensive codec
+      num_channels: 2
+      sample_rate: 48000
+    
     on_mute:
       - script.execute: control_leds
     on_unmute:
       - script.execute: control_leds
     on_volume:
       - script.execute: control_leds
+    
     on_announcement:
-      - nabu.set_ducking:
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
           decibel_reduction: 20
           duration: 0.0s
+    
     on_state:
       if:
         condition:
@@ -138,9 +174,10 @@ media_player:
             - not:
                 voice_assistant.is_running:
             - not:
-                lambda: return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+                media_player.is_announcing:
         then:
-          - nabu.set_ducking:
+          - mixer_speaker.apply_ducking:
+              id: media_mixing_input
               decibel_reduction: 0
               duration: 1.0s
 
@@ -176,22 +213,19 @@ script:
   - id: play_sound
     parameters:
       priority: bool
-      sound_file: "media_player::MediaFile*"
+      sound_file: "audio::AudioFile*"
     then:
       - lambda: |-
           if (priority) {
-            id(nabu_media_player)
+            id(external_media_player)
               ->make_call()
               .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
               .set_announcement(true)
               .perform();
           }
-          if ( (id(nabu_media_player).state != media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING ) || priority) {
-            id(nabu_media_player)
-              ->make_call()
-              .set_announcement(true)
-              .set_local_media_file(sound_file)
-              .perform();
+          if ( (id(external_media_player).state != media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING ) || priority) {
+            id(external_media_player)
+              ->play_file(sound_file, true, false);
           }
   
   # Script to increased/decreased volume  

--- a/config/common/timer.yaml
+++ b/config/common/timer.yaml
@@ -22,23 +22,25 @@ switch:
       # Stop any current annoucement (ie: stop the timer ring mid playback)
       - if:
           condition:
-            lambda: return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+            lambda: return id(external_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
           then:
             lambda: |-
-              id(nabu_media_player)
+              id(external_media_player)
                 ->make_call()
                 .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
                 .set_announcement(true)
                 .perform();
       # Set back ducking ratio to zero
-      - nabu.set_ducking:
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
           decibel_reduction: 0
           duration: 1.0s
       # Refresh the LED ring
       - script.execute: control_leds
     on_turn_on:
       # Duck audio
-      - nabu.set_ducking:
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
           decibel_reduction: 20
           duration: 0.0s
       # Enable stop wake word
@@ -66,11 +68,11 @@ script:
                 sound_file: !lambda return id(timer_finished_sound);
             - wait_until:
                 lambda: |-
-                  return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+                  return id(external_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
             - wait_until:
                 not:
                   lambda: |-
-                    return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+                    return id(external_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
 
 
   # Script used to fetch the first active timer (Stored in global first_active_timer)

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -70,10 +70,10 @@ micro_wake_word:
               else:
                 - if:
                     condition:
-                      lambda: return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+                      lambda: return id(external_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
                     then:
                       lambda: |-
-                        id(nabu_media_player)
+                        id(external_media_player)
                           ->make_call()
                           .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
                           .set_announcement(true)
@@ -96,7 +96,7 @@ micro_wake_word:
 voice_assistant:
   id: va
   microphone: asr_mic
-  media_player: nabu_media_player
+  media_player: external_media_player
   micro_wake_word: mww
   use_wake_word: false
   noise_suppression_level: 0
@@ -120,9 +120,11 @@ voice_assistant:
         then:
           - lambda: id(voice_assistant_phase) = ${voice_assist_error_phase_id};
           - script.execute: control_leds
+  
   # When the voice assistant starts: Play a wake up sound, duck audio.
   on_start:
-    - nabu.set_ducking:
+    - mixer_speaker.apply_ducking:
+        id: media_mixing_input
         decibel_reduction: 20   # Number of dB quieter; higher implies more quiet, 0 implies full volume
         duration: 0.0s          # The duration of the transition (default is 0)
   on_listening:
@@ -145,7 +147,8 @@ voice_assistant:
         not:
           voice_assistant.is_running:
     # Stop ducking audio.
-    - nabu.set_ducking:
+    - mixer_speaker.apply_ducking:
+        id: media_mixing_input
         decibel_reduction: 0   # 0 dB means no reduction
         duration: 1.0s
     # Stop the script that would potentially enable the stop word if the response is longer than a second

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -40,7 +40,7 @@ esphome:
   name: ${node_name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2024.12.2
+  min_version: 2025.3.3
   
   project:
     name: ${company_name}.${project_name}
@@ -67,9 +67,9 @@ esphome:
 external_components:
   - source:
       type: git
-      url: https://github.com/FutureProofHomes/home-assistant-voice-pe
-      ref: 2024.12.10-fph.2
-    components: [ microphone, voice_assistant, audio_dac, media_player, nabu, micro_wake_word ]
+      url: https://github.com/esphome/home-assistant-voice-pe
+      ref: 25.3.4
+    components: [ microphone, voice_assistant, micro_wake_word ]
 
 ota:
   - platform: esphome

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -5,8 +5,9 @@ import esphome.final_validate as fv
 import esphome.codegen as cg
 
 from esphome import pins
-from esphome.components import i2c
 from esphome.const import CONF_ENABLE_PIN, CONF_ID, CONF_MODE, CONF_MODEL, CONF_VOLUME
+from esphome.const import CONF_BITS_PER_SAMPLE, CONF_CHANNEL, CONF_ID, CONF_SAMPLE_RATE
+from esphome.cpp_generator import MockObjClass
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
@@ -29,10 +30,20 @@ CONF_I2S_LRCLK_PIN = "i2s_lrclk_pin"
 
 CONF_I2S_AUDIO = "i2s_audio"
 CONF_I2S_AUDIO_ID = "i2s_audio_id"
+
+CONF_I2S_MODE = "i2s_mode"
+CONF_PRIMARY = "primary"
+CONF_SECONDARY = "secondary"
+CONF_USE_APLL = "use_apll"
 CONF_I2S_ACCESS_MODE = "access_mode"
 
-CONF_SAMPLE_RATE = "sample_rate"
-CONF_BITS_PER_SAMPLE = "bits_per_sample"
+
+CONF_BITS_PER_CHANNEL = "bits_per_channel"
+CONF_MONO = "mono"
+CONF_LEFT = "left"
+CONF_RIGHT = "right"
+CONF_STEREO = "stereo"
+
 CONF_PDM = "pdm"
 
 i2s_audio_ns = cg.esphome_ns.namespace("i2s_audio")
@@ -143,6 +154,73 @@ def final_validate_device_schema(name: str) -> cv.Schema:
         )(config)
 
     return create_schema
+
+i2s_mode_t = cg.global_ns.enum("i2s_mode_t")
+I2S_MODE_OPTIONS = {
+    CONF_PRIMARY: i2s_mode_t.I2S_MODE_MASTER,  # NOLINT
+    CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,  # NOLINT
+}
+
+
+i2s_channel_fmt_t = cg.global_ns.enum("i2s_channel_fmt_t")
+I2S_CHANNELS = {
+    CONF_MONO: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ALL_LEFT,
+    CONF_LEFT: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_LEFT,
+    CONF_RIGHT: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_RIGHT,
+    CONF_STEREO: i2s_channel_fmt_t.I2S_CHANNEL_FMT_RIGHT_LEFT,
+}
+
+i2s_bits_per_sample_t = cg.global_ns.enum("i2s_bits_per_sample_t")
+I2S_BITS_PER_SAMPLE = {
+    8: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_8BIT,
+    16: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_16BIT,
+    24: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_24BIT,
+    32: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_32BIT,
+}
+
+i2s_bits_per_chan_t = cg.global_ns.enum("i2s_bits_per_chan_t")
+I2S_BITS_PER_CHANNEL = {
+    "default": i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_DEFAULT,
+    8: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_8BIT,
+    16: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_16BIT,
+    24: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_24BIT,
+    32: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_32BIT,
+}
+
+_validate_bits = cv.float_with_unit("bits", "bit")
+
+
+
+def i2s_audio_component_schema(
+    class_: MockObjClass,
+    *,
+    default_sample_rate: int,
+    default_channel: str,
+    default_bits_per_sample: str,
+):
+    return cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(class_),
+            cv.GenerateID(CONF_I2S_AUDIO_ID): cv.use_id(I2SAudioComponent),
+            cv.Optional(CONF_CHANNEL, default=default_channel): cv.enum(I2S_CHANNELS),
+            cv.Optional(CONF_SAMPLE_RATE, default=default_sample_rate): cv.int_range(
+                min=1
+            ),
+            cv.Optional(CONF_BITS_PER_SAMPLE, default=default_bits_per_sample): cv.All(
+                _validate_bits, cv.enum(I2S_BITS_PER_SAMPLE)
+            ),
+            cv.Optional(CONF_I2S_MODE, default=CONF_PRIMARY): cv.enum(
+                I2S_MODE_OPTIONS, lower=True
+            ),
+            cv.Optional(CONF_USE_APLL, default=False): cv.boolean,
+            cv.Optional(CONF_BITS_PER_CHANNEL, default="default"): cv.All(
+                cv.Any(cv.float_with_unit("bits", "bit"), "default"),
+                cv.enum(I2S_BITS_PER_CHANNEL),
+            ),
+        }
+    )
+
+
 
 
 async def apply_i2s_settings(var, config) -> None:

--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -81,7 +81,7 @@ bool I2SAudioComponent::install_i2s_driver_(i2s_driver_config_t i2s_cfg, uint8_t
     if(this->access_mode_ == I2SAccessMode::DUPLEX){
       i2s_cfg.mode = (i2s_mode_t) (i2s_cfg.mode | I2S_MODE_TX | I2S_MODE_RX);
     }
-    success = ESP_OK == i2s_driver_install(this->get_port(), &i2s_cfg, 0, nullptr);
+    success = ESP_OK == i2s_driver_install(this->get_port(), &i2s_cfg, I2S_EVENT_QUEUE_COUNT, &this->i2s_event_queue_);
     esph_log_d(TAG, "Installing driver : %s", success ? "yes" : "no" );
     i2s_pin_config_t pin_config = this->get_pin_config();
     if( success ){
@@ -136,6 +136,16 @@ bool I2SAudioComponent::uninstall_i2s_driver_(uint8_t access){
   return success;
 }
 
+void I2SAudioComponent::process_i2s_events(bool &tx_dma_underflow){
+  i2s_event_t i2s_event;
+      while (xQueueReceive(this->i2s_event_queue_, &i2s_event, 0)) {
+        if (i2s_event.type == I2S_EVENT_TX_Q_OVF) {
+          tx_dma_underflow = true;
+        }
+      }
+}
+
+
 bool I2SAudioComponent::validate_cfg_for_duplex_(i2s_driver_config_t& i2s_cfg){
   i2s_driver_config_t& installed = this->installed_cfg_;
   return (
@@ -174,8 +184,8 @@ i2s_driver_config_t I2SSettings::get_i2s_cfg() const {
       .channel_format = this->channel_fmt_,
       .communication_format = I2S_COMM_FORMAT_STAND_I2S,
       .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
-      .dma_buf_count = 4,
-      .dma_buf_len = 480,
+      .dma_buf_count = DMA_BUFFERS_COUNT,
+      .dma_buf_len = 240,
       .use_apll = false,
       .tx_desc_auto_clear = true,
       .fixed_mclk = I2S_PIN_NO_CHANGE,

--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -7,7 +7,15 @@
 namespace esphome {
 namespace i2s_audio {
 
-static const char *const TAG = "i2s_audio";
+  static const char *const TAG = "i2s_audio";
+
+#if defined(USE_ESP_IDF) && (ESP_IDF_VERSION_MAJOR >= 5)
+static const uint8_t I2S_NUM_MAX = SOC_I2S_NUM;  // because IDF 5+ took this away :(
+#endif
+
+static const size_t DMA_BUFFERS_COUNT = 4;
+static const size_t I2S_EVENT_QUEUE_COUNT = DMA_BUFFERS_COUNT + 1;
+
 
 void I2SAudioComponent::setup() {
   static i2s_port_t next_port_num = I2S_NUM_0;
@@ -171,7 +179,7 @@ i2s_driver_config_t I2SSettings::get_i2s_cfg() const {
       .use_apll = false,
       .tx_desc_auto_clear = true,
       .fixed_mclk = I2S_PIN_NO_CHANGE,
-      .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT,
+      .mclk_multiple = I2S_MCLK_MULTIPLE_256,
       .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
 #if SOC_I2S_SUPPORTS_TDM
       .chan_mask = I2S_CHANNEL_MONO,

--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -51,6 +51,8 @@ class I2SAudioComponent : public Component {
   void set_access_mode(I2SAccessMode access_mode){this->access_mode_ = access_mode;}
   bool is_exclusive(){return this->access_mode_ == I2SAccessMode::EXCLUSIVE;}
 
+  void process_i2s_events(bool &tx_dma_underflow);
+
  protected:
   friend I2SReader;
   friend I2SWriter;
@@ -73,6 +75,7 @@ class I2SAudioComponent : public Component {
   int lrclk_pin_;
   i2s_port_t port_{};
   i2s_driver_config_t installed_cfg_{};
+  QueueHandle_t i2s_event_queue_;
   bool driver_loaded_{false};
 };
 
@@ -83,23 +86,28 @@ public:
 
   i2s_driver_config_t get_i2s_cfg() const;
   void dump_i2s_settings() const;
-
-  void set_use_apll(uint32_t use_apll) { this->use_apll_ = use_apll; }
-  void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
+  
+  void set_clk_mode(i2s_mode_t clk_mode){ this->i2s_clk_mode_ = clk_mode; } 
   void set_channel(i2s_channel_fmt_t channel_fmt) { this->channel_fmt_ = channel_fmt; }
-  void set_pdm(bool pdm) { this->pdm_ = pdm; }
   void set_sample_rate(uint32_t sample_rate) { this->sample_rate_ = sample_rate; }
+  void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
+  void set_bits_per_channel(i2s_bits_per_chan_t bits_per_channel) { this->bits_per_channel_ = bits_per_channel; }
+  void set_use_apll(uint32_t use_apll) { this->use_apll_ = use_apll; }
+  
+  void set_pdm(bool pdm) { this->pdm_ = pdm; }
   void set_fixed_settings(bool is_fixed){ this->is_fixed_ = is_fixed; }
   int num_of_channels() const { return (this->channel_fmt_ == I2S_CHANNEL_FMT_ONLY_RIGHT
    || this->channel_fmt_ == I2S_CHANNEL_FMT_ONLY_LEFT) ? 1 : 2; }
-  void set_clk_mode(i2s_mode_t clk_mode){ this->i2s_clk_mode_ = clk_mode; }
+  
 
 protected:
    bool use_apll_{false};
    i2s_bits_per_sample_t bits_per_sample_;
+   i2s_bits_per_chan_t bits_per_channel_;
    i2s_channel_fmt_t channel_fmt_;
    i2s_mode_t i2s_clk_mode_{I2S_MODE_MASTER};
    i2s_mode_t i2s_access_mode_;
+   
    bool pdm_{false};
    uint32_t sample_rate_;
 

--- a/esphome/components/i2s_audio/i2s_settings.py
+++ b/esphome/components/i2s_audio/i2s_settings.py
@@ -9,6 +9,12 @@ CONF_PDM = "pdm"
 CONF_USE_APLL = "use_apll"
 CONF_FIXED_SETTINGS = "fixed_settings"
 
+CONF_MONO = "mono"
+CONF_LEFT = "left"
+CONF_RIGHT = "right"
+CONF_STEREO = "stereo"
+
+
 
 INTERNAL_CLK = "internal"
 EXTERNAL_CLK = "external"
@@ -38,6 +44,12 @@ CHANNEL_FORMAT = {
     "all_right": i2s_channel_fmt_t.I2S_CHANNEL_FMT_ALL_RIGHT,
     # Load left channel data in both two channels
     "all_left": i2s_channel_fmt_t.I2S_CHANNEL_FMT_ALL_LEFT,
+}
+I2S_CHANNELS = {
+    CONF_MONO: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ALL_LEFT,
+    CONF_LEFT: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_LEFT,
+    CONF_RIGHT: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_RIGHT,
+    CONF_STEREO: i2s_channel_fmt_t.I2S_CHANNEL_FMT_RIGHT_LEFT,
 }
 
 i2s_bits_per_sample_t = cg.global_ns.enum("i2s_bits_per_sample_t")
@@ -76,7 +88,7 @@ def get_i2s_config_schema(default_channel, default_rate, default_bits):
     return cv.Schema(
         {
             cv.Optional(CONF_CLK_MODE, default=INTERNAL_CLK): cv.enum(I2S_CLK_MODES),
-            cv.Optional(CONF_CHANNEL, default=default_channel): cv.enum(CHANNEL_FORMAT),
+            cv.Optional(CONF_CHANNEL, default=default_channel): cv.enum(I2S_CHANNELS),
             cv.Optional(CONF_SAMPLE_RATE, default=default_rate): cv.int_range(min=1),
             cv.Optional(CONF_BITS_PER_SAMPLE, default=default_bits): cv.All(
                 _validate_bits, cv.enum(BITS_PER_SAMPLE)

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -13,15 +13,14 @@
 namespace esphome {
 namespace i2s_audio {
 
-static const uint8_t DMA_BUFFER_DURATION_MS = 10;
+static const uint8_t DMA_BUFFER_DURATION_MS = 15;
 static const size_t DMA_BUFFERS_COUNT = 4;
 
-static const size_t TASK_DELAY_MS = DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT ;
+static const size_t TASK_DELAY_MS = DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT / 2;
 
 static const size_t TASK_STACK_SIZE = 4096;
-static const ssize_t TASK_PRIORITY = 17;
+static const ssize_t TASK_PRIORITY = 23;
 
-static const size_t I2S_EVENT_QUEUE_COUNT = DMA_BUFFERS_COUNT + 1;
 
 static const char *const TAG = "i2s_audio.speaker";
 
@@ -33,14 +32,15 @@ enum SpeakerEventGroupBits : uint32_t {
   STATE_RUNNING = (1 << 11),
   STATE_STOPPING = (1 << 12),
   STATE_STOPPED = (1 << 13),
-  ERR_INVALID_FORMAT = (1 << 14),
-  ERR_TASK_FAILED_TO_START = (1 << 15),
-  ERR_ESP_INVALID_STATE = (1 << 16),
+  ERR_TASK_FAILED_TO_START = (1 << 14),
+  ERR_ESP_INVALID_STATE = (1 << 15),
+  ERR_ESP_NOT_SUPPORTED = (1 << 16),
   ERR_ESP_INVALID_ARG = (1 << 17),
   ERR_ESP_INVALID_SIZE = (1 << 18),
   ERR_ESP_NO_MEM = (1 << 19),
   ERR_ESP_FAIL = (1 << 20),
-  ALL_ERR_ESP_BITS = ERR_ESP_INVALID_STATE | ERR_ESP_INVALID_ARG | ERR_ESP_INVALID_SIZE | ERR_ESP_NO_MEM | ERR_ESP_FAIL,
+  ALL_ERR_ESP_BITS = ERR_ESP_INVALID_STATE | ERR_ESP_NOT_SUPPORTED | ERR_ESP_INVALID_ARG | ERR_ESP_INVALID_SIZE |
+                     ERR_ESP_NO_MEM | ERR_ESP_FAIL,
   ALL_BITS = 0x00FFFFFF,  // All valid FreeRTOS event group bits
 };
 
@@ -55,6 +55,8 @@ static esp_err_t err_bit_to_esp_err(uint32_t bit) {
       return ESP_ERR_INVALID_SIZE;
     case SpeakerEventGroupBits::ERR_ESP_NO_MEM:
       return ESP_ERR_NO_MEM;
+    case SpeakerEventGroupBits::ERR_ESP_NOT_SUPPORTED:
+      return ESP_ERR_NOT_SUPPORTED;
     default:
       return ESP_FAIL;
   }
@@ -135,19 +137,21 @@ void I2SAudioSpeaker::loop() {
     xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ERR_TASK_FAILED_TO_START);
   }
 
-  if (event_group_bits & SpeakerEventGroupBits::ERR_INVALID_FORMAT) {
-    this->status_set_error("Failed to adjust I2S bus to match the incoming audio");
-    ESP_LOGE(TAG,
-             "Incompatible audio format: sample rate = %" PRIu32 ", channels = %" PRIu8 ", bits per sample = %" PRIu8,
-             this->audio_stream_info_.sample_rate, this->audio_stream_info_.channels,
-             this->audio_stream_info_.bits_per_sample);
-}
-
   if (event_group_bits & SpeakerEventGroupBits::ALL_ERR_ESP_BITS) {
     uint32_t error_bits = event_group_bits & SpeakerEventGroupBits::ALL_ERR_ESP_BITS;
     ESP_LOGW(TAG, "Error writing to I2S: %s", esp_err_to_name(err_bit_to_esp_err(error_bits)));
     this->status_set_warning();
   }
+
+  if (event_group_bits & SpeakerEventGroupBits::ERR_ESP_NOT_SUPPORTED) {
+    this->status_set_error("Failed to adjust I2S bus to match the incoming audio");
+    ESP_LOGE(TAG,
+             "Incompatible audio format: sample rate = %" PRIu32 ", channels = %" PRIu8 ", bits per sample = %" PRIu8,
+             this->audio_stream_info_.get_sample_rate(), this->audio_stream_info_.get_channels(),
+             this->audio_stream_info_.get_bits_per_sample());
+}
+
+  xEventGroupClearBits(this->event_group_, ALL_ERR_ESP_BITS);
 }
 
 void I2SAudioSpeaker::set_volume(float volume) {
@@ -198,6 +202,12 @@ size_t I2SAudioSpeaker::play(const uint8_t *data, size_t length, TickType_t tick
     this->start();
   }
 
+  if ((this->state_ != speaker::STATE_RUNNING) || (this->audio_ring_buffer_.use_count() == 1)) {
+    // Unable to write data to a running speaker, so delay the max amount of time so it can get ready
+    vTaskDelay(ticks_to_wait);
+    ticks_to_wait = 0;
+  }
+
   size_t bytes_written = 0;
   if ((this->state_ == speaker::STATE_RUNNING) && (this->audio_ring_buffer_.use_count() == 1)) {
     // Only one owner of the ring buffer (the speaker task), so the ring buffer is allocated and no other components are
@@ -220,6 +230,8 @@ bool I2SAudioSpeaker::has_buffered_data() const {
 
 void I2SAudioSpeaker::speaker_task(void *params) {
   I2SAudioSpeaker *this_speaker = (I2SAudioSpeaker *) params;
+  this_speaker->task_created_ = true;
+
   uint32_t event_group_bits =
       xEventGroupWaitBits(this_speaker->event_group_,
                           SpeakerEventGroupBits::COMMAND_START | SpeakerEventGroupBits::COMMAND_STOP |
@@ -236,79 +248,113 @@ void I2SAudioSpeaker::speaker_task(void *params) {
   xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::STATE_STARTING);
 
   audio::AudioStreamInfo audio_stream_info = this_speaker->audio_stream_info_;
-  const ssize_t bytes_per_sample = audio_stream_info.get_bytes_per_sample();
-  const uint8_t number_of_channels = audio_stream_info.channels;
 
-  const size_t dma_buffers_size = 3 * DMA_BUFFER_DURATION_MS * this_speaker->sample_rate_ / 1000 *
-                                  bytes_per_sample * number_of_channels;
-  const size_t ring_buffer_size =
-      this_speaker->buffer_duration_ms_ * this_speaker->sample_rate_ / 1000 * bytes_per_sample * number_of_channels;
+  const uint32_t dma_buffers_duration_ms = DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT;
+  // Ensure ring buffer duration is at least the duration of all DMA buffers
+  const uint32_t ring_buffer_duration = std::max(dma_buffers_duration_ms, this_speaker->buffer_duration_ms_);
 
-  if (this_speaker->send_esp_err_to_event_group_(this_speaker->allocate_buffers_(dma_buffers_size, ring_buffer_size))) {
+  // The DMA buffers may have more bits per sample, so calculate buffer sizes based in the input audio stream info
+  const size_t data_buffer_size = audio_stream_info.ms_to_bytes(dma_buffers_duration_ms);
+  const size_t ring_buffer_size = audio_stream_info.ms_to_bytes(ring_buffer_duration);
+
+  const size_t single_dma_buffer_input_size = data_buffer_size / DMA_BUFFERS_COUNT;
+
+  if (this_speaker->send_esp_err_to_event_group_(this_speaker->allocate_buffers_(data_buffer_size, ring_buffer_size))) {
     // Failed to allocate buffers
     xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_ESP_NO_MEM);
-    this_speaker->delete_task_(dma_buffers_size);
+    this_speaker->delete_task_(data_buffer_size);
   }
 
-  if (this_speaker->send_esp_err_to_event_group_(this_speaker->start_i2s_driver_())) {
-    // Failed to start I2S driver
-    this_speaker->delete_task_(dma_buffers_size);
-  }
-
-  if (!this_speaker->send_esp_err_to_event_group_(this_speaker->reconfigure_i2s_stream_info_(audio_stream_info))) {
-    // Successfully set the I2S stream info, ready to write audio data to the I2S port
-
+  if (!this_speaker->send_esp_err_to_event_group_(this_speaker->start_i2s_driver_(audio_stream_info))) {
     xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::STATE_RUNNING);
 
     bool stop_gracefully = false;
     uint32_t last_data_received_time = millis();
     bool tx_dma_underflow = false;
 
-    while (!this_speaker->timeout_.has_value() ||
+    this_speaker->accumulated_frames_written_ = 0;
+
+    // Keep looping if paused, there is no timeout configured, or data was received more recently than the configured
+    // timeout
+    while (this_speaker->pause_state_ || !this_speaker->timeout_.has_value() ||
            (millis() - last_data_received_time) <= this_speaker->timeout_.value()) {
       event_group_bits = xEventGroupGetBits(this_speaker->event_group_);
 
       if (event_group_bits & SpeakerEventGroupBits::COMMAND_STOP) {
+        xEventGroupClearBits(this_speaker->event_group_, SpeakerEventGroupBits::COMMAND_STOP);
         break;
       }
       if (event_group_bits & SpeakerEventGroupBits::COMMAND_STOP_GRACEFULLY) {
+        xEventGroupClearBits(this_speaker->event_group_, SpeakerEventGroupBits::COMMAND_STOP_GRACEFULLY);
         stop_gracefully = true;
       }
-#if 0
-      i2s_event_t i2s_event;
-      while (xQueueReceive(this_speaker->i2s_event_queue_, &i2s_event, 0)) {
-        if (i2s_event.type == I2S_EVENT_TX_Q_OVF) {
-          tx_dma_underflow = true;
-        }
+
+      if (this_speaker->audio_stream_info_ != audio_stream_info) {
+        // Audio stream info changed, stop the speaker task so it will restart with the proper settings.
+        break;
       }
-#endif
-      size_t bytes_to_read = dma_buffers_size;
-      size_t bytes_read = this_speaker->audio_ring_buffer_->read((void *) this_speaker->data_buffer_, bytes_to_read,
+
+      this_speaker->parent_->process_i2s_events(tx_dma_underflow);
+      
+
+      if (this_speaker->pause_state_) {
+        // Pause state is accessed atomically, so thread safe
+        // Delay so the task can yields, then skip transferring audio data
+        delay(TASK_DELAY_MS);
+        continue;
+      }
+
+      size_t bytes_read = this_speaker->audio_ring_buffer_->read((void *) this_speaker->data_buffer_, data_buffer_size,
                                                                  pdMS_TO_TICKS(TASK_DELAY_MS));
       
-      if (bytes_read > 0) {
-        size_t bytes_written = 0;
-
-        if ((audio_stream_info.bits_per_sample == 16) && (this_speaker->q15_volume_factor_ < INT16_MAX)) {
+      if ( bytes_read > 0) {
+        if ((audio_stream_info.get_bits_per_sample() == 16) && (this_speaker->q15_volume_factor_ < INT16_MAX)) {
           // Scale samples by the volume factor in place
           q15_multiplication((int16_t *) this_speaker->data_buffer_, (int16_t *) this_speaker->data_buffer_,
                              bytes_read / sizeof(int16_t), this_speaker->q15_volume_factor_);
         }
 
-        if (audio_stream_info.bits_per_sample == (uint8_t) this_speaker->bits_per_sample_) {
-          i2s_write(this_speaker->parent_->get_port(), this_speaker->data_buffer_, bytes_read, &bytes_written,
-                    portMAX_DELAY);
-        } else if (audio_stream_info.bits_per_sample < (uint8_t) this_speaker->bits_per_sample_) {
-          i2s_write_expand(this_speaker->parent_->get_port(), this_speaker->data_buffer_, bytes_read,
-                           audio_stream_info.bits_per_sample, this_speaker->bits_per_sample_, &bytes_written,
-                           portMAX_DELAY);
+        // Write the audio data to a single DMA buffer at a time to reduce latency for the audio duration played
+        // callback.
+        const uint32_t batches = (bytes_read + single_dma_buffer_input_size - 1) / single_dma_buffer_input_size;
+
+        for (uint32_t i = 0; i < batches; ++i) {
+          size_t bytes_written = 0;
+          size_t bytes_to_write = std::min(single_dma_buffer_input_size, bytes_read);
+
+        if (audio_stream_info.get_bits_per_sample() == (uint8_t) this_speaker->bits_per_sample_) {
+            i2s_write(this_speaker->parent_->get_port(), this_speaker->data_buffer_ + i * single_dma_buffer_input_size,
+                      bytes_to_write, &bytes_written, pdMS_TO_TICKS(DMA_BUFFER_DURATION_MS * 5));
+        } else if (audio_stream_info.get_bits_per_sample() < (uint8_t) this_speaker->bits_per_sample_) {
+            i2s_write_expand(this_speaker->parent_->get_port(),
+                             this_speaker->data_buffer_ + i * single_dma_buffer_input_size, bytes_to_write,
+                           audio_stream_info.get_bits_per_sample(), this_speaker->bits_per_sample_, &bytes_written,
+                             pdMS_TO_TICKS(DMA_BUFFER_DURATION_MS * 5));
         }
 
-        if (bytes_written != bytes_read) {
+          uint32_t write_timestamp = micros();
+
+          if (bytes_written != bytes_to_write) {
           xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_ESP_INVALID_SIZE);
         }
+
+          bytes_read -= bytes_written;
+
+          this_speaker->accumulated_frames_written_ += audio_stream_info.bytes_to_frames(bytes_written);
+          const uint32_t new_playback_ms =
+              audio_stream_info.frames_to_milliseconds_with_remainder(&this_speaker->accumulated_frames_written_);
+          const uint32_t remainder_us =
+              audio_stream_info.frames_to_microseconds(this_speaker->accumulated_frames_written_);
+
+          uint32_t pending_frames =
+              audio_stream_info.bytes_to_frames(bytes_read + this_speaker->audio_ring_buffer_->available());
+          const uint32_t pending_ms = audio_stream_info.frames_to_milliseconds_with_remainder(&pending_frames);
+
+          this_speaker->audio_output_callback_(new_playback_ms, remainder_us, pending_ms, write_timestamp);
+
         tx_dma_underflow = false;
         last_data_received_time = millis();
+        }
       } else {
         // No data received
         if (stop_gracefully && tx_dma_underflow) {
@@ -316,19 +362,14 @@ void I2SAudioSpeaker::speaker_task(void *params) {
     }
       }
     }
-  } else {
-    // Couldn't configure the I2S port to be compatible with the incoming audio
-    xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_INVALID_FORMAT);
+
+    xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::STATE_STOPPING);
+
+    this_speaker->uninstall_i2s_driver();
+    this_speaker->release_i2s_access();
   }
-  i2s_zero_dma_buffer(this_speaker->parent_->get_port());
-
-  xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::STATE_STOPPING);
-
-  this_speaker->uninstall_i2s_driver();
-  this_speaker->release_i2s_access();
   
-
-  this_speaker->delete_task_(dma_buffers_size);
+  this_speaker->delete_task_(data_buffer_size);
 }
 
 void I2SAudioSpeaker::start() {
@@ -337,16 +378,15 @@ void I2SAudioSpeaker::start() {
   if ((this->state_ == speaker::STATE_STARTING) || (this->state_ == speaker::STATE_RUNNING))
     return;
 
-  if (this->speaker_task_handle_ == nullptr) {
+  if (!this->task_created_ && (this->speaker_task_handle_ == nullptr)) {
     xTaskCreate(I2SAudioSpeaker::speaker_task, "speaker_task", TASK_STACK_SIZE, (void *) this, TASK_PRIORITY,
                 &this->speaker_task_handle_);
-  }
 
   if (this->speaker_task_handle_ != nullptr) {
     xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);
-    this->task_created_ = true;
   } else {
     xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::ERR_TASK_FAILED_TO_START);
+    }
   }
 }
 
@@ -383,6 +423,9 @@ bool I2SAudioSpeaker::send_esp_err_to_event_group_(esp_err_t err) {
     case ESP_ERR_NO_MEM:
       xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::ERR_ESP_NO_MEM);
       return true;
+    case ESP_ERR_NOT_SUPPORTED:
+      xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::ERR_ESP_NOT_SUPPORTED);
+      return true;
     default:
       xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::ERR_ESP_FAIL);
       return true;
@@ -412,7 +455,12 @@ esp_err_t I2SAudioSpeaker::allocate_buffers_(size_t data_buffer_size, size_t rin
   return ESP_OK;
 }
 
-esp_err_t I2SAudioSpeaker::start_i2s_driver_() {
+esp_err_t I2SAudioSpeaker::start_i2s_driver_(audio::AudioStreamInfo &audio_stream_info) {
+  if ((this->i2s_clk_mode_ & I2S_MODE_SLAVE) && (this->sample_rate_ != audio_stream_info.get_sample_rate())) {  // NOLINT
+    // Can't reconfigure I2S bus, so the sample rate must match the configured value
+    return ESP_ERR_NOT_SUPPORTED;
+  }
+  
   if (!this->claim_i2s_access()) {
     return ESP_ERR_INVALID_STATE;
   }
@@ -427,22 +475,8 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver_() {
   return ESP_OK;
 }
 
-esp_err_t I2SAudioSpeaker::reconfigure_i2s_stream_info_(audio::AudioStreamInfo &audio_stream_info) {
-   if (this->sample_rate_ != audio_stream_info.sample_rate) {
-    // Can't reconfigure I2S bus, so the sample rate must match the configured value
-    return ESP_ERR_INVALID_ARG;
-  }
-
-  if ((i2s_bits_per_sample_t) audio_stream_info.bits_per_sample > this->bits_per_sample_) {
-    // Currently can't handle the case when the incoming audio has more bits per sample than the configured value
-    return ESP_ERR_INVALID_ARG;
-  }
-  return ESP_OK;
-
-}
-
 void I2SAudioSpeaker::delete_task_(size_t buffer_size) {
-  this->audio_ring_buffer_.reset();  // Releases onwership of the shared_ptr
+  this->audio_ring_buffer_.reset();  // Releases ownership of the shared_ptr
 
   if (this->data_buffer_ != nullptr) {
     ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -21,29 +21,7 @@
 namespace esphome {
 namespace i2s_audio {
 
-static const size_t BUFFER_SIZE = 1024;
-
-enum class TaskEventType : uint8_t {
-  STARTING = 0,
-  STARTED,
-  PLAYING,
-  STOPPING,
-  STOPPED,
-  WARNING = 255,
-};
-
-struct TaskEvent {
-  TaskEventType type;
-  esp_err_t err;
-};
-
-struct DataEvent {
-  bool stop;
-  size_t len;
-  uint8_t data[BUFFER_SIZE];
-};
-
-class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SWriter {
+class I2SAudioSpeaker : public I2SWriter, public speaker::Speaker, public Component {
  public:
   float get_setup_priority() const override { return esphome::setup_priority::PROCESSOR; }
 
@@ -57,6 +35,9 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SWri
   void start() override;
   void stop() override;
   void finish() override;
+
+  void set_pause_state(bool pause_state) override { this->pause_state_ = pause_state; }
+  bool get_pause_state() const override { return this->pause_state_; }
 
   /// @brief Plays the provided audio data.
   /// Starts the speaker task, if necessary. Writes the audio data to the ring buffer.
@@ -109,25 +90,16 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SWri
   esp_err_t allocate_buffers_(size_t data_buffer_size, size_t ring_buffer_size);
 
   /// @brief Starts the ESP32 I2S driver.
-  /// Attempts to lock the I2S port, starts the I2S driver, and sets the data out pin. If it fails, it will unlock
-  /// the I2S port and uninstall the driver, if necessary.
-  /// @return ESP_ERR_INVALID_STATE if the I2S port is already locked.
-  ///         ESP_ERR_INVALID_ARG if installing the driver or setting the data out pin fails due to a parameter error.
+  /// Attempts to lock the I2S port, starts the I2S driver using the passed in stream information, and sets the data out
+  /// pin. If it fails, it will unlock the I2S port and uninstall the driver, if necessary.
+  /// @param audio_stream_info Stream information for the I2S driver.
+  /// @return ESP_ERR_NOT_ALLOWED if the I2S port can't play the incoming audio stream.
+  ///         ESP_ERR_INVALID_STATE if the I2S port is already locked.
+  ///         ESP_ERR_INVALID_ARG if nstalling the driver or setting the data outpin fails due to a parameter error.
   ///         ESP_ERR_NO_MEM if the driver fails to install due to a memory allocation error.
-  ///         ESP_FAIL if setting the data out pin fails due to an IO error
-  ///         ESP_OK if successful
-  esp_err_t start_i2s_driver_();
-
-  /// @brief Adjusts the I2S driver configuration to match the incoming audio stream.
-  /// Modifies I2S driver's sample rate, bits per sample, and number of channel settings. If the I2S is in secondary
-  /// mode, it only modifies the number of channels.
-  /// @param audio_stream_info  Describes the incoming audio stream
-  /// @return ESP_ERR_INVALID_ARG if there is a parameter error, if there is more than 2 channels in the stream, or if
-  ///           the audio settings are incompatible with the configuration.
-  ///         ESP_ERR_NO_MEM if the driver fails to reconfigure due to a memory allocation error.
-  ///         ESP_OK if successful.
-  esp_err_t reconfigure_i2s_stream_info_(audio::AudioStreamInfo &audio_stream_info);
-
+  ///         ESP_FAIL if setting the data out pin fails due to an IO error ESP_OK if successful
+  esp_err_t start_i2s_driver_(audio::AudioStreamInfo &audio_stream_info);
+  
   /// @brief Deletes the speaker's task.
   /// Deallocates the data_buffer_ and audio_ring_buffer_, if necessary, and deletes the task. Should only be called by
   /// the speaker_task itself.
@@ -148,9 +120,12 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SWri
 
 
   bool task_created_{false};
+  bool pause_state_{false};
 
   int16_t q15_volume_factor_{INT16_MAX};
-
+  
+  size_t bytes_written_{0};
+  uint32_t accumulated_frames_written_{0};
 };
 
 }  // namespace i2s_audio

--- a/esphome/components/pcm5122/pcm_gpio.h
+++ b/esphome/components/pcm5122/pcm_gpio.h
@@ -18,6 +18,7 @@ public:
   void set_pin(uint8_t pin) { this->pin_ = pin; }
   void set_inverted(bool inverted) { this->inverted_ = inverted; }
   void set_flags(gpio::Flags flags) { this->flags_ = flags; }
+  gpio::Flags get_flags() const { return this->flags_; } 
 
 protected:
   uint8_t pin_;

--- a/esphome/components/satellite1/sat_gpio.h
+++ b/esphome/components/satellite1/sat_gpio.h
@@ -28,8 +28,9 @@ public:
     void set_pin(XMOSPort port, uint8_t pin) { this->port_ = port; this->pin_ = pin; }
     void set_inverted(bool inverted) { this->inverted_ = inverted; }
     void set_flags(gpio::Flags flags) { this->flags_ = flags; }
+    gpio::Flags get_flags() const {return this->flags_; }
 
-protected:
+ protected:
     XMOSPort port_;
     uint8_t pin_;
     bool inverted_;

--- a/esphome/components/udp_stream/__init__.py
+++ b/esphome/components/udp_stream/__init__.py
@@ -12,6 +12,7 @@ from esphome.components import microphone
 from esphome.components.network import IPAddress
 
 import socket
+from ipaddress import IPv4Address
 
 AUTO_LOAD = ["socket"]
 DEPENDENCIES = ["microphone"]
@@ -47,6 +48,8 @@ def get_local_ip() -> str | None :
 def safe_ip(ip):
     if ip is None:
         return IPAddress(0, 0, 0, 0)
+    elif isinstance(ip, IPv4Address):
+        return IPAddress( *map(int,str(ip).split(".")) )
     return IPAddress(*ip.args)
 
 
@@ -55,7 +58,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(UDPStreamer),
             cv.GenerateID(CONF_MICROPHONE): cv.use_id(microphone.Microphone),
-            cv.Optional(CONF_IP_ADDRESS, default=get_local_ip()) : cv.ipv4,
+            cv.Optional(CONF_IP_ADDRESS, default=get_local_ip()) : cv.ipaddress,
             cv.Optional(CONF_ON_START): automation.validate_automation(single=True),
             cv.Optional(CONF_ON_END): automation.validate_automation(single=True),
             cv.Optional(CONF_ON_ERROR): automation.validate_automation(single=True),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2024.12.2
+esphome==2025.3.3
 setuptools


### PR DESCRIPTION
- [x] use Voice-Assistant PE components that have moved to official ESPHome repo
    - [x] FPH components have been adapted to the introduced braking changes
- [x] import remaining Voice-Assistant PE components from official repo instead of our fork 
- [x] adapt i2s components to support IDF5
- [x] adapt LED ring config for IDF5
- [x] set minimum ESPHome version to 2025.3.3
  - [x] updated requirements.txt
  - [x] updated GitHub actions

Note:
The official speaker-media-player component has a potential deadlock issue in the current version.
- [x] PR for a fix created (https://github.com/esphome/esphome/pull/8548)
  
closes #256
closes #195
          