### PR TITLE
Use local audio component also in dashboard builds

### DIFF
--- a/config/common/components.external.yaml
+++ b/config/common/components.external.yaml
@@ -6,4 +6,4 @@ external_components:
       type: git
       url: https://github.com/FutureProofHomes/Satellite1-ESPHome
       ref: ${ext_comp_repo_ref}
-    components: [ i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]
+    components: [ audio, i2s_audio, satellite1, memory_flasher, tas2780, pcm5122, fusb302b ]


### PR DESCRIPTION
The dashboard configuration imports the external components as defined in components.external.yaml.
The recently (#308) added audio component (which includes the media player fix) was missing in that file.