### PR TITLE
Use local audio component to apply decoder fix

### DIFF
--- a/config/satellite1.factory.yaml
+++ b/config/satellite1.factory.yaml
@@ -106,7 +106,7 @@ external_components:
   - source:
       type: local
       path: ../esphome/components
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
+    components: [ audio, i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
 
 
 logger:

--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -1,0 +1,168 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_BITS_PER_SAMPLE, CONF_NUM_CHANNELS, CONF_SAMPLE_RATE
+import esphome.final_validate as fv
+
+CODEOWNERS = ["@kahrendt"]
+audio_ns = cg.esphome_ns.namespace("audio")
+
+AudioFile = audio_ns.struct("AudioFile")
+AudioFileType = audio_ns.enum("AudioFileType", is_class=True)
+AUDIO_FILE_TYPE_ENUM = {
+    "NONE": AudioFileType.NONE,
+    "WAV": AudioFileType.WAV,
+    "MP3": AudioFileType.MP3,
+    "FLAC": AudioFileType.FLAC,
+}
+
+
+CONF_MIN_BITS_PER_SAMPLE = "min_bits_per_sample"
+CONF_MAX_BITS_PER_SAMPLE = "max_bits_per_sample"
+CONF_MIN_CHANNELS = "min_channels"
+CONF_MAX_CHANNELS = "max_channels"
+CONF_MIN_SAMPLE_RATE = "min_sample_rate"
+CONF_MAX_SAMPLE_RATE = "max_sample_rate"
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema({}),
+)
+
+AUDIO_COMPONENT_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_BITS_PER_SAMPLE): cv.int_range(8, 32),
+        cv.Optional(CONF_NUM_CHANNELS): cv.int_range(1, 2),
+        cv.Optional(CONF_SAMPLE_RATE): cv.int_range(8000, 48000),
+    }
+)
+
+
+def set_stream_limits(
+    min_bits_per_sample: int = cv.UNDEFINED,
+    max_bits_per_sample: int = cv.UNDEFINED,
+    min_channels: int = cv.UNDEFINED,
+    max_channels: int = cv.UNDEFINED,
+    min_sample_rate: int = cv.UNDEFINED,
+    max_sample_rate: int = cv.UNDEFINED,
+):
+    """Sets the limits for the audio stream that audio component can handle
+
+    When the component sinks audio (e.g., a speaker), these indicate the limits to the audio it can receive.
+    When the component sources audio (e.g., a microphone), these indicate the limits to the audio it can send.
+    """
+
+    def set_limits_in_config(config):
+        if min_bits_per_sample is not cv.UNDEFINED:
+            config[CONF_MIN_BITS_PER_SAMPLE] = min_bits_per_sample
+        if max_bits_per_sample is not cv.UNDEFINED:
+            config[CONF_MAX_BITS_PER_SAMPLE] = max_bits_per_sample
+        if min_channels is not cv.UNDEFINED:
+            config[CONF_MIN_CHANNELS] = min_channels
+        if max_channels is not cv.UNDEFINED:
+            config[CONF_MAX_CHANNELS] = max_channels
+        if min_sample_rate is not cv.UNDEFINED:
+            config[CONF_MIN_SAMPLE_RATE] = min_sample_rate
+        if max_sample_rate is not cv.UNDEFINED:
+            config[CONF_MAX_SAMPLE_RATE] = max_sample_rate
+
+    return set_limits_in_config
+
+
+def final_validate_audio_schema(
+    name: str,
+    *,
+    audio_device: str,
+    bits_per_sample: int = cv.UNDEFINED,
+    channels: int = cv.UNDEFINED,
+    sample_rate: int = cv.UNDEFINED,
+    enabled_channels: list[int] = cv.UNDEFINED,
+    audio_device_issue: bool = False,
+):
+    """Validates audio compatibility when passed between different components.
+
+    The component derived from ``AUDIO_COMPONENT_SCHEMA`` should call ``set_stream_limits`` in a validator to specify its compatible settings
+
+      - If audio_device_issue is True, then the error message indicates the user should adjust the AUDIO_COMPONENT_SCHEMA derived component's configuration to match the values passed to this function
+      - If audio_device_issue is False, then the error message indicates the user should adjust the configuration of the component calling this function, as it falls out of the valid stream limits
+
+    Args:
+        name (str): Friendly name of the component calling this function with an audio component to validate
+        audio_device (str): The configuration parameter name that contains the ID of an AUDIO_COMPONENT_SCHEMA derived component to validate against
+        bits_per_sample (int, optional): The desired bits per sample
+        channels (int, optional): The desired number of channels
+        sample_rate (int, optional): The desired sample rate
+        enabled_channels (list[int], optional): The desired enabled channels
+        audio_device_issue (bool, optional): Format the error message to indicate the problem is in the configuration for the ``audio_device`` component. Defaults to False.
+    """
+
+    def validate_audio_compatiblity(audio_config):
+        audio_schema = {}
+
+        if bits_per_sample is not cv.UNDEFINED:
+            try:
+                cv.int_range(
+                    min=audio_config.get(CONF_MIN_BITS_PER_SAMPLE),
+                    max=audio_config.get(CONF_MAX_BITS_PER_SAMPLE),
+                )(bits_per_sample)
+            except cv.Invalid as exc:
+                if audio_device_issue:
+                    error_string = f"Invalid configuration for the specified {audio_device}. The {name} component requires {bits_per_sample} bits per sample."
+                else:
+                    error_string = f"Invalid configuration for the {name} component. The {CONF_BITS_PER_SAMPLE} {str(exc)}"
+                raise cv.Invalid(error_string) from exc
+
+        if channels is not cv.UNDEFINED:
+            try:
+                cv.int_range(
+                    min=audio_config.get(CONF_MIN_CHANNELS),
+                    max=audio_config.get(CONF_MAX_CHANNELS),
+                )(channels)
+            except cv.Invalid as exc:
+                if audio_device_issue:
+                    error_string = f"Invalid configuration for the specified {audio_device}. The {name} component requires {channels} channels."
+                else:
+                    error_string = f"Invalid configuration for the {name} component. The {CONF_NUM_CHANNELS} {str(exc)}"
+                raise cv.Invalid(error_string) from exc
+
+        if sample_rate is not cv.UNDEFINED:
+            try:
+                cv.int_range(
+                    min=audio_config.get(CONF_MIN_SAMPLE_RATE),
+                    max=audio_config.get(CONF_MAX_SAMPLE_RATE),
+                )(sample_rate)
+            except cv.Invalid as exc:
+                if audio_device_issue:
+                    error_string = f"Invalid configuration for the specified {audio_device}. The {name} component requires a {sample_rate} sample rate."
+                else:
+                    error_string = f"Invalid configuration for the {name} component. The {CONF_SAMPLE_RATE} {str(exc)}"
+                raise cv.Invalid(error_string) from exc
+
+        if enabled_channels is not cv.UNDEFINED:
+            for channel in enabled_channels:
+                try:
+                    # Channels are 0-indexed
+                    cv.int_range(
+                        min=0,
+                        max=audio_config.get(CONF_MAX_CHANNELS) - 1,
+                    )(channel)
+                except cv.Invalid as exc:
+                    if audio_device_issue:
+                        error_string = f"Invalid configuration for the specified {audio_device}. The {name} component requires channel {channel}."
+                    else:
+                        error_string = f"Invalid configuration for the {name} component. Enabled channel {channel} {str(exc)}"
+                    raise cv.Invalid(error_string) from exc
+
+        return cv.Schema(audio_schema, extra=cv.ALLOW_EXTRA)(audio_config)
+
+    return cv.Schema(
+        {
+            cv.Required(audio_device): fv.id_declaration_match_schema(
+                validate_audio_compatiblity
+            )
+        },
+        extra=cv.ALLOW_EXTRA,
+    )
+
+
+async def to_code(config):
+    cg.add_library("esphome/esp-audio-libs", "1.1.4")

