### PR TITLE
dac_proxy,media_player: fix not restoring the active dac

### DIFF
--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -10,23 +10,11 @@ audio_dac:
     id: dac_proxy
     speaker_dac: speaker_dac
     line_out_dac: line_out_dac
-    
-    on_line_out_activated:
-        # if line_out was used previously but is not available try speaker
-        - lambda: |
-            if( !id(line_out_sensor).state ){
-              id(dac_proxy).activate_speaker();
-            }
-    
+        
     on_state_change:
-      - media_player.volume_set:
+      - media_player.speaker.restore_volume:
           volume: !lambda return id(dac_proxy).volume();
-      - lambda: |
-           if( id(dac_proxy).is_muted() ){
-              id(external_media_player)->make_call()
-                .set_command(MEDIA_PLAYER_COMMAND_MUTE)
-                .perform();
-           }
+          mute: !lambda return id(dac_proxy).is_muted(); 
 
 select:
   - platform: template

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -45,12 +45,19 @@ esphome:
     version: ${esp32_fw_version}
   
   on_boot:
-    - priority: 375
+    - priority: -100
       then:
         - logger.log: "${company_name} ${project_name} ${component_name} running ESP firmware: ${esp32_fw_version} and XMOS firmware: ${xmos_fw_version}"
         # Run the script to refresh the LED status
         - script.execute: control_leds
         - delay: 1s
+        
+        # if line_out was used previously but is not available try speaker 
+        - lambda: |    
+            if( !id(line_out_sensor).state && id(dac_proxy).active_dac == 1){
+              id(dac_proxy).activate_speaker();
+            }
+             
         
         # If after 10 minutes, the device is still initializing (It did not yet connect to Home Assistant), turn off the init_in_progress variable and run the script to refresh the LED status
         - delay: 10min

--- a/esphome/components/satellite1/audio_dac/dac_proxy.cpp
+++ b/esphome/components/satellite1/audio_dac/dac_proxy.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "dac_proxy";
 
 void DACProxy::setup(){
   ESP_LOGD(TAG, "Setting up DACProxy...");
-  this->pref_ = global_preferences->make_preference<DACProxyRestoreState>(this->get_object_id_hash());
+  this->pref_ = global_preferences->make_preference<DACProxyRestoreState>(this->get_preference_hash());
   
   if (this->pref_.load(&this->restore_state_)) {
     ESP_LOGD(TAG, "Read preferences from flash");
@@ -27,6 +27,7 @@ void DACProxy::setup(){
             this->tas2780_->set_mute_on();
         }
     }
+    ESP_LOGD(TAG, "   active dac: %d", this->restore_state_.dac_output);
     this->active_dac = (DacOutput) this->restore_state_.dac_output;
     this->activate();
   }
@@ -139,17 +140,22 @@ bool DACProxy::set_mute_off(){
         ESP_LOGD(TAG, "DACProxy::set_mute_off() called before setup()");
         return false;
     }
-    ESP_LOGD(TAG, "set_mute_off: for %s", this->active_dac == LINE_OUT? "Line-Out" : "Speaker");
+    bool has_changed = false;
     bool ret = false;
