### PR TITLE
Update XMOS version sensor every 10s

### DIFF
--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -126,6 +126,12 @@ satellite1:
       - text_sensor.template.publish:
           id: xmos_firmware_version_text
           state: !lambda 'return id(satellite1_id).status_string();'
+  
+  on_xmos_version_poll:
+    then:
+      - text_sensor.template.publish:
+          id: xmos_firmware_version_text
+          state: !lambda 'return id(satellite1_id).status_string();'
       
 
 memory_flasher:

--- a/esphome/components/satellite1/automation.h
+++ b/esphome/components/satellite1/automation.h
@@ -39,6 +39,15 @@ class XMOSNoResponseStateTrigger : public Trigger<> {
   }
 };
 
+class XMOSVersionPollTrigger : public Trigger<> {
+  public:
+   explicit XMOSVersionPollTrigger(Satellite1 *sat1) {
+     sat1->add_on_version_poll_callback([this, sat1]() {
+         this->trigger();
+     });
+   }
+ };
+
 
 
 }

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -50,7 +50,7 @@ void Satellite1::loop(){
       break;
     case SAT_XMOS_CONNECTED_STATE:
       if( (millis() - this->last_version_poll_timestamp_) > 10000 ){
-        this->dfu_get_fw_version_();
+        bool read_success = this->dfu_get_fw_version_();
         this->last_version_poll_timestamp_ = millis();
         version_poll_callback_.call();
       }
@@ -78,12 +78,20 @@ std::string Satellite1::status_string(){
       return "XMOS not responding";
     
     case SAT_XMOS_CONNECTED_STATE:
-      return  (    "v" + std::to_string(this->xmos_fw_version[0])
-                +  "." + std::to_string(this->xmos_fw_version[1]) 
-                +  "." + std::to_string(this->xmos_fw_version[2])
-                +  ( this->xmos_fw_version[3] ? "-" + prerelease_str(this->xmos_fw_version[3]) : "")
-                +  ( this->xmos_fw_version[4] ? "." + std::to_string(this->xmos_fw_version[4]) : "")
-              );
+      {
+        bool allZero = std::all_of(std::begin(this->xmos_fw_version), std::end(this->xmos_fw_version), [](int x) {
+          return x == 0;
+        });
+        if ( allZero ) return "XMOS not responding";
+        
+        return  (    "v" + std::to_string(this->xmos_fw_version[0])
+                    +  "." + std::to_string(this->xmos_fw_version[1]) 
+                    +  "." + std::to_string(this->xmos_fw_version[2])
+                    +  ( this->xmos_fw_version[3] ? "-" + prerelease_str(this->xmos_fw_version[3]) : "")
+                    +  ( this->xmos_fw_version[4] ? "." + std::to_string(this->xmos_fw_version[4]) : "")
+        );
+      }
+      
     case SAT_FLASH_CONNECTED_STATE:
       return "Flashing Mode";
     default: return "";

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -49,6 +49,12 @@ void Satellite1::loop(){
       } 
       break;
     case SAT_XMOS_CONNECTED_STATE:
+      if( (millis() - this->last_version_poll_timestamp_) > 10000 ){
+        this->dfu_get_fw_version_();
+        this->last_version_poll_timestamp_ = millis();
+        version_poll_callback_.call();
+      }
+      break;
     case SAT_FLASH_CONNECTED_STATE:
       break;
   }
@@ -167,6 +173,7 @@ bool Satellite1::dfu_get_fw_version_(){
   uint8_t version_resp[5];
   if( !this->transfer(DC_RESOURCE::DFU_CONTROLLER, DC_DFU_CMD::GET_VERSION, version_resp, 5 ) ){
     ESP_LOGW(TAG, "Requesting XMOS version failed");
+    memset( this->xmos_fw_version, 0, 5);
     return false;    
   }
   

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -160,6 +160,9 @@ class Satellite1 : public Component,
   void add_on_state_callback(std::function<void()> &&callback) {
     this->state_callback_.add(std::move(callback));
   }
+  void add_on_version_poll_callback(std::function<void()> &&callback) {
+   this->version_poll_callback_.add(std::move(callback));
+ }
 
   void xmos_hardware_reset(); 
 
@@ -168,8 +171,10 @@ protected:
   bool dfu_get_fw_version_();
   bool check_for_xmos_();
   CallbackManager<void()> state_callback_{};
+  CallbackManager<void()> version_poll_callback_{};
 
   uint32_t last_attempt_timestamp_{0};
+  uint32_t last_version_poll_timestamp_{0};
 
   uint8_t dc_status_register_[DC_STATUS_REGISTER::REGISTER_LEN];
   bool spi_flash_direct_access_enabled_{false};

--- a/esphome/components/satellite1/satellite1.py
+++ b/esphome/components/satellite1/satellite1.py
@@ -27,13 +27,16 @@ XMOSNoResponseStateTrigger = namespace.class_(
     "XMOSNoResponseStateTrigger", automation.Trigger
 )
 
-
+XMOSVersionPollTrigger = namespace.class_(
+    "XMOSVersionPollTrigger", automation.Trigger
+)
 
 CONF_SATELLITE1 = "satellite1"
 CONF_XMOS_RST_PIN = "xmos_rst_pin"
 CONF_ON_XMOS_NO_RESPONSE = "on_xmos_no_response"
 CONF_ON_XMOS_CONNECTED = "on_xmos_connected"
 CONF_ON_FLASH_CONNECTED = "on_flash_connected"
+CONF_ON_XMOS_VERION_POLL = "on_xmos_version_poll"
 
 SAT1_CONFIG_SCHEMA = (
      cv.Schema({
@@ -48,6 +51,9 @@ SAT1_CONFIG_SCHEMA = (
         }),
         cv.Optional(CONF_ON_XMOS_NO_RESPONSE): automation.validate_automation({
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(XMOSNoResponseStateTrigger),
+        }),
+        cv.Optional(CONF_ON_XMOS_VERION_POLL): automation.validate_automation({
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(XMOSVersionPollTrigger),
         }),
 
     }).extend(spi_device_schema(True, "1Hz"))
@@ -71,6 +77,10 @@ async def register_satellite1(config) :
          await automation.build_automation(trigger, [], conf)
     
     for conf in config.get(CONF_ON_XMOS_NO_RESPONSE, []):
+         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var )
+         await automation.build_automation(trigger, [], conf)
+    
+    for conf in config.get(CONF_ON_XMOS_VERION_POLL, []):
          trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var )
          await automation.build_automation(trigger, [], conf)
     