--- a/esphome/components/audio/audio.cpp
+++ b/esphome/components/audio/audio.cpp
@@ -1,0 +1,67 @@
+#include "audio.h"
+
+namespace esphome {
+namespace audio {
+
+// Euclidean's algorithm for finding the greatest common divisor
+static uint32_t gcd(uint32_t a, uint32_t b) {
+  while (b != 0) {
+    uint32_t t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+AudioStreamInfo::AudioStreamInfo(uint8_t bits_per_sample, uint8_t channels, uint32_t sample_rate)
+    : bits_per_sample_(bits_per_sample), channels_(channels), sample_rate_(sample_rate) {
+  this->ms_sample_rate_gcd_ = gcd(1000, this->sample_rate_);
+  this->bytes_per_sample_ = (this->bits_per_sample_ + 7) / 8;
+}
+
+uint32_t AudioStreamInfo::frames_to_microseconds(uint32_t frames) const {
+  return (frames * 1000000 + (this->sample_rate_ >> 1)) / this->sample_rate_;
+}
+
+uint32_t AudioStreamInfo::frames_to_milliseconds_with_remainder(uint32_t *total_frames) const {
+  uint32_t unprocessable_frames = *total_frames % (this->sample_rate_ / this->ms_sample_rate_gcd_);
+  uint32_t frames_for_ms_calculation = *total_frames - unprocessable_frames;
+
+  uint32_t playback_ms = (frames_for_ms_calculation * 1000) / this->sample_rate_;
+  *total_frames = unprocessable_frames;
+  return playback_ms;
+}
+
+bool AudioStreamInfo::operator==(const AudioStreamInfo &rhs) const {
+  return (this->bits_per_sample_ == rhs.get_bits_per_sample()) && (this->channels_ == rhs.get_channels()) &&
+         (this->sample_rate_ == rhs.get_sample_rate());
+}
+
+const char *audio_file_type_to_string(AudioFileType file_type) {
+  switch (file_type) {
+#ifdef USE_AUDIO_FLAC_SUPPORT
+    case AudioFileType::FLAC:
+      return "FLAC";
+#endif
+#ifdef USE_AUDIO_MP3_SUPPORT
+    case AudioFileType::MP3:
+      return "MP3";
+#endif
+    case AudioFileType::WAV:
+      return "WAV";
+    default:
+      return "unknown";
+  }
+}
+
+void scale_audio_samples(const int16_t *audio_samples, int16_t *output_buffer, int16_t scale_factor,
+                         size_t samples_to_scale) {
+  // Note the assembly dsps_mulc function has audio glitches if the input and output buffers are the same.
+  for (int i = 0; i < samples_to_scale; i++) {
+    int32_t acc = (int32_t) audio_samples[i] * (int32_t) scale_factor;
+    output_buffer[i] = (int16_t) (acc >> 15);
+  }
+}
+
+}  // namespace audio
+}  // namespace esphome

--- a/esphome/components/audio/audio.h
+++ b/esphome/components/audio/audio.h
@@ -1,0 +1,187 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace esphome {
+namespace audio {
+
+class AudioStreamInfo {
+  /* Class to respresent important parameters of the audio stream that also provides helper function to convert between
+   * various audio related units.
+   *
+   *  - An audio sample represents a unit of audio for one channel.
+   *  - A frame represents a unit of audio with a sample for every channel.
+   *
+   * In gneneral, converting between bytes, samples, and frames shouldn't result in rounding errors so long as frames
+   * are used as the main unit when transferring audio data. Durations may result in rounding for certain sample rates;
+   * e.g., 44.1 KHz. The ``frames_to_milliseconds_with_remainder`` function should be used for accuracy, as it takes
+   * into account the remainder rather than just ignoring any rounding.
+   */
+ public:
+  AudioStreamInfo()
+      : AudioStreamInfo(16, 1, 16000){};  // Default values represent ESPHome's audio components historical values
+  AudioStreamInfo(uint8_t bits_per_sample, uint8_t channels, uint32_t sample_rate);
+
+  uint8_t get_bits_per_sample() const { return this->bits_per_sample_; }
+  uint8_t get_channels() const { return this->channels_; }
+  uint32_t get_sample_rate() const { return this->sample_rate_; }
+
+  /// @brief Convert bytes to duration in milliseconds.
+  /// @param bytes Number of bytes to convert
+  /// @return Duration in milliseconds that will store `bytes` bytes of audio. May round down for certain sample rates
+  ///         or values of `bytes`.
+  uint32_t bytes_to_ms(size_t bytes) const {
+    return bytes * 1000 / (this->sample_rate_ * this->bytes_per_sample_ * this->channels_);
+  }
+
+  /// @brief Convert bytes to frames.
+  /// @param bytes Number of bytes to convert
+  /// @return Audio frames that will store `bytes` bytes.
+  uint32_t bytes_to_frames(size_t bytes) const { return (bytes / (this->bytes_per_sample_ * this->channels_)); }
+
+  /// @brief Convert bytes to samples.
+  /// @param bytes Number of bytes to convert
+  /// @return Audio samples that will store `bytes` bytes.
+  uint32_t bytes_to_samples(size_t bytes) const { return (bytes / this->bytes_per_sample_); }
+
+  /// @brief Converts frames to bytes.
+  /// @param frames Number of frames to convert.
+  /// @return Number of bytes that will store `frames` frames of audio.
+  size_t frames_to_bytes(uint32_t frames) const { return frames * this->bytes_per_sample_ * this->channels_; }
+
+  /// @brief Converts samples to bytes.
+  /// @param samples Number of samples to convert.
+  /// @return Number of bytes that will store `samples` samples of audio.
+  size_t samples_to_bytes(uint32_t samples) const { return samples * this->bytes_per_sample_; }
+
+  /// @brief Converts duration to frames.
+  /// @param ms Duration in milliseconds
+  /// @return Audio frames that will store `ms` milliseconds of audio.  May round down for certain sample rates.
+  uint32_t ms_to_frames(uint32_t ms) const { return (ms * this->sample_rate_) / 1000; }
+
+  /// @brief Converts duration to samples.
+  /// @param ms Duration in milliseconds
+  /// @return Audio samples that will store `ms` milliseconds of audio.  May round down for certain sample rates.
+  uint32_t ms_to_samples(uint32_t ms) const { return (ms * this->channels_ * this->sample_rate_) / 1000; }
+
+  /// @brief Converts duration to bytes. May round down for certain sample rates.
+  /// @param ms Duration in milliseconds
+  /// @return Bytes that will store `ms` milliseconds of audio.  May round down for certain sample rates.
+  size_t ms_to_bytes(uint32_t ms) const {
+    return (ms * this->bytes_per_sample_ * this->channels_ * this->sample_rate_) / 1000;
+  }
+
+  /// @brief Computes the duration, in microseconds, the given amount of frames represents.
+  /// @param frames Number of audio frames
+  /// @return Duration in microseconds `frames` respresents. May be slightly inaccurate due to integer divison rounding
+  ///         for certain sample rates.
+  uint32_t frames_to_microseconds(uint32_t frames) const;
+
+  /// @brief Computes the duration, in milliseconds, the given amount of frames represents. Avoids
+  /// accumulating rounding errors by updating `frames` with the remainder after converting.
+  /// @param frames Pointer to uint32_t with the number of audio frames. Replaced with the remainder.
+  /// @return Duration in milliseconds `frames` represents. Always less than or equal to the actual value due to
+  ///         rounding.
+  uint32_t frames_to_milliseconds_with_remainder(uint32_t *frames) const;
+
+  // Class comparison operators
+  bool operator==(const AudioStreamInfo &rhs) const;
+  bool operator!=(const AudioStreamInfo &rhs) const { return !operator==(rhs); }
+
+ protected:
+  uint8_t bits_per_sample_;
+  uint8_t channels_;
+  uint32_t sample_rate_;
+
+  // The greatest common divisor between 1000 ms = 1 second and the sample rate. Used to avoid accumulating error when
+  // converting from frames to duration. Computed at construction.
+  uint32_t ms_sample_rate_gcd_;
+
+  // Conversion factor derived from the number of bits per sample. Assumes audio data is aligned to the byte. Computed
+  // at construction.
+  size_t bytes_per_sample_;
+};
+
+enum class AudioFileType : uint8_t {
+  NONE = 0,
+#ifdef USE_AUDIO_FLAC_SUPPORT
+  FLAC,
+#endif
+#ifdef USE_AUDIO_MP3_SUPPORT
+  MP3,
+#endif
+  WAV,
+};
+
+struct AudioFile {
+  const uint8_t *data;
+  size_t length;
+  AudioFileType file_type;
+};
+
+/// @brief Helper function to convert file type to a const char string
+/// @param file_type
+/// @return const char pointer to the readable file type
+const char *audio_file_type_to_string(AudioFileType file_type);
+
+/// @brief Scales Q15 fixed point audio samples. Scales in place if audio_samples == output_buffer.
+/// @param audio_samples PCM int16 audio samples
+/// @param output_buffer Buffer to store the scaled samples
+/// @param scale_factor Q15 fixed point scaling factor
+/// @param samples_to_scale Number of samples to scale
+void scale_audio_samples(const int16_t *audio_samples, int16_t *output_buffer, int16_t scale_factor,
+                         size_t samples_to_scale);
+
+/// @brief Unpacks a quantized audio sample into a Q31 fixed-point number.
+/// @param data Pointer to uint8_t array containing the audio sample
+/// @param bytes_per_sample The number of bytes per sample
+/// @return Q31 sample
+inline int32_t unpack_audio_sample_to_q31(const uint8_t *data, size_t bytes_per_sample) {
+  int32_t sample = 0;
+  if (bytes_per_sample == 1) {
+    sample |= data[0] << 24;
+  } else if (bytes_per_sample == 2) {
+    sample |= data[0] << 16;
+    sample |= data[1] << 24;
+  } else if (bytes_per_sample == 3) {
+    sample |= data[0] << 8;
+    sample |= data[1] << 16;
+    sample |= data[2] << 24;
+  } else if (bytes_per_sample == 4) {
+    sample |= data[0];
+    sample |= data[1] << 8;
+    sample |= data[2] << 16;
+    sample |= data[3] << 24;
+  }
+
+  return sample;
+}
+
+/// @brief Packs a Q31 fixed-point number as an audio sample with the specified number of bytes per sample.
+/// Packs the most significant bits - no dithering is applied.
+/// @param sample Q31 fixed-point number to pack
+/// @param data Pointer to data array to store
+/// @param bytes_per_sample The audio data's bytes per sample
+inline void pack_q31_as_audio_sample(int32_t sample, uint8_t *data, size_t bytes_per_sample) {
+  if (bytes_per_sample == 1) {
+    data[0] = static_cast<uint8_t>(sample >> 24);
+  } else if (bytes_per_sample == 2) {
+    data[0] = static_cast<uint8_t>(sample >> 16);
+    data[1] = static_cast<uint8_t>(sample >> 24);
+  } else if (bytes_per_sample == 3) {
+    data[0] = static_cast<uint8_t>(sample >> 8);
+    data[1] = static_cast<uint8_t>(sample >> 16);
+    data[2] = static_cast<uint8_t>(sample >> 24);
+  } else if (bytes_per_sample == 4) {
+    data[0] = static_cast<uint8_t>(sample);
+    data[1] = static_cast<uint8_t>(sample >> 8);
+    data[2] = static_cast<uint8_t>(sample >> 16);
+    data[3] = static_cast<uint8_t>(sample >> 24);
+  }
+}
+
+}  // namespace audio
+}  // namespace esphome

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -1,0 +1,393 @@
+#include "audio_decoder.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace audio {
+
+static const uint32_t DECODING_TIMEOUT_MS = 50;    // The decode function will yield after this duration
+static const uint32_t READ_WRITE_TIMEOUT_MS = 20;  // Timeout for transferring audio data
+
+static const uint32_t MAX_POTENTIALLY_FAILED_COUNT = 10;
+
+AudioDecoder::AudioDecoder(size_t input_buffer_size, size_t output_buffer_size) {
+  this->input_transfer_buffer_ = AudioSourceTransferBuffer::create(input_buffer_size);
+  this->output_transfer_buffer_ = AudioSinkTransferBuffer::create(output_buffer_size);
+}
+
+AudioDecoder::~AudioDecoder() {
+#ifdef USE_AUDIO_MP3_SUPPORT
+  if (this->audio_file_type_ == AudioFileType::MP3) {
+    esp_audio_libs::helix_decoder::MP3FreeDecoder(this->mp3_decoder_);
+  }
+#endif
+}
+
+esp_err_t AudioDecoder::add_source(std::weak_ptr<RingBuffer> &input_ring_buffer) {
+  if (this->input_transfer_buffer_ != nullptr) {
+    this->input_transfer_buffer_->set_source(input_ring_buffer);
+    return ESP_OK;
+  }
+  return ESP_ERR_NO_MEM;
+}
+
+esp_err_t AudioDecoder::add_sink(std::weak_ptr<RingBuffer> &output_ring_buffer) {
+  if (this->output_transfer_buffer_ != nullptr) {
+    this->output_transfer_buffer_->set_sink(output_ring_buffer);
+    return ESP_OK;
+  }
+  return ESP_ERR_NO_MEM;
+}
+
+#ifdef USE_SPEAKER
+esp_err_t AudioDecoder::add_sink(speaker::Speaker *speaker) {
+  if (this->output_transfer_buffer_ != nullptr) {
+    this->output_transfer_buffer_->set_sink(speaker);
+    return ESP_OK;
+  }
+  return ESP_ERR_NO_MEM;
+}
+#endif
+
+esp_err_t AudioDecoder::start(AudioFileType audio_file_type) {
+  if ((this->input_transfer_buffer_ == nullptr) || (this->output_transfer_buffer_ == nullptr)) {
+    return ESP_ERR_NO_MEM;
+  }
+
+  this->audio_file_type_ = audio_file_type;
+
+  this->potentially_failed_count_ = 0;
+  this->end_of_file_ = false;
+
+  switch (this->audio_file_type_) {
+#ifdef USE_AUDIO_FLAC_SUPPORT
+    case AudioFileType::FLAC:
+      this->flac_decoder_ = make_unique<esp_audio_libs::flac::FLACDecoder>();
+      this->free_buffer_required_ =
+          this->output_transfer_buffer_->capacity();  // Adjusted and reallocated after reading the header
+      break;
+#endif
+#ifdef USE_AUDIO_MP3_SUPPORT
+    case AudioFileType::MP3:
+      this->mp3_decoder_ = esp_audio_libs::helix_decoder::MP3InitDecoder();
+
+      // MP3 always has 1152 samples per chunk
+      this->free_buffer_required_ = 1152 * sizeof(int16_t) * 2;  // samples * size per sample * channels
+
+      // Always reallocate the output transfer buffer to the smallest necessary size
+      this->output_transfer_buffer_->reallocate(this->free_buffer_required_);
+      break;
+#endif
+    case AudioFileType::WAV:
+      this->wav_decoder_ = make_unique<esp_audio_libs::wav_decoder::WAVDecoder>();
+      this->wav_decoder_->reset();
+
+      // Processing WAVs doesn't actually require a specific amount of buffer size, as it is already in PCM format.
+      // Thus, we don't reallocate to a minimum size.
+      this->free_buffer_required_ = 1024;
+      if (this->output_transfer_buffer_->capacity() < this->free_buffer_required_) {
+        this->output_transfer_buffer_->reallocate(this->free_buffer_required_);
+      }
+      break;
+    case AudioFileType::NONE:
+    default:
+      return ESP_ERR_NOT_SUPPORTED;
+      break;
+  }
+
+  return ESP_OK;
+}
+
+AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
+  if (stop_gracefully) {
+    if (this->output_transfer_buffer_->available() == 0) {
+      if (this->end_of_file_) {
+        // The file decoder indicates it reached the end of file
+        return AudioDecoderState::FINISHED;
+      }
+
+      if (!this->input_transfer_buffer_->has_buffered_data()) {
+        // If all the internal buffers are empty, the decoding is done
+        return AudioDecoderState::FINISHED;
+      }
+    }
+  }
+
+  if (this->potentially_failed_count_ > MAX_POTENTIALLY_FAILED_COUNT) {
+    if (stop_gracefully) {
+      // No more new data is going to come in, so decoding is done
+      return AudioDecoderState::FINISHED;
+    }
+    return AudioDecoderState::FAILED;
+  }
+
+  FileDecoderState state = FileDecoderState::MORE_TO_PROCESS;
+
+  uint32_t decoding_start = millis();
+
+  bool first_loop_iteration = true;
+
+  size_t bytes_processed = 0;
+  size_t bytes_available_before_processing = 0;
+
+  while (state == FileDecoderState::MORE_TO_PROCESS) {
+    // Transfer decoded out
+    if (!this->pause_output_) {
+      // Never shift the data in the output transfer buffer to avoid unnecessary, slow data moves
+      size_t bytes_written =
+          this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
+
+      if (this->audio_stream_info_.has_value()) {
+        this->accumulated_frames_written_ += this->audio_stream_info_.value().bytes_to_frames(bytes_written);
+        this->playback_ms_ +=
+            this->audio_stream_info_.value().frames_to_milliseconds_with_remainder(&this->accumulated_frames_written_);
+      }
+    } else {
+      // If paused, block to avoid wasting CPU resources
+      delay(READ_WRITE_TIMEOUT_MS);
+    }
+
+    // Verify there is enough space to store more decoded audio and that the function hasn't been running too long
+    if ((this->output_transfer_buffer_->free() < this->free_buffer_required_) ||
+        (millis() - decoding_start > DECODING_TIMEOUT_MS)) {
+      return AudioDecoderState::DECODING;
+    }
+
+    // Decode more audio
+
+    // Only shift data on the first loop iteration to avoid unnecessary, slow moves
+    size_t bytes_read = this->input_transfer_buffer_->transfer_data_from_source(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS),
+                                                                                first_loop_iteration);
+
+    if (!first_loop_iteration && (this->input_transfer_buffer_->available() < bytes_processed)) {
+      // Less data is available than what was processed in last iteration, so don't attempt to decode.
+      // This attempts to avoid the decoder from consistently trying to decode an incomplete frame. The transfer buffer
+      // will shift the remaining data to the start and copy more from the source the next time the decode function is
+      // called
+      break;
+    }
+
+    bytes_available_before_processing = this->input_transfer_buffer_->available();
+
+    if ((this->potentially_failed_count_ > 0) && (bytes_read == 0)) {
+      // Failed to decode in last attempt and there is no new data
+
+      if ((this->input_transfer_buffer_->free() == 0) && first_loop_iteration) {
+        // The input buffer is full. Since it previously failed on the exact same data, we can never recover
+        state = FileDecoderState::FAILED;
+      } else {
+        // Attempt to get more data next time
+        state = FileDecoderState::IDLE;
+      }
+    } else if (this->input_transfer_buffer_->available() == 0) {
+      // No data to decode, attempt to get more data next time
+      state = FileDecoderState::IDLE;
+    } else {
+      switch (this->audio_file_type_) {
+#ifdef USE_AUDIO_FLAC_SUPPORT
+        case AudioFileType::FLAC:
+          state = this->decode_flac_();
+          break;
+#endif
+#ifdef USE_AUDIO_MP3_SUPPORT
+        case AudioFileType::MP3:
+          state = this->decode_mp3_();
+          break;
+#endif
+        case AudioFileType::WAV:
+          state = this->decode_wav_();
+          break;
+        case AudioFileType::NONE:
+        default:
+          state = FileDecoderState::IDLE;
+          break;
+      }
+    }
+
+    first_loop_iteration = false;
+    bytes_processed = bytes_available_before_processing - this->input_transfer_buffer_->available();
+
+    if (state == FileDecoderState::POTENTIALLY_FAILED) {
+      ++this->potentially_failed_count_;
+    } else if (state == FileDecoderState::END_OF_FILE) {
+      this->end_of_file_ = true;
+    } else if (state == FileDecoderState::FAILED) {
+      return AudioDecoderState::FAILED;
+    } else if (state == FileDecoderState::MORE_TO_PROCESS) {
+      this->potentially_failed_count_ = 0;
+    }
+  }
+  return AudioDecoderState::DECODING;
+}
+
+#ifdef USE_AUDIO_FLAC_SUPPORT
+FileDecoderState AudioDecoder::decode_flac_() {
+  if (!this->audio_stream_info_.has_value()) {
+    // Header hasn't been read
+    auto result = this->flac_decoder_->read_header(this->input_transfer_buffer_->get_buffer_start(),
+                                                   this->input_transfer_buffer_->available());
+
+    if (result == esp_audio_libs::flac::FLAC_DECODER_HEADER_OUT_OF_DATA) {
+      return FileDecoderState::POTENTIALLY_FAILED;
+    }
+
+    if (result != esp_audio_libs::flac::FLAC_DECODER_SUCCESS) {
+      // Couldn't read FLAC header
+      return FileDecoderState::FAILED;
+    }
+
+    size_t bytes_consumed = this->flac_decoder_->get_bytes_index();
+    this->input_transfer_buffer_->decrease_buffer_length(bytes_consumed);
+
+    // Reallocate the output transfer buffer to the smallest necessary size
+    this->free_buffer_required_ = flac_decoder_->get_output_buffer_size_bytes();
+    if (!this->output_transfer_buffer_->reallocate(this->free_buffer_required_)) {
+      // Couldn't reallocate output buffer
+      return FileDecoderState::FAILED;
+    }
+
+    this->audio_stream_info_ =
+        audio::AudioStreamInfo(this->flac_decoder_->get_sample_depth(), this->flac_decoder_->get_num_channels(),
+                               this->flac_decoder_->get_sample_rate());
+
+    return FileDecoderState::MORE_TO_PROCESS;
+  }
+
+  uint32_t output_samples = 0;
+  auto result = this->flac_decoder_->decode_frame(
+      this->input_transfer_buffer_->get_buffer_start(), this->input_transfer_buffer_->available(),
+      reinterpret_cast<int16_t *>(this->output_transfer_buffer_->get_buffer_end()), &output_samples);
+
+  if (result == esp_audio_libs::flac::FLAC_DECODER_ERROR_OUT_OF_DATA) {
+    // Not an issue, just needs more data that we'll get next time.
+    return FileDecoderState::POTENTIALLY_FAILED;
+  }
+
+  size_t bytes_consumed = this->flac_decoder_->get_bytes_index();
+  this->input_transfer_buffer_->decrease_buffer_length(bytes_consumed);
+
+  if (result > esp_audio_libs::flac::FLAC_DECODER_ERROR_OUT_OF_DATA) {
+    // Corrupted frame, don't retry with current buffer content, wait for new sync
+    return FileDecoderState::POTENTIALLY_FAILED;
+  }
+
+  // We have successfully decoded some input data and have new output data
+  this->output_transfer_buffer_->increase_buffer_length(
+      this->audio_stream_info_.value().samples_to_bytes(output_samples));
+
+  if (result == esp_audio_libs::flac::FLAC_DECODER_NO_MORE_FRAMES) {
+    return FileDecoderState::END_OF_FILE;
+  }
+
+  return FileDecoderState::MORE_TO_PROCESS;
+}
+#endif
+
+#ifdef USE_AUDIO_MP3_SUPPORT
+FileDecoderState AudioDecoder::decode_mp3_() {
+  // Look for the next sync word
+  int buffer_length = (int) this->input_transfer_buffer_->available();
+  int32_t offset =
+      esp_audio_libs::helix_decoder::MP3FindSyncWord(this->input_transfer_buffer_->get_buffer_start(), buffer_length);
+
+  if (offset < 0) {
+    // New data may have the sync word
+    this->input_transfer_buffer_->decrease_buffer_length(buffer_length);
+    return FileDecoderState::POTENTIALLY_FAILED;
+  }
+
+  // Advance read pointer to match the offset for the syncword
+  this->input_transfer_buffer_->decrease_buffer_length(offset);
+  uint8_t *buffer_start = this->input_transfer_buffer_->get_buffer_start();
+
+  buffer_length = (int) this->input_transfer_buffer_->available();
+  int err = esp_audio_libs::helix_decoder::MP3Decode(this->mp3_decoder_, &buffer_start, &buffer_length,
+                                                     (int16_t *) this->output_transfer_buffer_->get_buffer_end(), 0);
+
+  size_t consumed = this->input_transfer_buffer_->available() - buffer_length;
+  this->input_transfer_buffer_->decrease_buffer_length(consumed);
+
+  if (err) {
+    switch (err) {
+      case esp_audio_libs::helix_decoder::ERR_MP3_OUT_OF_MEMORY:
+        // Intentional fallthrough
+      case esp_audio_libs::helix_decoder::ERR_MP3_NULL_POINTER:
+        return FileDecoderState::FAILED;
+        break;
+      default:
+        // Most errors are recoverable by moving on to the next frame, so mark as potentailly failed
+        return FileDecoderState::POTENTIALLY_FAILED;
+        break;
+    }
+  } else {
+    esp_audio_libs::helix_decoder::MP3FrameInfo mp3_frame_info;
+    esp_audio_libs::helix_decoder::MP3GetLastFrameInfo(this->mp3_decoder_, &mp3_frame_info);
+    if (mp3_frame_info.outputSamps > 0) {
+      int bytes_per_sample = (mp3_frame_info.bitsPerSample / 8);
+      this->output_transfer_buffer_->increase_buffer_length(mp3_frame_info.outputSamps * bytes_per_sample);
+
+      if (!this->audio_stream_info_.has_value()) {
+        this->audio_stream_info_ =
+            audio::AudioStreamInfo(mp3_frame_info.bitsPerSample, mp3_frame_info.nChans, mp3_frame_info.samprate);
+      }
+    }
+  }
+
+  return FileDecoderState::MORE_TO_PROCESS;
+}
+#endif
+
+FileDecoderState AudioDecoder::decode_wav_() {
+  if (!this->audio_stream_info_.has_value()) {
+    // Header hasn't been processed
+
+    esp_audio_libs::wav_decoder::WAVDecoderResult result = this->wav_decoder_->decode_header(
+        this->input_transfer_buffer_->get_buffer_start(), this->input_transfer_buffer_->available());
+
+    if (result == esp_audio_libs::wav_decoder::WAV_DECODER_SUCCESS_IN_DATA) {
+      this->input_transfer_buffer_->decrease_buffer_length(this->wav_decoder_->bytes_processed());
+
+      this->audio_stream_info_ = audio::AudioStreamInfo(
+          this->wav_decoder_->bits_per_sample(), this->wav_decoder_->num_channels(), this->wav_decoder_->sample_rate());
+
+      this->wav_bytes_left_ = this->wav_decoder_->chunk_bytes_left();
+      this->wav_has_known_end_ = (this->wav_bytes_left_ > 0);
+      return FileDecoderState::MORE_TO_PROCESS;
+    } else if (result == esp_audio_libs::wav_decoder::WAV_DECODER_WARNING_INCOMPLETE_DATA) {
+      // Available data didn't have the full header
+      return FileDecoderState::POTENTIALLY_FAILED;
+    } else {
+      return FileDecoderState::FAILED;
+    }
+  } else {
+    if (!this->wav_has_known_end_ || (this->wav_bytes_left_ > 0)) {
+      size_t bytes_to_copy = this->input_transfer_buffer_->available();
+
+      if (this->wav_has_known_end_) {
+        bytes_to_copy = std::min(bytes_to_copy, this->wav_bytes_left_);
+      }
+
+      bytes_to_copy = std::min(bytes_to_copy, this->output_transfer_buffer_->free());
+
+      if (bytes_to_copy > 0) {
+        std::memcpy(this->output_transfer_buffer_->get_buffer_end(), this->input_transfer_buffer_->get_buffer_start(),
+                    bytes_to_copy);
+        this->input_transfer_buffer_->decrease_buffer_length(bytes_to_copy);
+        this->output_transfer_buffer_->increase_buffer_length(bytes_to_copy);
+        if (this->wav_has_known_end_) {
+          this->wav_bytes_left_ -= bytes_to_copy;
+        }
+      }
+      return FileDecoderState::IDLE;
+    }
+  }
+
+  return FileDecoderState::END_OF_FILE;
+}
+
+}  // namespace audio
+}  // namespace esphome
+
+#endif