-    if( this->active_dac == LINE_OUT && this->pcm5122_ ){
+    if( this->active_dac == LINE_OUT && this->pcm5122_ && this->pcm5122_->is_muted()){
         ret = this->pcm5122_->set_mute_off();
         this->restore_state_.line_out_is_muted = false;
+        has_changed = true;
     }
-    if( this->active_dac == SPEAKER && this->tas2780_ ){
+    if( this->active_dac == SPEAKER && this->tas2780_ && this->tas2780_->is_muted()){
         ret = this->tas2780_->set_mute_off();
         this->restore_state_.speaker_is_muted = false;
+        has_changed = true;
     }
-    this->save_volume_restore_state_();
+    if( has_changed ){
+        ESP_LOGD(TAG, "set_mute_off: for %s", this->active_dac == LINE_OUT? "Line-Out" : "Speaker");
+        this->save_volume_restore_state_();
+    }
     return ret;
 }
 
@@ -158,17 +164,22 @@ bool DACProxy::set_mute_on(){
         ESP_LOGD(TAG, "DACProxy::set_mute_on() called before setup()");
         return false;
     }
-    ESP_LOGD(TAG, "set_mute_on: for %s", this->active_dac == LINE_OUT? "Line-Out" : "Speaker");
+    bool has_changed = false;
     bool ret = false;
-    if( this->active_dac == LINE_OUT && this->pcm5122_ ){
+    if( this->active_dac == LINE_OUT && this->pcm5122_ && !this->pcm5122_->is_muted() ){
         ret = this->pcm5122_->set_mute_on();
         this->restore_state_.line_out_is_muted = true;
+        has_changed = true;
     }
-    if( this->active_dac == SPEAKER && this->tas2780_ ){
+    if( this->active_dac == SPEAKER && this->tas2780_ && !this->tas2780_->is_muted()){
         ret = this->tas2780_->set_mute_on();
         this->restore_state_.speaker_is_muted = true;
+        has_changed = true;
     }
-    this->save_volume_restore_state_();
+    if( has_changed ){
+        ESP_LOGD(TAG, "set_mute_on: for %s", this->active_dac == LINE_OUT? "Line-Out" : "Speaker");
+        this->save_volume_restore_state_();
+    }    
     return ret;
 }
 
@@ -177,13 +188,18 @@ bool DACProxy::set_volume(float volume){
         ESP_LOGD(TAG, "DACProxy::set_volume() called before setup()");
         return false;
     }
+    bool has_changed = false;
     bool ret = false;
-    if( this->active_dac == LINE_OUT && this->pcm5122_ ){
+    if( this->active_dac == LINE_OUT && this->pcm5122_ && this->pcm5122_->volume() != volume){
         ret = this->pcm5122_->set_volume(volume);
-    } else if( this->active_dac == SPEAKER && this->tas2780_ ){
+        has_changed = true;
+    } else if( this->active_dac == SPEAKER && this->tas2780_ && this->tas2780_->volume() != volume ){
         ret = this->tas2780_->set_volume(volume);
+        has_changed = true;
     }
-    this->save_volume_restore_state_();
+    if( has_changed ){
+        this->save_volume_restore_state_();
+    }    
     return ret;
 }
 

--- a/esphome/components/speaker/media_player/automation.h
+++ b/esphome/components/speaker/media_player/automation.h
@@ -20,6 +20,15 @@ template<typename... Ts> class PlayOnDeviceMediaAction : public Action<Ts...>, p
   }
 };
 