--- a/esphome/components/satellite1/satellite1.py
+++ b/esphome/components/satellite1/satellite1.py
@@ -36,7 +36,7 @@ CONF_XMOS_RST_PIN = "xmos_rst_pin"
 CONF_ON_XMOS_NO_RESPONSE = "on_xmos_no_response"
 CONF_ON_XMOS_CONNECTED = "on_xmos_connected"
 CONF_ON_FLASH_CONNECTED = "on_flash_connected"
-CONF_ON_XMOS_VERION_POLL = "on_xmos_version_poll"
+CONF_ON_XMOS_VERSION_POLL = "on_xmos_version_poll"
 
 SAT1_CONFIG_SCHEMA = (
      cv.Schema({
@@ -52,7 +52,7 @@ SAT1_CONFIG_SCHEMA = (
         cv.Optional(CONF_ON_XMOS_NO_RESPONSE): automation.validate_automation({
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(XMOSNoResponseStateTrigger),
         }),
-        cv.Optional(CONF_ON_XMOS_VERION_POLL): automation.validate_automation({
+        cv.Optional(CONF_ON_XMOS_VERSION_POLL): automation.validate_automation({
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(XMOSVersionPollTrigger),
         }),
 
@@ -80,7 +80,7 @@ async def register_satellite1(config) :
          trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var )
          await automation.build_automation(trigger, [], conf)
     
-    for conf in config.get(CONF_ON_XMOS_VERION_POLL, []):
+    for conf in config.get(CONF_ON_XMOS_VERSION_POLL, []):
          trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var )
          await automation.build_automation(trigger, [], conf)
     


### PR DESCRIPTION
Previously, the XMOS firmware version was read only once at boot time.
This change introduces periodic polling — the firmware version is now read every 10 seconds.

This serves as a lightweight heartbeat mechanism to monitor the XMOS's presence and responsiveness at runtime.

closes #264