### PR TITLE
Add api dynamic encryption

### DIFF
--- a/config/common/home_assistant.yaml
+++ b/config/common/home_assistant.yaml
@@ -5,6 +5,7 @@ api:
     - script.execute: control_leds
   on_client_disconnected:
     - script.execute: control_leds
+  encryption:   # Uses key set by Home Assistant
 
 
 button:


### PR DESCRIPTION
Allow HA to automatically encrypt api connection.

When downgrading from firmware version with this option enabled HA automatically prompt user if its oke go go further unsecured.

(squashed version of PR #381 )