### PR TITLE
Add id to mww sensitivity selector

### DIFF
--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -235,6 +235,7 @@ script:
 
 select:
   - platform: template
+    id: mww_sensitivity_select 
     name: "Wake word sensitivity"
     optimistic: true
     initial_option: Slightly sensitive

--- a/config/satellite1.dashboard.yaml
+++ b/config/satellite1.dashboard.yaml
@@ -68,4 +68,6 @@ logger:
 #      model: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
 #    # uncomment the following line to remove the default "hey_jarvis" wake word
 #    - id: !remove hey_jarvis
-
+# you also want to remove the sensitivity selector as it is hard coded to the provided models
+#select:
+#  id: !remove mww_sensitivity_select


### PR DESCRIPTION
The mWW sensitivity selector is hard coded for the provided mWW models.
This PR adds an id to that selector in order to remove it easily in custom builds with custom mWW models.