+template<typename... Ts> class RestoreVolumeAction : public Action<Ts...>, public Parented<SpeakerMediaPlayer> {
+  TEMPLATABLE_VALUE(float, volume)
+  TEMPLATABLE_VALUE(bool, muted)
+  void play(const Ts&... x) override {
+    this->parent_->set_volume_(this->volume_.value(x...), true, true);
+    this->parent_->set_mute_state_(this->muted_.value(x...), true);
+  }
+};
+
 
 
 }  // namespace speaker

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -63,14 +63,14 @@ void SpeakerMediaPlayer::setup() {
 
   this->pref_ = global_preferences->make_preference<VolumeRestoreState>(this->get_object_id_hash());
 
-  VolumeRestoreState volume_restore_state;
-  if (this->pref_.load(&volume_restore_state)) {
-    this->set_volume_(volume_restore_state.volume);
-    this->set_mute_state_(volume_restore_state.is_muted);
-  } else {
-    this->set_volume_(FIRST_BOOT_DEFAULT_VOLUME);
-    this->set_mute_state_(false);
-  }
+  // VolumeRestoreState volume_restore_state;
+  // if (this->pref_.load(&volume_restore_state)) {
+  //   this->set_volume_(volume_restore_state.volume);
+  //   this->set_mute_state_(volume_restore_state.is_muted);
+  // } else {
+  //   this->set_volume_(FIRST_BOOT_DEFAULT_VOLUME);
+  //   this->set_mute_state_(false);
+  // }
 
 #ifdef USE_OTA
   ota::get_global_ota_callback()->add_on_state_callback(
@@ -532,13 +532,16 @@ void SpeakerMediaPlayer::save_volume_restore_state_() {
   this->pref_.save(&volume_restore_state);
 }
 
-void SpeakerMediaPlayer::set_mute_state_(bool mute_state) {
-  if (this->media_speaker_ != nullptr) {
-    this->media_speaker_->set_mute_state(mute_state);
+void SpeakerMediaPlayer::set_mute_state_(bool mute_state, bool restore_only) {
+  if (!restore_only){
+    if (this->media_speaker_ != nullptr) {
+      this->media_speaker_->set_mute_state(mute_state);
+    }
+    if (this->announcement_speaker_ != nullptr) {
+      this->announcement_speaker_->set_mute_state(mute_state);
+    }
   }
-  if (this->announcement_speaker_ != nullptr) {
-    this->announcement_speaker_->set_mute_state(mute_state);
-  }
+
 
   bool old_mute_state = this->is_muted_;
   this->is_muted_ = mute_state;
@@ -554,17 +557,19 @@ void SpeakerMediaPlayer::set_mute_state_(bool mute_state) {
   }
 }
 
-void SpeakerMediaPlayer::set_volume_(float volume, bool publish) {
+void SpeakerMediaPlayer::set_volume_(float volume, bool publish, bool restore_only) {
   // Remap the volume to fit with in the configured limits
   float bounded_volume = remap<float, float>(volume, 0.0f, 1.0f, this->volume_min_, this->volume_max_);
 
-  if (this->media_speaker_ != nullptr) {
-    this->media_speaker_->set_volume(bounded_volume);
+  if (!restore_only){
+    if (this->media_speaker_ != nullptr) {
+      this->media_speaker_->set_volume(bounded_volume);
+    }
+    if (this->announcement_speaker_ != nullptr) {
+      this->announcement_speaker_->set_volume(bounded_volume);
+    }
   }
-
-  if (this->announcement_speaker_ != nullptr) {
-    this->announcement_speaker_->set_volume(bounded_volume);
-  }
+  
 
   if (publish) {
     this->volume = volume;

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -89,18 +89,21 @@ class SpeakerMediaPlayer : public Component, public media_player::MediaPlayer {
 #endif
   void set_playlist_delay_ms(AudioPipelineType pipeline_type, uint32_t delay_ms);
 
- protected:
+  /// @brief Updates this->volume and saves volume/mute state to flash for restortation if publish is true.
+  void set_volume_(float volume, bool publish = true, bool restore_only = false);
+  /// @brief Sets the mute state. Restores previous volume if unmuting. Always saves volume/mute state to flash for
+  /// restoration.
+  /// @param mute_state If true, audio will be muted. If false, audio will be unmuted
+  void set_mute_state_(bool mute_state, bool restore_only = false);
+ 
+  protected:
   // Receives commands from HA or from the voice assistant component
   // Sends commands to the media_control_commanda_queue_
   void control(const media_player::MediaPlayerCall &call) override;
 
-  /// @brief Updates this->volume and saves volume/mute state to flash for restortation if publish is true.
-  void set_volume_(float volume, bool publish = true);
+  
 
-  /// @brief Sets the mute state. Restores previous volume if unmuting. Always saves volume/mute state to flash for
-  /// restoration.
-  /// @param mute_state If true, audio will be muted. If false, audio will be unmuted
-  void set_mute_state_(bool mute_state);
+  
 
   /// @brief Saves the current volume and mute state to the flash for restoration.
   void save_volume_restore_state_();


### PR DESCRIPTION
- due to unpredictable boot order the speaker dac got activated on startup as the line-out sensor was not active yet
- moved the line-out sensor check to on_boot with -100 priority
- when the proxy dac reported a new volume/mute to the media_player, the media_player was re sending this information to the DACs
- mute and volume states got reported even though they haven't changed
