### PR TITLE
Migrate to 2025.7

### DIFF
--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -18,7 +18,7 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2025.5.2
+      esphome-version: 2025.7.5
       release-summary: develop-branch
       release-url:
       release-version:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -80,7 +80,7 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2025.5.2
+      esphome-version: 2025.7.5
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
   push-tag:

--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -9,7 +9,9 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: recommended
+    version: 5.1.6
+    platform_version: 51.3.7
+
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"

--- a/esphome/components/snapcast/snapcast_client.h
+++ b/esphome/components/snapcast/snapcast_client.h
@@ -42,7 +42,7 @@ ESPHome Snapcast client, this component manages connections to the Snapcast serv
 class SnapcastClient : public Component {
 public:
   void setup() override;
-  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+  float get_setup_priority() const override { return setup_priority::AFTER_CONNECTION - 10; }
 
   error_t connect_to_server(std::string url, uint32_t stream_port=1704, uint32_t rpc_port=1705);
   void set_media_player(esphome::speaker::SpeakerMediaPlayer* media_player){ this->media_player_ = media_player; }  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2025.5.2
+esphome==2025.7.5
 setuptools


### PR DESCRIPTION
Build firmware with ESPHome 2025.7.5
requires:
- IDF 5.3.2 doesn't work stable, stay with 5.1.6
- fix: make sure to start the snapcast client only after the mDNS component has been set up