--- a/esphome/components/audio/audio_decoder.h
+++ b/esphome/components/audio/audio_decoder.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "audio.h"
+#include "audio_transfer_buffer.h"
+
+#include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/ring_buffer.h"
+
+#ifdef USE_SPEAKER
+#include "esphome/components/speaker/speaker.h"
+#endif
+
+#include "esp_err.h"
+
+// esp-audio-libs
+#ifdef USE_AUDIO_FLAC_SUPPORT
+#include <flac_decoder.h>
+#endif
+#ifdef USE_AUDIO_MP3_SUPPORT
+#include <mp3_decoder.h>
+#endif
+#include <wav_decoder.h>
+
+namespace esphome {
+namespace audio {
+
+enum class AudioDecoderState : uint8_t {
+  DECODING = 0,  // More data is available to decode
+  FINISHED,      // All file data has been decoded and transferred
+  FAILED,        // Encountered an error
+};
+
+// Only used within the AudioDecoder class; conveys the state of the particular file type decoder
+enum class FileDecoderState : uint8_t {
+  MORE_TO_PROCESS,     // Successsfully read a file chunk and more data is available to decode
+  IDLE,                // Not enough data to decode, waiting for more to be transferred
+  POTENTIALLY_FAILED,  // Decoder encountered a potentially recoverable error if more file data is available
+  FAILED,              // Decoder encoutnered an uncrecoverable error
+  END_OF_FILE,         // The specific file decoder knows its the end of the file
+};
+
+class AudioDecoder {
+  /*
+   * @brief Class that facilitates decoding an audio file.
+   * The audio file is read from a ring buffer source, decoded, and sent to an audio sink (ring buffer or speaker
+   * component).
+   * Supports wav, flac, and mp3 formats.
+   */
+ public:
+  /// @brief Allocates the input and output transfer buffers
+  /// @param input_buffer_size Size of the input transfer buffer in bytes.
+  /// @param output_buffer_size Size of the output transfer buffer in bytes.
+  AudioDecoder(size_t input_buffer_size, size_t output_buffer_size);
+
+  /// @brief Deallocates the MP3 decoder (the flac and wav decoders are deallocated automatically)
+  ~AudioDecoder();
+
+  /// @brief Adds a source ring buffer for raw file data. Takes ownership of the ring buffer in a shared_ptr.
+  /// @param input_ring_buffer weak_ptr of a shared_ptr of the sink ring buffer to transfer ownership
+  /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
+  esp_err_t add_source(std::weak_ptr<RingBuffer> &input_ring_buffer);
+
+  /// @brief Adds a sink ring buffer for decoded audio. Takes ownership of the ring buffer in a shared_ptr.
+  /// @param output_ring_buffer weak_ptr of a shared_ptr of the sink ring buffer to transfer ownership
+  /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
+  esp_err_t add_sink(std::weak_ptr<RingBuffer> &output_ring_buffer);
+
+#ifdef USE_SPEAKER
+  /// @brief Adds a sink speaker for decoded audio.
+  /// @param speaker pointer to speaker component
+  /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
+  esp_err_t add_sink(speaker::Speaker *speaker);
+#endif
+
+  /// @brief Sets up decoding the file
+  /// @param audio_file_type AudioFileType of the file
+  /// @return ESP_OK if successful, ESP_ERR_NO_MEM if the transfer buffers fail to allocate, or ESP_ERR_NOT_SUPPORTED if
+  /// the format isn't supported.
+  esp_err_t start(AudioFileType audio_file_type);
+
+  /// @brief Decodes audio from the ring buffer source and writes to the sink.
+  /// @param stop_gracefully If true, it indicates the file source is finished. The decoder will decode all the
+  /// reamining data and then finish.
+  /// @return AudioDecoderState
+  AudioDecoderState decode(bool stop_gracefully);
+
+  /// @brief Gets the audio stream information, if it has been decoded from the files header
+  /// @return optional<AudioStreamInfo> with the audio information. If not available yet, returns no value.
+  const optional<audio::AudioStreamInfo> &get_audio_stream_info() const { return this->audio_stream_info_; }
+
+  /// @brief Returns the duration of audio (in milliseconds) decoded and sent to the sink
+  /// @return Duration of decoded audio in milliseconds
+  uint32_t get_playback_ms() const { return this->playback_ms_; }
+
+  /// @brief Pauses sending resampled audio to the sink. If paused, it will continue to process internal buffers.
+  /// @param pause_state If true, audio data is not sent to the sink.
+  void set_pause_output_state(bool pause_state) { this->pause_output_ = pause_state; }
+
+ protected:
+  std::unique_ptr<esp_audio_libs::wav_decoder::WAVDecoder> wav_decoder_;
+#ifdef USE_AUDIO_FLAC_SUPPORT
+  FileDecoderState decode_flac_();
+  std::unique_ptr<esp_audio_libs::flac::FLACDecoder> flac_decoder_;
+#endif
+#ifdef USE_AUDIO_MP3_SUPPORT
+  FileDecoderState decode_mp3_();
+  esp_audio_libs::helix_decoder::HMP3Decoder mp3_decoder_;
+#endif
+  FileDecoderState decode_wav_();
+
+  std::unique_ptr<AudioSourceTransferBuffer> input_transfer_buffer_;
+  std::unique_ptr<AudioSinkTransferBuffer> output_transfer_buffer_;
+
+  AudioFileType audio_file_type_{AudioFileType::NONE};
+  optional<AudioStreamInfo> audio_stream_info_{};
+
+  size_t free_buffer_required_{0};
+  size_t wav_bytes_left_{0};
+
+  uint32_t potentially_failed_count_{0};
+  bool end_of_file_{false};
+  bool wav_has_known_end_{false};
+
+  bool pause_output_{false};
+
+  uint32_t accumulated_frames_written_{0};
+  uint32_t playback_ms_{0};
+};
+}  // namespace audio
+}  // namespace esphome
+
+#endif

