### PR TITLE
Add Home Assistant Media Player (External Speakers) to Sat1 Output

### DIFF
--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -96,7 +96,7 @@ micro_wake_word:
 voice_assistant:
   id: va
   microphone: asr_mic
-  media_player: external_media_player
+  media_player: media_player.vlc_telnet
   micro_wake_word: mww
   use_wake_word: false
   noise_suppression_level: 0
@@ -141,15 +141,6 @@ voice_assistant:
     - script.execute: control_leds
     # Start a script that would potentially enable the stop word if the response is longer than a second
     - script.execute: activate_stop_word_if_tts_step_is_long
- #Add this section to output TTS to external speaker 
-  on_tts_end: 
-    - homeassistant.service
-        service: media_player.play_media
-        data:
-          entity_id: media_player.vlc_telnet_2
-          media_content_id: !lambda 'return x;'
-          media_content_type: music
-          announce: "true"
   # When the voice assistant ends ...
   on_end:
     - wait_until:

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -96,7 +96,7 @@ micro_wake_word:
 voice_assistant:
   id: va
   microphone: asr_mic
-  media_player: media_player.vlc_telnet
+  media_player: external_media_player
   micro_wake_word: mww
   use_wake_word: false
   noise_suppression_level: 0
@@ -141,6 +141,14 @@ voice_assistant:
     - script.execute: control_leds
     # Start a script that would potentially enable the stop word if the response is longer than a second
     - script.execute: activate_stop_word_if_tts_step_is_long
+  on_tts_end: 
+    - homeassistant.service
+        service: media_player.play_media
+        data:
+          entity_id: media_player.vlc_telnet
+          media_content_id: !lambda 'return x;'
+          media_content_type: music
+          announce: "true"
   # When the voice assistant ends ...
   on_end:
     - wait_until:

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -141,12 +141,12 @@ voice_assistant:
     - script.execute: control_leds
     # Start a script that would potentially enable the stop word if the response is longer than a second
     - script.execute: activate_stop_word_if_tts_step_is_long
-    - homeassistant.service:
+    - homeassistant.action:
         service: tts.speak
         data:
-          media_player_entity_id: media_player.vlc_telnet_2   #replace this with your media player entity id
+          entity_id: tts.piper
+          media_player_entity_id: media_player.vlc_telnet
           message: !lambda 'return x;'
-          entity_id: tts.piper 
   # When the voice assistant ends ...
   on_end:
     - wait_until:

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -141,15 +141,13 @@ voice_assistant:
     - script.execute: control_leds
     # Start a script that would potentially enable the stop word if the response is longer than a second
     - script.execute: activate_stop_word_if_tts_step_is_long
-  # When the voice assistant ends ...
- on_tts_end: 
-    - homeassistant.service
-        service: media_player.play_media
+    - homeassistant.service:
+        service: tts.speak
         data:
-          entity_id: media_player.vlc_telnet
-          media_content_id: !lambda 'return x;'
-          media_content_type: music
-          announce: "true"
+          media_player_entity_id: media_player.vlc_telnet_2   #replace this with your media player entity id
+          message: !lambda 'return x;'
+          entity_id: tts.piper 
+  # When the voice assistant ends ...
   on_end:
     - wait_until:
         not:

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -146,7 +146,6 @@ voice_assistant:
     - homeassistant.service
         service: media_player.play_media
         data:
-          #input external speaker media player id that you want to use
           entity_id: media_player.vlc_telnet_2
           media_content_id: !lambda 'return x;'
           media_content_type: music

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -143,8 +143,8 @@ voice_assistant:
     - script.execute: activate_stop_word_if_tts_step_is_long
  #Add this section to output TTS to external speaker 
   on_tts_end: 
-    - homeassistant.services
-        services: media_player.play_media
+    - homeassistant.service
+        service: media_player.play_media
         data:
           #input external speaker media player id that you want to use
           entity_id: media_player.vlc_telnet_2

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -142,6 +142,14 @@ voice_assistant:
     # Start a script that would potentially enable the stop word if the response is longer than a second
     - script.execute: activate_stop_word_if_tts_step_is_long
   # When the voice assistant ends ...
+ on_tts_end: 
+    - homeassistant.service
+        service: media_player.play_media
+        data:
+          entity_id: media_player.vlc_telnet
+          media_content_id: !lambda 'return x;'
+          media_content_type: music
+          announce: "true"
   on_end:
     - wait_until:
         not:

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -141,6 +141,16 @@ voice_assistant:
     - script.execute: control_leds
     # Start a script that would potentially enable the stop word if the response is longer than a second
     - script.execute: activate_stop_word_if_tts_step_is_long
+ #Add this section to output TTS to external speaker 
+  on_tts_end: 
+    - homeassistant.services
+        services: media_player.play_media
+        data:
+          #input external speaker media player id that you want to use
+          entity_id: media_player.vlc_telnet_2
+          media_content_id: !lambda 'return x;'
+          media_content_type: music
+          announce: "true"
   # When the voice assistant ends ...
   on_end:
     - wait_until:

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -141,14 +141,6 @@ voice_assistant:
     - script.execute: control_leds
     # Start a script that would potentially enable the stop word if the response is longer than a second
     - script.execute: activate_stop_word_if_tts_step_is_long
-  on_tts_end: 
-    - homeassistant.service
-        service: media_player.play_media
-        data:
-          entity_id: media_player.vlc_telnet
-          media_content_id: !lambda 'return x;'
-          media_content_type: music
-          announce: "true"
   # When the voice assistant ends ...
   on_end:
     - wait_until:


### PR DESCRIPTION
The code added to the voice_assistant.yaml file worked to send the output response of the Sat1 to my whole home audio speakers.  However, the media player entity id that you guys decide to use, you may want to do something different like other_speakers or something like that, generic for people to rename their media play entity ID in HA to or maybe there is a better way to use a variable of same kind (I am not much of a coder as you can see from my github account haha).  

The other thing is I wasn't able to get it to output the Sat1 initial recognition sound after the wake word unfortunately, it only outputs the response.  I also haven't tested if renaming the media player entity ID in home assistant will work but I would assume so but you may want to hold off until I test that.