### PR TITLE
Fusb302b fixes for non-pd power supplies

### DIFF
--- a/esphome/components/fusb302b/automation.h
+++ b/esphome/components/fusb302b/automation.h
@@ -35,7 +35,9 @@ class PowerReadyTrigger : public Trigger<>{
 public:
   explicit PowerReadyTrigger(PowerDelivery *pd) {
     pd->add_on_state_callback([this, pd]() {
-      if (pd->state == PD_STATE_EXPLICIT_SPR_CONTRACT || pd->state == PD_STATE_EXPLICIT_EPR_CONTRACT )
+      if (    pd->state == PD_STATE_EXPLICIT_SPR_CONTRACT 
+           || pd->state == PD_STATE_EXPLICIT_EPR_CONTRACT 
+           || pd->state == PD_STATE_PD_TIMEOUT)
         this->trigger();
     });
   }

--- a/esphome/components/fusb302b/fusb302b.cpp
+++ b/esphome/components/fusb302b/fusb302b.cpp
@@ -345,6 +345,8 @@ void FUSB302B::check_status_(){
             ESP_LOGD(TAG, "PD-Negotiaton failed. Staying with default 5V supply.");
             this->wait_src_cap_ = false;
             this->active_ams_ = false;
+            this->set_state_(PD_STATE_PD_TIMEOUT);
+            this->publish_();
           }
         } 
       }

--- a/esphome/components/fusb302b/pd.cpp
+++ b/esphome/components/fusb302b/pd.cpp
@@ -156,7 +156,7 @@ std::string PowerDelivery::get_contract_string(pd_contract_t contract) const{
 void PowerDelivery::set_contract_(pd_contract_t contract){
   this->accepted_contract_ = contract;
   this->contract = this->get_contract_string(contract);
-  this->contract_voltage = contract.max_v;
+  this->contract_voltage = contract.max_v * 5 / 100;
   this->contract_timer_ = millis();
 }
 

--- a/esphome/components/fusb302b/pd.cpp
+++ b/esphome/components/fusb302b/pd.cpp
@@ -57,7 +57,7 @@ static PDMsg build_source_cap_response( pd_contract_t pwr_info, uint8_t pos )
   constexpr uint32_t templ = ( 
         //((uint32_t)   1 << 22)  |   /* B22 EPR Mode Capable */
         //((uint32_t)   1 << 23)  |   /* B23 Unchunked Extended Messages Supported */                                       
-          ((uint32_t)   1 << 24)  |   /* B24  No USB Suspend */
+          ((uint32_t)   1 << 24)  |   /* B24 No USB Suspend */
           ((uint32_t)   1 << 25)      /* B25 USB Communication Capable */ 
         //((uint32_t)   1 << 26)      /* B26 Capability Mismatch */
         //((uint32_t)   1 << 27)      /* B27 GiveBack flag = 0 (depricated)*/              

--- a/esphome/components/fusb302b/pd.h
+++ b/esphome/components/fusb302b/pd.h
@@ -66,7 +66,8 @@ enum pd_power_data_obj_type {   /* Power data object type */
 };
 
 enum PowerDeliveryState : uint8_t {
-  PD_STATE_DISCONNECTED,  
+  PD_STATE_DISCONNECTED,
+  PD_STATE_PD_TIMEOUT,  
   PD_STATE_DEFAULT_CONTRACT,
   PD_STATE_TRANSITION,
   PD_STATE_EXPLICIT_SPR_CONTRACT,
@@ -145,7 +146,7 @@ typedef uint32_t pd_pdo_t;
 class PowerDelivery {
 public:
   PowerDeliveryState state{PD_STATE_DISCONNECTED};
-  int contract_voltage{0};
+  int contract_voltage{5};
   int measured_voltage{0};
   std::string contract{"0.3A @ 5V"};
   PowerDeliveryState prev_state_{PD_STATE_DISCONNECTED};

--- a/esphome/components/fusb302b/pd.h
+++ b/esphome/components/fusb302b/pd.h
@@ -147,8 +147,7 @@ class PowerDelivery {
 public:
   PowerDeliveryState state{PD_STATE_DISCONNECTED};
   int contract_voltage{5};
-  int measured_voltage{0};
-  std::string contract{"0.3A @ 5V"};
+  std::string contract{"0.5A @ 5V"};
   PowerDeliveryState prev_state_{PD_STATE_DISCONNECTED};
   
   bool request_voltage(int voltage);


### PR DESCRIPTION
- the internally stored contract value of max voltage was incorrect (used in yaml lambda conditions)
- powerReady trigger was only called when a valid PD contract was received. Now, it also triggers when no PD supply was found within 5 seconds and max allowed values are set to 0.5 A @ 5V in that case
- text sensor showed 0.3A @ 5V instead of allowed 0.5A @ 5V