--- a/esphome/components/audio/audio_reader.cpp
+++ b/esphome/components/audio/audio_reader.cpp
@@ -1,0 +1,308 @@
+#include "audio_reader.h"
+
+#ifdef USE_ESP_IDF
+
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+#include "esp_crt_bundle.h"
+#endif
+
+namespace esphome {
+namespace audio {
+
+static const uint32_t READ_WRITE_TIMEOUT_MS = 20;
+
+static const uint32_t CONNECTION_TIMEOUT_MS = 5000;
+
+// The number of times the http read times out with no data before throwing an error
+static const uint32_t ERROR_COUNT_NO_DATA_READ_TIMEOUT = 100;
+
+static const size_t HTTP_STREAM_BUFFER_SIZE = 2048;
+
+static const uint8_t MAX_REDIRECTION = 5;
+
+// Some common HTTP status codes - borrowed from http_request component accessed 20241224
+enum HttpStatus {
+  HTTP_STATUS_OK = 200,
+  HTTP_STATUS_NO_CONTENT = 204,
+  HTTP_STATUS_PARTIAL_CONTENT = 206,
+
+  /* 3xx - Redirection */
+  HTTP_STATUS_MULTIPLE_CHOICES = 300,
+  HTTP_STATUS_MOVED_PERMANENTLY = 301,
+  HTTP_STATUS_FOUND = 302,
+  HTTP_STATUS_SEE_OTHER = 303,
+  HTTP_STATUS_NOT_MODIFIED = 304,
+  HTTP_STATUS_TEMPORARY_REDIRECT = 307,
+  HTTP_STATUS_PERMANENT_REDIRECT = 308,
+
+  /* 4XX - CLIENT ERROR */
+  HTTP_STATUS_BAD_REQUEST = 400,
+  HTTP_STATUS_UNAUTHORIZED = 401,
+  HTTP_STATUS_FORBIDDEN = 403,
+  HTTP_STATUS_NOT_FOUND = 404,
+  HTTP_STATUS_METHOD_NOT_ALLOWED = 405,
+  HTTP_STATUS_NOT_ACCEPTABLE = 406,
+  HTTP_STATUS_LENGTH_REQUIRED = 411,
+
+  /* 5xx - Server Error */
+  HTTP_STATUS_INTERNAL_ERROR = 500
+};
+
+AudioReader::~AudioReader() { this->cleanup_connection_(); }
+
+esp_err_t AudioReader::add_sink(const std::weak_ptr<RingBuffer> &output_ring_buffer) {
+  if (current_audio_file_ != nullptr) {
+    // A transfer buffer isn't ncessary for a local file
+    this->file_ring_buffer_ = output_ring_buffer.lock();
+    return ESP_OK;
+  }
+
+  if (this->output_transfer_buffer_ != nullptr) {
+    this->output_transfer_buffer_->set_sink(output_ring_buffer);
+    return ESP_OK;
+  }
+
+  return ESP_ERR_INVALID_STATE;
+}
+
+esp_err_t AudioReader::start(AudioFile *audio_file, AudioFileType &file_type) {
+  file_type = AudioFileType::NONE;
+
+  this->current_audio_file_ = audio_file;
+
+  this->file_current_ = audio_file->data;
+  file_type = audio_file->file_type;
+
+  return ESP_OK;
+}
+
+esp_err_t AudioReader::start(const std::string &uri, AudioFileType &file_type) {
+  file_type = AudioFileType::NONE;
+
+  this->cleanup_connection_();
+
+  if (uri.empty()) {
+    return ESP_ERR_INVALID_ARG;
+  }
+
+  esp_http_client_config_t client_config = {};
+
+  client_config.url = uri.c_str();
+  client_config.cert_pem = nullptr;
+  client_config.disable_auto_redirect = false;
+  client_config.max_redirection_count = 10;
+  client_config.event_handler = http_event_handler;
+  client_config.user_data = this;
+  client_config.buffer_size = HTTP_STREAM_BUFFER_SIZE;
+  client_config.keep_alive_enable = true;
+  client_config.timeout_ms = CONNECTION_TIMEOUT_MS;  // Shouldn't trigger watchdog resets if caller runs in a task
+
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+  if (uri.find("https:") != std::string::npos) {
+    client_config.crt_bundle_attach = esp_crt_bundle_attach;
+  }
+#endif
+
+  this->client_ = esp_http_client_init(&client_config);
+
+  if (this->client_ == nullptr) {
+    return ESP_FAIL;
+  }
+
+  esp_err_t err = esp_http_client_open(this->client_, 0);
+
+  if (err != ESP_OK) {
+    this->cleanup_connection_();
+    return err;
+  }
+
+  int64_t header_length = esp_http_client_fetch_headers(this->client_);
+  if (header_length < 0) {
+    this->cleanup_connection_();
+    return ESP_FAIL;
+  }
+
+  int status_code = esp_http_client_get_status_code(this->client_);
+
+  if ((status_code < HTTP_STATUS_OK) || (status_code > HTTP_STATUS_PERMANENT_REDIRECT)) {
+    this->cleanup_connection_();
+    return ESP_FAIL;
+  }
+
+  ssize_t redirect_count = 0;
+
+  while ((esp_http_client_set_redirection(this->client_) == ESP_OK) && (redirect_count < MAX_REDIRECTION)) {
+    err = esp_http_client_open(this->client_, 0);
+    if (err != ESP_OK) {
+      this->cleanup_connection_();
+      return ESP_FAIL;
+    }
+
+    header_length = esp_http_client_fetch_headers(this->client_);
+    if (header_length < 0) {
+      this->cleanup_connection_();
+      return ESP_FAIL;
+    }
+
+    status_code = esp_http_client_get_status_code(this->client_);
+
+    if ((status_code < HTTP_STATUS_OK) || (status_code > HTTP_STATUS_PERMANENT_REDIRECT)) {
+      this->cleanup_connection_();
+      return ESP_FAIL;
+    }
+
+    ++redirect_count;
+  }
+
+  if (this->audio_file_type_ == AudioFileType::NONE) {
+    // Failed to determine the file type from the header, fallback to using the url
+    char url[500];
+    err = esp_http_client_get_url(this->client_, url, 500);
+    if (err != ESP_OK) {
+      this->cleanup_connection_();
+      return err;
+    }
+
+    std::string url_string = str_lower_case(url);
+
+    if (str_endswith(url_string, ".wav")) {
+      file_type = AudioFileType::WAV;
+    }
+#ifdef USE_AUDIO_MP3_SUPPORT
+    else if (str_endswith(url_string, ".mp3")) {
+      file_type = AudioFileType::MP3;
+    }
+#endif
+#ifdef USE_AUDIO_FLAC_SUPPORT
+    else if (str_endswith(url_string, ".flac")) {
+      file_type = AudioFileType::FLAC;
+    }
+#endif
+    else {
+      file_type = AudioFileType::NONE;
+      this->cleanup_connection_();
+      return ESP_ERR_NOT_SUPPORTED;
+    }
+  } else {
+    file_type = this->audio_file_type_;
+  }
+
+  this->last_data_read_ms_ = millis();
+
+  this->output_transfer_buffer_ = AudioSinkTransferBuffer::create(this->buffer_size_);
+  if (this->output_transfer_buffer_ == nullptr) {
+    return ESP_ERR_NO_MEM;
+  }
+
+  return ESP_OK;
+}
+
+AudioReaderState AudioReader::read() {
+  if (this->client_ != nullptr) {
+    return this->http_read_();
+  } else if (this->current_audio_file_ != nullptr) {
+    return this->file_read_();
+  }
+
+  return AudioReaderState::FAILED;
+}
+
+AudioFileType AudioReader::get_audio_type(const char *content_type) {
+#ifdef USE_AUDIO_MP3_SUPPORT
+  if (strcasecmp(content_type, "mp3") == 0 || strcasecmp(content_type, "audio/mp3") == 0 ||
+      strcasecmp(content_type, "audio/mpeg") == 0) {
+    return AudioFileType::MP3;
+  }
+#endif
+  if (strcasecmp(content_type, "audio/wav") == 0) {
+    return AudioFileType::WAV;
+  }
+#ifdef USE_AUDIO_FLAC_SUPPORT
+  if (strcasecmp(content_type, "audio/flac") == 0 || strcasecmp(content_type, "audio/x-flac") == 0) {
+    return AudioFileType::FLAC;
+  }
+#endif
+  return AudioFileType::NONE;
+}
+
+esp_err_t AudioReader::http_event_handler(esp_http_client_event_t *evt) {
+  // Based on https://github.com/maroc81/WeatherLily/tree/main/main/net accessed 20241224
+  AudioReader *this_reader = (AudioReader *) evt->user_data;
+
+  switch (evt->event_id) {
+    case HTTP_EVENT_ON_HEADER:
+      if (strcasecmp(evt->header_key, "Content-Type") == 0) {
+        this_reader->audio_file_type_ = get_audio_type(evt->header_value);
+      }
+      break;
+    default:
+      break;
+  }
+  return ESP_OK;
+}
+
+AudioReaderState AudioReader::file_read_() {
+  size_t remaining_bytes = this->current_audio_file_->length - (this->file_current_ - this->current_audio_file_->data);
+  if (remaining_bytes > 0) {
+    size_t bytes_written = this->file_ring_buffer_->write_without_replacement(this->file_current_, remaining_bytes,
+                                                                              pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
+    this->file_current_ += bytes_written;
+
+    return AudioReaderState::READING;
+  }
+
+  return AudioReaderState::FINISHED;
+}
+
+AudioReaderState AudioReader::http_read_() {
+  this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
+
+  if (esp_http_client_is_complete_data_received(this->client_)) {
+    if (this->output_transfer_buffer_->available() == 0) {
+      this->cleanup_connection_();
+      return AudioReaderState::FINISHED;
+    }
+  } else if (this->output_transfer_buffer_->free() > 0) {
+    size_t bytes_to_read = this->output_transfer_buffer_->free();
+    int received_len =
+        esp_http_client_read(this->client_, (char *) this->output_transfer_buffer_->get_buffer_end(), bytes_to_read);
+
+    if (received_len > 0) {
+      this->output_transfer_buffer_->increase_buffer_length(received_len);
+      this->last_data_read_ms_ = millis();
+    } else if (received_len < 0) {
+      // HTTP read error
+      this->cleanup_connection_();
+      return AudioReaderState::FAILED;
+    } else {
+      if (bytes_to_read > 0) {
+        // Read timed out
+        if ((millis() - this->last_data_read_ms_) > CONNECTION_TIMEOUT_MS) {
+          this->cleanup_connection_();
+          return AudioReaderState::FAILED;
+        }
+
+        delay(READ_WRITE_TIMEOUT_MS);
+      }
+    }
+  }
+
+  return AudioReaderState::READING;
+}
+
+void AudioReader::cleanup_connection_() {
+  if (this->client_ != nullptr) {
+    esp_http_client_close(this->client_);
+    esp_http_client_cleanup(this->client_);
+    this->client_ = nullptr;
+  }
+}
+
+}  // namespace audio
+}  // namespace esphome
+
+#endif

--- a/esphome/components/audio/audio_reader.h
+++ b/esphome/components/audio/audio_reader.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#ifdef USE_ESP_IDF
+
+#include "audio.h"
+#include "audio_transfer_buffer.h"
+
+#include "esphome/core/ring_buffer.h"
+
+#include "esp_err.h"
+
+#include <esp_http_client.h>
+
+namespace esphome {
+namespace audio {
+
+enum class AudioReaderState : uint8_t {
+  READING = 0,  // More data is available to read
+  FINISHED,     // All data has been read and transferred
+  FAILED,       // Encountered an error
+};
+
+class AudioReader {
+  /*
+   * @brief Class that facilitates reading a raw audio file.
+   * Files can be read from flash (stored in a AudioFile struct) or from an http source.
+   * The file data is sent to a ring buffer sink.
+   */
+ public:
+  /// @brief Constructs an AudioReader object.
+  /// The transfer buffer isn't allocated here, but only if necessary (an http source) in the start function.
+  /// @param buffer_size Transfer buffer size in bytes.
+  AudioReader(size_t buffer_size) : buffer_size_(buffer_size) {}
+  ~AudioReader();
+
+  /// @brief Adds a sink ring buffer for audio data. Takes ownership of the ring buffer in a shared_ptr
+  /// @param output_ring_buffer weak_ptr of a shared_ptr of the sink ring buffer to transfer ownership
+  /// @return  ESP_OK if successful, ESP_ERR_INVALID_STATE otherwise
+  esp_err_t add_sink(const std::weak_ptr<RingBuffer> &output_ring_buffer);
+
+  /// @brief Starts reading an audio file from an http source. The transfer buffer is allocated here.
+  /// @param uri Web url to the http file.
+  /// @param file_type AudioFileType variable passed-by-reference indicating the type of file being read.
+  /// @return ESP_OK if successful, an ESP_ERR* code otherwise.
+  esp_err_t start(const std::string &uri, AudioFileType &file_type);
+
+  /// @brief Starts reading an audio file from flash. No transfer buffer is allocated.
+  /// @param audio_file AudioFile struct containing the file.
+  /// @param file_type AudioFileType variable passed-by-reference indicating the type of file being read.
+  /// @return ESP_OK
+  esp_err_t start(AudioFile *audio_file, AudioFileType &file_type);
+
+  /// @brief Reads new file data from the source and sends to the ring buffer sink.
+  /// @return AudioReaderState
+  AudioReaderState read();
+
+ protected:
+  /// @brief Monitors the http client events to attempt determining the file type from the Content-Type header
+  static esp_err_t http_event_handler(esp_http_client_event_t *evt);
+
+  /// @brief Determines the audio file type from the http header's Content-Type key
+  /// @param content_type string with the Content-Type key
+  /// @return AudioFileType of the url, if it can be determined. If not, return AudioFileType::NONE.
+  static AudioFileType get_audio_type(const char *content_type);
+
+  AudioReaderState file_read_();
+  AudioReaderState http_read_();
+
+  std::shared_ptr<RingBuffer> file_ring_buffer_;
+  std::unique_ptr<AudioSinkTransferBuffer> output_transfer_buffer_;
+  void cleanup_connection_();
+
+  size_t buffer_size_;
+  uint32_t last_data_read_ms_;
+
+  esp_http_client_handle_t client_{nullptr};
+
+  AudioFile *current_audio_file_{nullptr};
+  AudioFileType audio_file_type_{AudioFileType::NONE};
+  const uint8_t *file_current_{nullptr};
+};
+}  // namespace audio
+}  // namespace esphome
+
+#endif

--- a/esphome/components/audio/audio_resampler.cpp
+++ b/esphome/components/audio/audio_resampler.cpp
@@ -1,0 +1,163 @@
+#include "audio_resampler.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/hal.h"
+
+#include <cstring>
+
+namespace esphome {
+namespace audio {
+
+static const uint32_t READ_WRITE_TIMEOUT_MS = 20;
+
+AudioResampler::AudioResampler(size_t input_buffer_size, size_t output_buffer_size)
+    : input_buffer_size_(input_buffer_size), output_buffer_size_(output_buffer_size) {
+  this->input_transfer_buffer_ = AudioSourceTransferBuffer::create(input_buffer_size);
+  this->output_transfer_buffer_ = AudioSinkTransferBuffer::create(output_buffer_size);
+}
+
+esp_err_t AudioResampler::add_source(std::weak_ptr<RingBuffer> &input_ring_buffer) {
+  if (this->input_transfer_buffer_ != nullptr) {
+    this->input_transfer_buffer_->set_source(input_ring_buffer);
+    return ESP_OK;
+  }
+  return ESP_ERR_NO_MEM;
+}
+
+esp_err_t AudioResampler::add_sink(std::weak_ptr<RingBuffer> &output_ring_buffer) {
+  if (this->output_transfer_buffer_ != nullptr) {
+    this->output_transfer_buffer_->set_sink(output_ring_buffer);
+    return ESP_OK;
+  }
+  return ESP_ERR_NO_MEM;
+}
+
+#ifdef USE_SPEAKER
+esp_err_t AudioResampler::add_sink(speaker::Speaker *speaker) {
+  if (this->output_transfer_buffer_ != nullptr) {
+    this->output_transfer_buffer_->set_sink(speaker);
+    return ESP_OK;
+  }
+  return ESP_ERR_NO_MEM;
+}
+#endif
+
+esp_err_t AudioResampler::start(AudioStreamInfo &input_stream_info, AudioStreamInfo &output_stream_info,
+                                uint16_t number_of_taps, uint16_t number_of_filters) {
+  this->input_stream_info_ = input_stream_info;
+  this->output_stream_info_ = output_stream_info;
+
+  if ((this->input_transfer_buffer_ == nullptr) || (this->output_transfer_buffer_ == nullptr)) {
+    return ESP_ERR_NO_MEM;
+  }
+
+  if ((input_stream_info.get_bits_per_sample() > 32) || (output_stream_info.get_bits_per_sample() > 32) ||
+      (input_stream_info_.get_channels() != output_stream_info.get_channels())) {
+    return ESP_ERR_NOT_SUPPORTED;
+  }
+
+  if ((input_stream_info.get_sample_rate() != output_stream_info.get_sample_rate()) ||
+      (input_stream_info.get_bits_per_sample() != output_stream_info.get_bits_per_sample())) {
+    this->resampler_ = make_unique<esp_audio_libs::resampler::Resampler>(
+        input_stream_info.bytes_to_samples(this->input_buffer_size_),
+        output_stream_info.bytes_to_samples(this->output_buffer_size_));
+
+    // Use cascaded biquad filters when downsampling to avoid aliasing
+    bool use_pre_filter = output_stream_info.get_sample_rate() < input_stream_info.get_sample_rate();
+
+    esp_audio_libs::resampler::ResamplerConfiguration resample_config = {
+        .source_sample_rate = static_cast<float>(input_stream_info.get_sample_rate()),
+        .target_sample_rate = static_cast<float>(output_stream_info.get_sample_rate()),
+        .source_bits_per_sample = input_stream_info.get_bits_per_sample(),
+        .target_bits_per_sample = output_stream_info.get_bits_per_sample(),
+        .channels = input_stream_info_.get_channels(),
+        .use_pre_or_post_filter = use_pre_filter,
+        .subsample_interpolate = false,  // Doubles the CPU load. Using more filters is a better alternative
+        .number_of_taps = number_of_taps,
+        .number_of_filters = number_of_filters,
+    };
+
+    if (!this->resampler_->initialize(resample_config)) {
+      // Failed to allocate the resampler's internal buffers
+      return ESP_ERR_NO_MEM;
+    }
+  }
+
+  return ESP_OK;
+}
+
+AudioResamplerState AudioResampler::resample(bool stop_gracefully, int32_t *ms_differential) {
+  if (stop_gracefully) {
+    if (!this->input_transfer_buffer_->has_buffered_data() && (this->output_transfer_buffer_->available() == 0)) {
+      return AudioResamplerState::FINISHED;
+    }
+  }
+
+  if (!this->pause_output_) {
+    // Move audio data to the sink without shifting the data in the output transfer buffer to avoid unnecessary, slow
+    // data moves
+    this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
+  } else {
+    // If paused, block to avoid wasting CPU resources
+    delay(READ_WRITE_TIMEOUT_MS);
+  }
+
+  this->input_transfer_buffer_->transfer_data_from_source(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
+
+  if (this->input_transfer_buffer_->available() == 0) {
+    // No samples available to process
+    return AudioResamplerState::RESAMPLING;
+  }
+
+  const size_t bytes_free = this->output_transfer_buffer_->free();
+  const uint32_t frames_free = this->output_stream_info_.bytes_to_frames(bytes_free);
+
+  const size_t bytes_available = this->input_transfer_buffer_->available();
+  const uint32_t frames_available = this->input_stream_info_.bytes_to_frames(bytes_available);
+
+  if ((this->input_stream_info_.get_sample_rate() != this->output_stream_info_.get_sample_rate()) ||
+      (this->input_stream_info_.get_bits_per_sample() != this->output_stream_info_.get_bits_per_sample())) {
+    // Adjust gain by -3 dB to avoid clipping due to the resampling process
+    esp_audio_libs::resampler::ResamplerResults results =
+        this->resampler_->resample(this->input_transfer_buffer_->get_buffer_start(),
+                                   this->output_transfer_buffer_->get_buffer_end(), frames_available, frames_free, -3);
+
+    this->input_transfer_buffer_->decrease_buffer_length(this->input_stream_info_.frames_to_bytes(results.frames_used));
+    this->output_transfer_buffer_->increase_buffer_length(
+        this->output_stream_info_.frames_to_bytes(results.frames_generated));
+
+    // Resampling causes slight differences in the durations used versus generated. Computes the difference in
+    // millisconds. The callback function passing the played audio duration uses the difference to convert from output
+    // duration to input duration.
+    this->accumulated_frames_used_ += results.frames_used;
+    this->accumulated_frames_generated_ += results.frames_generated;
+
+    const int32_t used_ms =
+        this->input_stream_info_.frames_to_milliseconds_with_remainder(&this->accumulated_frames_used_);
+    const int32_t generated_ms =
+        this->output_stream_info_.frames_to_milliseconds_with_remainder(&this->accumulated_frames_generated_);
+
+    *ms_differential = used_ms - generated_ms;
+
+  } else {
+    // No resampling required, copy samples directly to the output transfer buffer
+    *ms_differential = 0;
+
+    const size_t bytes_to_transfer = std::min(this->output_stream_info_.frames_to_bytes(frames_free),
+                                              this->input_stream_info_.frames_to_bytes(frames_available));
+
+    std::memcpy((void *) this->output_transfer_buffer_->get_buffer_end(),
+                (void *) this->input_transfer_buffer_->get_buffer_start(), bytes_to_transfer);
+
+    this->input_transfer_buffer_->decrease_buffer_length(bytes_to_transfer);
+    this->output_transfer_buffer_->increase_buffer_length(bytes_to_transfer);
+  }
+
+  return AudioResamplerState::RESAMPLING;
+}
+
+}  // namespace audio
+}  // namespace esphome
+
+#endif

--- a/esphome/components/audio/audio_resampler.h
+++ b/esphome/components/audio/audio_resampler.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "audio.h"
+#include "audio_transfer_buffer.h"
+
+#include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/ring_buffer.h"
+
+#ifdef USE_SPEAKER
+#include "esphome/components/speaker/speaker.h"
+#endif
+
+#include "esp_err.h"
+
+#include <resampler.h>  // esp-audio-libs
+
+namespace esphome {
+namespace audio {
+
+enum class AudioResamplerState : uint8_t {
+  RESAMPLING,  // More data is available to resample
+  FINISHED,    // All file data has been resampled and transferred
+  FAILED,      // Unused state included for consistency among Audio classes
+};
+
+class AudioResampler {
+  /*
+   * @brief Class that facilitates resampling audio.
+   * The audio data is read from a ring buffer source, resampled, and sent to an audio sink (ring buffer or speaker
+   * component). Also supports converting bits per sample.
+   */
+ public:
+  /// @brief Allocates the input and output transfer buffers
+  /// @param input_buffer_size Size of the input transfer buffer in bytes.
+  /// @param output_buffer_size Size of the output transfer buffer in bytes.
+  AudioResampler(size_t input_buffer_size, size_t output_buffer_size);
+
+  /// @brief Adds a source ring buffer for audio data. Takes ownership of the ring buffer in a shared_ptr.
+  /// @param input_ring_buffer weak_ptr of a shared_ptr of the sink ring buffer to transfer ownership
+  /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
+  esp_err_t add_source(std::weak_ptr<RingBuffer> &input_ring_buffer);
+
+  /// @brief Adds a sink ring buffer for resampled audio. Takes ownership of the ring buffer in a shared_ptr.
+  /// @param output_ring_buffer weak_ptr of a shared_ptr of the sink ring buffer to transfer ownership
+  /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
+  esp_err_t add_sink(std::weak_ptr<RingBuffer> &output_ring_buffer);
+
+#ifdef USE_SPEAKER
+  /// @brief Adds a sink speaker for decoded audio.
+  /// @param speaker pointer to speaker component
+  /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
+  esp_err_t add_sink(speaker::Speaker *speaker);
+#endif
+
+  /// @brief Sets up the class to resample.
+  /// @param input_stream_info The incoming sample rate, bits per sample, and number of channels
+  /// @param output_stream_info The desired outgoing sample rate, bits per sample, and number of channels
+  /// @param number_of_taps Number of taps per FIR filter
+  /// @param number_of_filters Number of FIR filters
+  /// @return ESP_OK if it is able to convert the incoming stream,
+  ///         ESP_ERR_NO_MEM if the transfer buffers failed to allocate,
+  ///         ESP_ERR_NOT_SUPPORTED if the stream can't be converted.
+  esp_err_t start(AudioStreamInfo &input_stream_info, AudioStreamInfo &output_stream_info, uint16_t number_of_taps,
+                  uint16_t number_of_filters);
+
+  /// @brief Resamples audio from the ring buffer source and writes to the sink.
+  /// @param stop_gracefully If true, it indicates the file decoder is finished. The resampler will resample all the
+  ///                        remaining audio and then finish.
+  /// @param ms_differential Pointer to a (int32_t) variable that will store the difference, in milliseconds, between
+  ///                        the duration of input audio used and the duration of output audio generated.
+  /// @return AudioResamplerState
+  AudioResamplerState resample(bool stop_gracefully, int32_t *ms_differential);
+
+  /// @brief Pauses sending resampled audio to the sink. If paused, it will continue to process internal buffers.
+  /// @param pause_state If true, audio data is not sent to the sink.
+  void set_pause_output_state(bool pause_state) { this->pause_output_ = pause_state; }
+
+ protected:
+  std::unique_ptr<AudioSourceTransferBuffer> input_transfer_buffer_;
+  std::unique_ptr<AudioSinkTransferBuffer> output_transfer_buffer_;
+
+  size_t input_buffer_size_;
+  size_t output_buffer_size_;
+
+  uint32_t accumulated_frames_used_{0};
+  uint32_t accumulated_frames_generated_{0};
+
+  bool pause_output_{false};
+
+  AudioStreamInfo input_stream_info_;
+  AudioStreamInfo output_stream_info_;
+
+  std::unique_ptr<esp_audio_libs::resampler::Resampler> resampler_;
+};
+
+}  // namespace audio
+}  // namespace esphome
+
+#endif

--- a/esphome/components/audio/audio_transfer_buffer.cpp
+++ b/esphome/components/audio/audio_transfer_buffer.cpp
@@ -1,0 +1,175 @@
+#include "audio_transfer_buffer.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace audio {
+
+AudioTransferBuffer::~AudioTransferBuffer() { this->deallocate_buffer_(); };
+
+std::unique_ptr<AudioSinkTransferBuffer> AudioSinkTransferBuffer::create(size_t buffer_size) {
+  std::unique_ptr<AudioSinkTransferBuffer> sink_buffer = make_unique<AudioSinkTransferBuffer>();
+
+  if (!sink_buffer->allocate_buffer_(buffer_size)) {
+    return nullptr;
+  }
+
+  return sink_buffer;
+}
+
+std::unique_ptr<AudioSourceTransferBuffer> AudioSourceTransferBuffer::create(size_t buffer_size) {
+  std::unique_ptr<AudioSourceTransferBuffer> source_buffer = make_unique<AudioSourceTransferBuffer>();
+
+  if (!source_buffer->allocate_buffer_(buffer_size)) {
+    return nullptr;
+  }
+
+  return source_buffer;
+}
+
+size_t AudioTransferBuffer::free() const {
+  if (this->buffer_size_ == 0) {
+    return 0;
+  }
+  return this->buffer_size_ - (this->buffer_length_ + (this->data_start_ - this->buffer_));
+}
+
+void AudioTransferBuffer::decrease_buffer_length(size_t bytes) {
+  this->buffer_length_ -= bytes;
+  if (this->buffer_length_ > 0) {
+    this->data_start_ += bytes;
+  } else {
+    // All the data in the buffer has been consumed, reset the start pointer
+    this->data_start_ = this->buffer_;
+  }
+}
+
+void AudioTransferBuffer::increase_buffer_length(size_t bytes) { this->buffer_length_ += bytes; }
+
+void AudioTransferBuffer::clear_buffered_data() {
+  this->buffer_length_ = 0;
+  if (this->ring_buffer_.use_count() > 0) {
+    this->ring_buffer_->reset();
+  }
+}
+
+void AudioSinkTransferBuffer::clear_buffered_data() {
+  this->buffer_length_ = 0;
+  if (this->ring_buffer_.use_count() > 0) {
+    this->ring_buffer_->reset();
+  }
+#ifdef USE_SPEAKER
+  if (this->speaker_ != nullptr) {
+    this->speaker_->stop();
+  }
+#endif
+}
+
+bool AudioTransferBuffer::has_buffered_data() const {
+  if (this->ring_buffer_.use_count() > 0) {
+    return ((this->ring_buffer_->available() > 0) || (this->available() > 0));
+  }
+  return (this->available() > 0);
+}
+
+bool AudioTransferBuffer::reallocate(size_t new_buffer_size) {
+  if (this->buffer_length_ > 0) {
+    // Buffer currently has data, so reallocation is impossible
+    return false;
+  }
+  this->deallocate_buffer_();
+  return this->allocate_buffer_(new_buffer_size);
+}
+
+bool AudioTransferBuffer::allocate_buffer_(size_t buffer_size) {
+  this->buffer_size_ = buffer_size;
+
+  RAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+
+  this->buffer_ = allocator.allocate(this->buffer_size_);
+  if (this->buffer_ == nullptr) {
+    return false;
+  }
+
+  this->data_start_ = this->buffer_;
+  this->buffer_length_ = 0;
+
+  return true;
+}
+
+void AudioTransferBuffer::deallocate_buffer_() {
+  if (this->buffer_ != nullptr) {
+    RAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+    allocator.deallocate(this->buffer_, this->buffer_size_);
+    this->buffer_ = nullptr;
+    this->data_start_ = nullptr;
+  }
+
+  this->buffer_size_ = 0;
+  this->buffer_length_ = 0;
+}
+
+size_t AudioSourceTransferBuffer::transfer_data_from_source(TickType_t ticks_to_wait, bool pre_shift) {
+  if (pre_shift) {
+    // Shift data in buffer to start
+    if (this->buffer_length_ > 0) {
+      memmove(this->buffer_, this->data_start_, this->buffer_length_);
+    }
+    this->data_start_ = this->buffer_;
+  }
+
+  size_t bytes_to_read = this->free();
+  size_t bytes_read = 0;
+  if (bytes_to_read > 0) {
+    if (this->ring_buffer_.use_count() > 0) {
+      bytes_read = this->ring_buffer_->read((void *) this->get_buffer_end(), bytes_to_read, ticks_to_wait);
+    }
+
+    this->increase_buffer_length(bytes_read);
+  }
+  return bytes_read;
+}
+
+size_t AudioSinkTransferBuffer::transfer_data_to_sink(TickType_t ticks_to_wait, bool post_shift) {
+  size_t bytes_written = 0;
+  if (this->available()) {
+#ifdef USE_SPEAKER
+    if (this->speaker_ != nullptr) {
+      bytes_written = this->speaker_->play(this->data_start_, this->available(), ticks_to_wait);
+    } else
+#endif
+        if (this->ring_buffer_.use_count() > 0) {
+      bytes_written =
+          this->ring_buffer_->write_without_replacement((void *) this->data_start_, this->available(), ticks_to_wait);
+    }
+
+    this->decrease_buffer_length(bytes_written);
+  }
+
+  if (post_shift) {
+    // Shift unwritten data to the start of the buffer
+    memmove(this->buffer_, this->data_start_, this->buffer_length_);
+    this->data_start_ = this->buffer_;
+  }
+
+  return bytes_written;
+}
+
+bool AudioSinkTransferBuffer::has_buffered_data() const {
+#ifdef USE_SPEAKER
+  if (this->speaker_ != nullptr) {
+    return (this->speaker_->has_buffered_data() || (this->available() > 0));
+  }
+#endif
+  if (this->ring_buffer_.use_count() > 0) {
+    return ((this->ring_buffer_->available() > 0) || (this->available() > 0));
+  }
+  return (this->available() > 0);
+}
+
+}  // namespace audio
+}  // namespace esphome
+
+#endif

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#ifdef USE_ESP32
+#include "esphome/core/defines.h"
+#include "esphome/core/ring_buffer.h"
+
+#ifdef USE_SPEAKER
+#include "esphome/components/speaker/speaker.h"
+#endif
+
+#include "esp_err.h"
+
+#include <freertos/FreeRTOS.h>
+
+namespace esphome {
+namespace audio {
+
+class AudioTransferBuffer {
+  /*
+   * @brief Class that facilitates tranferring data between a buffer and an audio source or sink.
+   * The transfer buffer is a typical C array that temporarily holds data for processing in other audio components.
+   * Both sink and source transfer buffers can use a ring buffer as the sink/source.
+   *   - The ring buffer is stored in a shared_ptr, so destroying the transfer buffer object will release ownership.
+   */
+ public:
+  /// @brief Destructor that deallocates the transfer buffer
+  ~AudioTransferBuffer();
+
+  /// @brief Returns a pointer to the start of the transfer buffer where available() bytes of exisiting data can be read
+  uint8_t *get_buffer_start() const { return this->data_start_; }
+
+  /// @brief Returns a pointer to the end of the transfer buffer where free() bytes of new data can be written
+  uint8_t *get_buffer_end() const { return this->data_start_ + this->buffer_length_; }
+
+  /// @brief Updates the internal state of the transfer buffer. This should be called after reading data
+  /// @param bytes The number of bytes consumed/read
+  void decrease_buffer_length(size_t bytes);
+
+  /// @brief Updates the internal state of the transfer buffer. This should be called after writing data
+  /// @param bytes The number of bytes written
+  void increase_buffer_length(size_t bytes);
+
+  /// @brief Returns the transfer buffer's currently available bytes to read
+  size_t available() const { return this->buffer_length_; }
+
+  /// @brief Returns the transfer buffers allocated bytes
+  size_t capacity() const { return this->buffer_size_; }
+
+  /// @brief Returns the transfer buffer's currrently free bytes available to write
+  size_t free() const;
+
+  /// @brief Clears data in the transfer buffer and, if possible, the source/sink.
+  virtual void clear_buffered_data();
+
+  /// @brief Tests if there is any data in the tranfer buffer or the source/sink.
+  /// @return True if there is data, false otherwise.
+  virtual bool has_buffered_data() const;
+
+  bool reallocate(size_t new_buffer_size);
+
+ protected:
+  /// @brief Allocates the transfer buffer in external memory, if available.
+  /// @param buffer_size The number of bytes to allocate
+  /// @return True is successful, false otherwise.
+  bool allocate_buffer_(size_t buffer_size);
+
+  /// @brief Deallocates the buffer and resets the class variables.
+  void deallocate_buffer_();
+
+  // A possible source or sink for the transfer buffer
+  std::shared_ptr<RingBuffer> ring_buffer_;
+
+  uint8_t *buffer_{nullptr};
+  uint8_t *data_start_{nullptr};
+
+  size_t buffer_size_{0};
+  size_t buffer_length_{0};
+};
+
+class AudioSinkTransferBuffer : public AudioTransferBuffer {
+  /*
+   * @brief A class that implements a transfer buffer for audio sinks.
+   * Supports writing processed data in the transfer buffer to a ring buffer or a speaker component.
+   */
+ public:
+  /// @brief Creates a new sink transfer buffer.
+  /// @param buffer_size Size of the transfer buffer in bytes.
+  /// @return unique_ptr if successfully allocated, nullptr otherwise
+  static std::unique_ptr<AudioSinkTransferBuffer> create(size_t buffer_size);
+
+  /// @brief Writes any available data in the transfer buffer to the sink.
+  /// @param ticks_to_wait FreeRTOS ticks to block while waiting for the sink to have enough space
+  /// @param post_shift If true, all remaining data is moved to the start of the buffer after transferring to the sink.
+  ///                   Defaults to true.
+  /// @return Number of bytes written
+  size_t transfer_data_to_sink(TickType_t ticks_to_wait, bool post_shift = true);
+
+  /// @brief Adds a ring buffer as the transfer buffer's sink.
+  /// @param ring_buffer weak_ptr to the allocated ring buffer
+  void set_sink(const std::weak_ptr<RingBuffer> &ring_buffer) { this->ring_buffer_ = ring_buffer.lock(); }
+
+#ifdef USE_SPEAKER
+  /// @brief Adds a speaker as the transfer buffer's sink.
+  /// @param speaker Pointer to the speaker component
+  void set_sink(speaker::Speaker *speaker) { this->speaker_ = speaker; }
+#endif
+
+  void clear_buffered_data() override;
+
+  bool has_buffered_data() const override;
+
+ protected:
+#ifdef USE_SPEAKER
+  speaker::Speaker *speaker_{nullptr};
+#endif
+};
+
+class AudioSourceTransferBuffer : public AudioTransferBuffer {
+  /*
+   * @brief A class that implements a transfer buffer for audio sources.
+   * Supports reading audio data from a ring buffer into the transfer buffer for processing.
+   */
+ public:
+  /// @brief Creates a new source transfer buffer.
+  /// @param buffer_size Size of the transfer buffer in bytes.
+  /// @return unique_ptr if successfully allocated, nullptr otherwise
+  static std::unique_ptr<AudioSourceTransferBuffer> create(size_t buffer_size);
+
+  /// @brief Reads any available data from the sink into the transfer buffer.
+  /// @param ticks_to_wait FreeRTOS ticks to block while waiting for the source to have enough data
+  /// @param pre_shift If true, any unwritten data is moved to the start of the buffer before transferring from the
+  ///                  source. Defaults to true.
+  /// @return Number of bytes read
+  size_t transfer_data_from_source(TickType_t ticks_to_wait, bool pre_shift = true);
+
+  /// @brief Adds a ring buffer as the transfer buffer's source.
+  /// @param ring_buffer weak_ptr to the allocated ring buffer
+  void set_source(const std::weak_ptr<RingBuffer> &ring_buffer) { this->ring_buffer_ = ring_buffer.lock(); };
+};
+
+}  // namespace audio
+}  // namespace esphome
+
+#endif


### PR DESCRIPTION
Fix for the media player pipeline: previously, playback would stop immediately when a frame lacked sufficient data, instead of waiting for more data and retrying. This change ensures the player waits and retries instead of failing prematurely.

(Temporarily using a local copy of the audio component due to upstream ESPHome breaking changes.)
