### PR TITLE
Snapcast: Fixes task notify issues for stopping the transport task

### DIFF
--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -185,7 +185,6 @@ static void transport_task_(
                 TimeStats* time_stats ){
     
     constexpr size_t HEADER_SIZE = sizeof(MessageHeader);
-    ESP_LOGI("transport", "Starting task!");
     volatile bool stop_requested = false;
     while( !stop_requested ){
         uint32_t notify_value = 0;

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -185,13 +185,17 @@ static void transport_task_(
                 TimeStats* time_stats ){
     
     constexpr size_t HEADER_SIZE = sizeof(MessageHeader);
-    
-    while( true ){
+    ESP_LOGI("transport", "Starting task!");
+    volatile bool stop_requested = false;
+    while( !stop_requested ){
         uint32_t notify_value = 0;
-        xTaskNotifyWait(0, CONNECT_BIT | STOP_BIT, &notify_value, portMAX_DELAY);
-        if (notify_value & STOP_BIT) break;
-        if (!(notify_value & CONNECT_BIT)) continue;
-        
+        xTaskNotifyWait(0, 0xFFFFFFFFUL, &notify_value, portMAX_DELAY);
+        if (notify_value & STOP_BIT){
+            break;
+        } 
+        if (!(notify_value & CONNECT_BIT)){
+            continue;
+        } 
         
         // === Create socket and connect ===
         int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
@@ -231,14 +235,17 @@ static void transport_task_(
         xTaskNotify(stream_task_handle, CONNECTION_ESTABLISHED_BIT, eSetBits);
         rx_buffer_length = 0;
         bool time_set = false;
+
         while (true) {
             // Check for shutdown signal
-            uint32_t notify_value;
-            if (xTaskNotifyWait( 0, DISCONNECT_BIT, &notify_value, 0) > 0) {
-                break;
+            uint32_t notify_value = 0;
+            if (xTaskNotifyWait(0, DISCONNECT_BIT | STOP_BIT, &notify_value, 0) == pdTRUE) {
+                if (notify_value & STOP_BIT) { stop_requested = true; break; }
+                if (notify_value & DISCONNECT_BIT) { break; }
             }
-
+            
             if (!ring_buffer) {
+                ESP_LOGE("transport", "ring_buffer_not_set");
                 break;
             }
             size_t to_read = 0;
@@ -319,7 +326,6 @@ static void transport_task_(
         close(sock);
         xTaskNotify(stream_task_handle, CONNECTION_CLOSED_BIT, eSetBits);
     }
-    
     xTaskNotify(stream_task_handle, TASK_CLOSING_BIT, eSetBits);
 }
 


### PR DESCRIPTION
fixes:
- transport task could end up in non-blocking loop
- transport task wouldn't shutdown if notified in an unfortunate state