### PR TITLE
Dashboard builds: Add XMOS upload button & use staging branch as default

### DIFF
--- a/config/common/dashboard_build.yaml
+++ b/config/common/dashboard_build.yaml
@@ -1,0 +1,11 @@
+## Configuration used by dashboard builds only
+
+button:
+  # Flashes Sat1 HAT with XMOS firmware embedded in the ESP32 firmware
+  - platform: template
+    id: flash_embedded
+    name: "XMOS Flash Embedded FW"
+    entity_category: diagnostic
+    on_press:
+      then:
+        - memory_flasher.write_embedded_image:

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -66,7 +66,7 @@ ota:
     id: ota_esphome
 
 dashboard_import:
-  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.dashboard.yaml@develop
+  package_import_url: github://futureproofhomes/satellite1-esphome/config/satellite1.dashboard.yaml@staging
   import_full_config: true
 
 

--- a/config/satellite1.dashboard.yaml
+++ b/config/satellite1.dashboard.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: satellite1
   friendly_name: Satellite1
-  xmos_fw_version: "v1.0.2"
+  xmos_fw_version: "v1.0.3"
   
   # OPTIONALLY, set the log level to debug, info, warn, error
   log_level: debug
@@ -19,6 +19,7 @@ packages:
     files: 
     # Main config files, don't remove
     - config/satellite1.base.yaml
+    - config/common/dashboard_build.yaml
     - path: config/common/components.external.yaml
       vars:
         ext_comp_repo_ref: develop # Make sure to set this to the same as the ref above
@@ -30,7 +31,7 @@ packages:
     #- config/common/mmwave_ld2450.yaml
 
     ## OPTIONALLY, uncomment if want extra memory, wifi and xmos control of the device.
-    #- config/common/debug.yaml 
+    #- config/common/debug.yaml
       
 logger:
   level: ${log_level}
@@ -58,3 +59,13 @@ logger:
 #snapcast:
 #  id: snapcast_client
 #  server_ip: 192.168.178.101
+
+## OPTIONALLY, uncomment the following lines to set a custom micro wake word model
+#micro_wake_word:
+#  id: mww
+#  models:
+#    - id: new_wake_word
+#      model: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
+#    # uncomment the following line to remove the default "hey_jarvis" wake word
+#    - id: !remove hey_jarvis
+

--- a/config/satellite1.dashboard.yaml
+++ b/config/satellite1.dashboard.yaml
@@ -14,7 +14,7 @@ esphome:
 packages:
   FutureProofHomes.Satellite1: 
     url: https://github.com/futureproofhomes/satellite1-esphome
-    ref: develop # Make sure to also change the ext_comp_repo_ref below 
+    ref: staging # Make sure to also change the ext_comp_repo_ref below 
     refresh: 1s  
     files: 
     # Main config files, don't remove
@@ -22,7 +22,7 @@ packages:
     - config/common/dashboard_build.yaml
     - path: config/common/components.external.yaml
       vars:
-        ext_comp_repo_ref: develop # Make sure to set this to the same as the ref above
+        ext_comp_repo_ref: staging # Make sure to set this to the same as the ref above
     
     ## OPTIONALLY, uncomment if you have the smaller LD2410 mmWave sensor connected to your HAT.
     #- config/common/mmwave_ld2410.yaml    


### PR DESCRIPTION
- adds a button for uploading the embedded XMOS firmware to the HAT flash memory
- use `staging` (latest beta release) as the default branch for dashboard builds
- add instructions/comments to the dashboard for adding a custom wake word

closes #367 