### PR TITLE
Missing dac settings in i2s_speaker config

### DIFF
--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -107,6 +107,7 @@ speaker:
     dac_type: external
     channel: stereo
     timeout: never
+    audio_dac: dac_proxy
     #buffer_duration: 100ms
 
 # Virtual speakers to combine the announcement and media streams together into one output


### PR DESCRIPTION
The DAC component needs to be set in the speaker settings now and was missing. 
Without that config the software volume control was not disabled.

closes #286
