### PR TITLE
snapcast: check which ip is reachable

### DIFF
--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -180,6 +180,31 @@ static void mdns_print_results(mdns_result_t *results)
     }
 }
 
+
+static bool test_tcp_connect(const esp_ip4_addr_t &ip, uint16_t port, uint32_t timeout_ms)
+{
+    int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    if (sock < 0) {
+        return false;
+    }
+
+    struct timeval tv;
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    struct sockaddr_in dest = {};
+    dest.sin_family      = AF_INET;
+    dest.sin_port        = htons(port);
+    dest.sin_addr.s_addr = ip.addr;   // esp_ip4_addr_t has .addr
+
+    bool ok = (connect(sock, (struct sockaddr*)&dest, sizeof(dest)) == 0);
+    close(sock);
+    return ok;
+}
+
+
 std::string resolve_mdns_host(const char * host_name)
 {
     esp_ip4_addr_t addr;
@@ -198,62 +223,78 @@ std::string resolve_mdns_host(const char * host_name)
 }
 
 
-error_t SnapcastClient::connect_via_mdns(){
-    // search for the snapcast server that has `is_mass` in its .txt entries 
-    mdns_result_t * results = nullptr;
-    esp_err_t err = mdns_query_ptr( "_snapcast", "_tcp", 6000, 20,  &results);
-    if(err){
-        ESP_LOGE(TAG, "mDNS query Failed");
-        return ESP_OK;
+error_t SnapcastClient::connect_via_mdns()
+{
+    mdns_result_t *results = nullptr;
+
+    // PTR query: _snapcast._tcp.local
+    esp_err_t err = mdns_query_ptr("_snapcast", "_tcp", 6000, 20, &results);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "mDNS query failed: %s", esp_err_to_name(err));
+        return ESP_FAIL;
     }
-    if(!results){
+    if (!results) {
         ESP_LOGW(TAG, "No Snapcast server found via mDNS!");
-        return ESP_OK;
+        return ESP_FAIL;
     }
 
 #if SNAPCAST_DEBUG    
     mdns_print_results(results);
 #endif    
+
+    std::string chosen_hostname;
+    std::string chosen_ip;
+    uint32_t chosen_port = 0;
+    bool found_mass = false;
+
+    for (mdns_result_t *r = results; r != nullptr; r = r->next) {
+
+        // If we already found a reachable MA server, we can break early
+        if (found_mass) {
+            break;
+        }
+
+        // Snapcast advertised port
+        uint16_t port = r->port;
     
-    std::string ma_snapcast_hostname;
-    std::string ma_snapcast_ip;
-    uint32_t port = 0;
-    mdns_result_t *r = results;
-    while(r){
-        std::string check_ip;
-        if( r->addr && r->addr->addr.type == ESP_IPADDR_TYPE_V4 ){
-            mdns_ip_addr_t *a = r->addr;
-            char buffer[16];  // Enough for "255.255.255.255\0"
-            snprintf(buffer, sizeof(buffer), IPSTR, IP2STR(&(a->addr.u_addr.ip4)));
-            check_ip = std::string(buffer);   
-        } else {
-            check_ip = resolve_mdns_host( r->hostname);
-        }
-        if(!check_ip.empty()){
-            ma_snapcast_ip = check_ip;
-            ma_snapcast_hostname = std::string(r->hostname) + ".local";
-            port = r->port;
-        }
-        if (r->txt_count) {
-            for (int t = 0; t < r->txt_count; t++) {
-                if( strcmp(r->txt[t].key, "is_mass") == 0){
-                    // if music assistant snapcast server is among found servers, take it
-                    if(!check_ip.empty()) break;
+        for (mdns_ip_addr_t *a = r->addr; a != nullptr; a = a->next) {
+            if (a->addr.type != ESP_IPADDR_TYPE_V4) {
+                continue;
+            }
+
+            esp_ip4_addr_t ip4 = a->addr.u_addr.ip4;
+
+            if (test_tcp_connect(ip4, port, 1000)) {
+                char buf[16];
+                snprintf(buf, sizeof(buf), IPSTR, IP2STR(&ip4));
+                chosen_ip       = buf;
+                chosen_hostname = std::string(r->hostname) + ".local";
+                chosen_port     = port;
+
+                // TXT handling stays the same
+                if (r->txt_count) {
+                    for (int t = 0; t < r->txt_count; t++) {
+                        if (strcmp(r->txt[t].key, "is_mass") == 0) {
+                            found_mass = true;
+                            break;
+                        }
+                    }
                 }
+                break; // found a reachable IP for this result
             }
         }
-        r = r->next;
     }
+
     mdns_query_results_free(results);
 
-    if( !ma_snapcast_ip.empty() ){
-        ESP_LOGI(TAG, "MA-Snapcast server found: %s:%d", ma_snapcast_hostname.c_str(), port );
-        ESP_LOGI(TAG, "resolved: %s:%d\n", ma_snapcast_ip.c_str(), port );
-        
-        this->connect_to_server( ma_snapcast_ip, port, 1705);
+    if (!chosen_ip.empty()) {
+        ESP_LOGI(TAG, "Snapcast server found: %s:%d", chosen_hostname.c_str(), chosen_port);
+        ESP_LOGI(TAG, "resolved reachable IP: %s:%d", chosen_ip.c_str(), chosen_port);
+        this->connect_to_server(chosen_ip, chosen_port, 1705);
         return ESP_OK;
     }
-    ESP_LOGW(TAG, "Couldn't find MA-Snapcast server.");
+
+    ESP_LOGW(TAG, "Couldn't find any reachable Snapcast server via mDNS.");
     return ESP_FAIL;
 }
 

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -203,7 +203,7 @@ static void transport_task_(
         
         int err = connect(sock, (struct sockaddr*)&dest_addr, sizeof(dest_addr));
         if (err != 0) {
-            ESP_LOGE("transport", "Socket unable to connect: errno %d", errno);
+            ESP_LOGE("transport", "Socket unable to connect to %s: errno %d", server.c_str(), errno);
             close(sock);
             xTaskNotify(stream_task_handle, CONNECTION_FAILED_BIT, eSetBits);
             continue;


### PR DESCRIPTION
If mdns reports several IPs for the snapcast server, check which one is reachable instead of simple taking the first one.