### PR TITLE
Release beta update: v0.1.2-beta.1

### DIFF
--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -107,6 +107,7 @@ speaker:
     dac_type: external
     channel: stereo
     timeout: never
+    audio_dac: dac_proxy
     #buffer_duration: 100ms
 
 # Virtual speakers to combine the announcement and media streams together into one output

--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -80,7 +80,7 @@ binary_sensor:
 fusb302b:
   id: pd_fusb302b
   irq_pin: GPIO1
-  request_voltage: 9
+  request_voltage: 20
   on_power_ready:
     then:
       - logger.log: 


### PR DESCRIPTION
- Fix: Add missing DAC settings in i2s_speaker (previously, software volume control was unintentionally used).
- Enhancement: Set default USB-C port request to 20V.