### PR TITLE
Remove fast connect option from wifi_credentials.yaml

### DIFF
--- a/config/common/wifi_credentials.yaml
+++ b/config/common/wifi_credentials.yaml
@@ -1,7 +1,6 @@
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
-  fast_connect: true
 
   ap:
     ssid: "${node_name}"


### PR DESCRIPTION
Copied from original PR #383 by @remcom 

While the wifi_fast_connect option helps speed up the initial connection, it can lead to suboptimal performance in environments with multiple access points. This is because it connects to the first AP from which it receives a broadcast, rather than selecting the AP with the strongest signal.

Disabling this option allows the device to scan all available access points and connect to the one with the best signal strength, resulting in a more reliable and faster WiFi connection in multi-AP environments.