### PR TITLE
dac_proxy: Expose DAC selection as HA actions

### DIFF
--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -16,6 +16,17 @@ audio_dac:
           volume: !lambda return id(dac_proxy).volume();
           mute: !lambda return id(dac_proxy).is_muted(); 
 
+api:
+  actions:
+    - action: activate_speaker_dac
+      then:
+        - dac_proxy.activate_speaker:
+
+    - action: activate_lineout_dac
+      then:
+        - dac_proxy.activate_line_out:
+
+
 select:
   - platform: template
     name: Speaker channel output


### PR DESCRIPTION
the active DAC can now selected from HA with the following actions:
action: esphome.satellite1_XXXXXX_activate_speaker_dac
action: esphome.satellite1_XXXXXX_activate_lineout_dac