### PR TITLE
Snapcast: Fixes re-connection issues

### DIFF
--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -101,8 +101,18 @@ void SnapcastClient::report_volume(float volume, bool muted) {
 }
 
 void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t volume, bool muted) {
-  ESP_LOGD(TAG, "Stream component changed to state %d.", stream_state);
+  ESP_LOGD(TAG, "Stream component called: %d volume: %d muted: %d.", stream_state, volume, muted);
+  if ((stream_state == StreamState::STREAMING || stream_state == StreamState::CONNECTED_IDLE) &&
+      this->media_player_ != nullptr && volume >= 0 && volume <= 100) {
+    this->media_player_->make_call()
+        .set_volume(volume / 100.)
+        .set_command(muted ? media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_MUTE
+                           : media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_UNMUTE)
+        .perform();
+    return;
+  }
 
+  ESP_LOGD(TAG, "Stream component changed to state %d.", stream_state);
   switch (stream_state) {
     case StreamState::ERROR:
       ESP_LOGE(TAG, "stream: %s", this->stream_.error_msg_.c_str());
@@ -137,15 +147,6 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
     default:
       break;
   }
-
-  if ((stream_state == StreamState::STREAMING || stream_state == StreamState::CONNECTED_IDLE) &&
-      this->media_player_ != nullptr && volume >= 0 && volume <= 100) {
-    this->media_player_->make_call()
-        .set_volume(volume / 100.)
-        .set_command(muted ? media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_MUTE
-                           : media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_UNMUTE)
-        .perform();
-  }
 }
 
 void SnapcastClient::on_stream_update_msg(const StreamInfo &info) {
@@ -157,17 +158,19 @@ void SnapcastClient::on_stream_update_msg(const StreamInfo &info) {
     if (info.status == "playing") {
       ESP_LOGI(TAG, "Playing stream: %s\n", info.id.c_str());
       this->curr_server_url_.stream_name = info.id;
-      if (this->state_ == SnapcastClientState::IDLE) {
+      if (this->state_ == SnapcastClientState::IDLE && !this->play_requested_) {
         this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
       } else {
         this->play_requested_ = true;
       }
     } else if (info.status != "playing") {
       this->play_requested_ = false;
-      this->media_player_->make_call()
-          .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
-          .perform();
-      ESP_LOGI(TAG, "Stopping stream: %s\n", info.id.c_str());
+      if (this->state_ == SnapcastClientState::PLAYING) {
+        this->media_player_->make_call()
+            .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
+            .perform();
+        ESP_LOGI(TAG, "Stopping stream: %s\n", info.id.c_str());
+      }
     }
   }
 }

--- a/esphome/components/snapcast/snapcast_client.h
+++ b/esphome/components/snapcast/snapcast_client.h
@@ -42,6 +42,14 @@ struct SnapcastServer {
   uint32_t rpc_port = 1705;
 };
 
+enum class SnapcastClientState {
+  DISCONNECTED,
+  CONNECTING,
+  IDLE,
+  PLAYING,
+  DISCONNECTING,
+};
+
 /*
 ESPHome Snapcast client, this component manages connections to the Snapcast server and controls the media_player
 component.
@@ -78,6 +86,8 @@ class SnapcastClient : public Component {
   bool enabled_{true};
   bool network_initialized_{false};
   void on_network_ready_();
+  SnapcastClientState state_{SnapcastClientState::DISCONNECTED};
+  bool play_requested_{false};
 
   error_t start_mdns_scan_();
   error_t mdns_task_();

--- a/esphome/components/snapcast/snapcast_rpc.cpp
+++ b/esphome/components/snapcast/snapcast_rpc.cpp
@@ -194,15 +194,7 @@ void SnapcastControlSession::notification_loop() {
                 std::string method = root["method"].as<std::string>();
                 if (method == "Server.OnUpdate") {
                   this->update_from_server_obj_(root["params"]["server"].as<JsonObject>());
-                } else if (method == "Stream.OnUpdate") {
-                  JsonObject params = root["params"];
-                  if (params["id"].as<std::string>() == this->client_state_.stream_id) {
-                    StreamInfo sInfo;
-                    sInfo.from_json(params["stream"]);
-                    if (this->on_stream_update_) {
-                      this->on_stream_update_(sInfo);
-                    }
-                  }
+
                 } else if (method == "Stream.OnProperties") {
                   JsonObject params = root["params"];
                   if (params["id"].as<std::string>() == this->client_state_.stream_id) {
@@ -233,10 +225,12 @@ void SnapcastControlSession::notification_loop() {
                   }
                 } else if (method == "Stream.OnUpdate") {
                   JsonObject params = root["params"];
-                  StreamInfo &sInfo = this->known_streams_[params["id"].as<std::string>()];
-                  sInfo.from_json(params["stream"]);
-                  if (sInfo.id == this->client_state_.stream_id && this->on_stream_update_) {
-                    this->on_stream_update_(sInfo);
+                  if (params["id"].as<std::string>() == this->client_state_.stream_id) {
+                    StreamInfo &sInfo = this->known_streams_[params["id"].as<std::string>()];
+                    sInfo.from_json(params["stream"]);
+                    if (this->on_stream_update_) {
+                      this->on_stream_update_(sInfo);
+                    }
                   }
                 } else if (method == "Client.OnConnect") {
                   JsonObject params = root["params"];

--- a/esphome/components/snapcast/snapcast_rpc.h
+++ b/esphome/components/snapcast/snapcast_rpc.h
@@ -136,6 +136,7 @@ class SnapcastControlSession {
   bool notification_task_should_run_{false};
   TaskHandle_t notification_task_handle_{nullptr};
   std::string recv_buffer_;
+  std::string line_buffer_;
   ClientState client_state_;
   std::map<std::string, StreamInfo> known_streams_;
   std::function<void(const StreamInfo &)> on_stream_update_;

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -20,6 +20,7 @@
 #include "messages.h"
 
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 
 extern "C" {
 #include <sys/select.h>
@@ -37,16 +38,13 @@ namespace snapcast {
 
 static const char *const TAG = "snapcast_stream";
 
-static uint8_t tx_buffer[1024];
-static uint8_t rx_buffer[4096];
-static uint32_t rx_buffer_length = 0;
+static const int32_t TX_BUFFER_SIZE = 1024;
+static const int32_t RX_BUFFER_SIZE = 4096;
 
 static const uint8_t STREAM_TASK_PRIORITY = 14;
 static const uint32_t CONNECTION_TIMEOUT_MS = 2000;
 static const size_t TASK_STACK_SIZE = 4 * 1024;
 static const uint32_t TIME_SYNC_INTERVAL_MS = 2000;
-
-QueueHandle_t outgoing_queue = nullptr;
 
 enum StreamTaskBits : uint32_t {
   // Command sent by the main controller logic to the transport task.
@@ -129,14 +127,14 @@ esp_err_t SnapcastStream::connect(std::string server, uint32_t port) {
       return ESP_FAIL;
     }
   }
-  xTaskNotify(this->stream_task_handle_, CONNECT_BIT, eSetValueWithOverwrite);
+  xTaskNotify(this->stream_task_handle_, CONNECT_BIT, eSetBits);
   return ESP_OK;
 }
 
 esp_err_t SnapcastStream::disconnect() {
   // close connection and stop all running tasks
   if (this->stream_task_handle_) {
-    xTaskNotify(this->stream_task_handle_, STOP_BIT, eSetValueWithOverwrite);
+    xTaskNotify(this->stream_task_handle_, STOP_BIT, eSetBits);
   } else {
     this->set_state_(StreamState::DESTROYED);
   }
@@ -148,39 +146,65 @@ esp_err_t SnapcastStream::start_with_notify(std::weak_ptr<esphome::TimedRingBuff
   ESP_LOGD(TAG, "Starting stream...");
   this->write_ring_buffer_ = ring_buffer;
   this->notification_target_ = notification_task;
-  xTaskNotify(this->stream_task_handle_, START_STREAM_BIT, eSetValueWithOverwrite);
+  xTaskNotify(this->stream_task_handle_, START_STREAM_BIT, eSetBits);
   return ESP_OK;
 }
 
 esp_err_t SnapcastStream::stop_streaming() {
-  xTaskNotify(this->stream_task_handle_, STOP_STREAM_BIT, eSetValueWithOverwrite);
+  xTaskNotify(this->stream_task_handle_, STOP_STREAM_BIT, eSetBits);
   return ESP_OK;
 }
 
 esp_err_t SnapcastStream::report_volume(uint8_t volume, bool muted) {
-  if (volume != this->volume_ || muted_ != this->muted_) {
-    this->volume_ = volume;
-    this->muted_ = muted;
-    xTaskNotify(this->stream_task_handle_, SEND_REPORT_BIT, eSetValueWithOverwrite);
+  const uint8_t old_vol = this->volume_.load(std::memory_order_relaxed);
+  const bool old_muted = this->muted_.load(std::memory_order_relaxed);
+
+  if (volume != old_vol || muted != old_muted) {
+    this->volume_.store(volume, std::memory_order_relaxed);
+    this->muted_.store(muted, std::memory_order_relaxed);
+    xTaskNotify(this->stream_task_handle_, SEND_REPORT_BIT, eSetBits);
   }
   return ESP_OK;
 }
 
-static void transport_task_(std::string server, uint32_t port, std::shared_ptr<ChunkedRingBuffer> ring_buffer,
-                            TaskHandle_t stream_task_handle, TimeStats *time_stats) {
+static void transport_task_(const std::string &server, uint32_t port, std::shared_ptr<ChunkedRingBuffer> ring_buffer,
+                            TaskHandle_t stream_task_handle, TimeStats *time_stats, QueueHandle_t outgoing_queue) {
   constexpr size_t HEADER_SIZE = sizeof(MessageHeader);
+  constexpr size_t MAX_ALLOWED_MSG_SIZE = 8 * 1024;
+  RAMAllocator<uint8_t> psram_allocator;
+  auto *tx_buffer = psram_allocator.allocate(TX_BUFFER_SIZE);
+  if (!tx_buffer) {
+    ESP_LOGE("transport", "Failed to allocate buffers");
+    xTaskNotify(stream_task_handle, TASK_CLOSING_BIT, eSetBits);
+    return;
+  }
+
+  // Small header staging buffer (only header lives outside ringbuffer)
+  uint8_t header_buf[HEADER_SIZE];
+  size_t header_have = 0;
+
+  // Current message assembly state
+  uint8_t *rb_chunk = nullptr;
+  size_t msg_size = 0;  // total bytes (header+payload)
+  size_t msg_have = 0;  // bytes already written into rb_chunk
+  bool have_rx_stamp = false;
+  tv_t rx_stamp;  // captured as early as possible per message
+
+  // If we can't store a message (oversize / ringbuffer full), we discard bytes.
+  bool discarding = false;
+  size_t discard_remaining = 0;
+  uint8_t discard_buf[128];
+
   volatile bool stop_requested = false;
-  volatile bool restart_requested = false;
   while (!stop_requested) {
     uint32_t notify_value = 0;
     xTaskNotifyWait(0, 0xFFFFFFFFUL, &notify_value, portMAX_DELAY);
     if (notify_value & STOP_BIT) {
       break;
     }
-    if (!(notify_value & CONNECT_BIT) && !restart_requested) {
+    if (!(notify_value & CONNECT_BIT)) {
       continue;
     }
-    restart_requested = false;
     // === Create socket and connect ===
     int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if (sock < 0) {
@@ -217,8 +241,6 @@ static void transport_task_(std::string server, uint32_t port, std::shared_ptr<C
 
     // Notify the RX task that the connection is established
     xTaskNotify(stream_task_handle, CONNECTION_ESTABLISHED_BIT, eSetBits);
-    rx_buffer_length = 0;
-    bool time_set = false;
 
     SnapcastMessage *hello_msg = new HelloMessage();
     hello_msg->set_send_time();
@@ -226,16 +248,20 @@ static void transport_task_(std::string server, uint32_t port, std::shared_ptr<C
     int bytes_written = send(sock, (char *) tx_buffer, hello_msg->getMessageSize(), 0);
     delete hello_msg;
 
+    header_have = 0;
+    rb_chunk = nullptr;
+    msg_size = 0;
+    msg_have = 0;
+    discarding = false;
+    discard_remaining = 0;
+    have_rx_stamp = false;
+
     while (true) {
       // Check for shutdown signal
       uint32_t notify_value = 0;
       if (xTaskNotifyWait(0, DISCONNECT_BIT | STOP_BIT, &notify_value, 0) == pdTRUE) {
         if (notify_value & STOP_BIT) {
           stop_requested = true;
-          break;
-        }
-        if (notify_value & CONNECT_BIT) {
-          restart_requested = true;
           break;
         }
         if (notify_value & DISCONNECT_BIT) {
@@ -247,15 +273,6 @@ static void transport_task_(std::string server, uint32_t port, std::shared_ptr<C
         ESP_LOGE("transport", "ring_buffer_not_set");
         break;
       }
-      size_t to_read = 0;
-
-      // Determine what we need next
-      if (rx_buffer_length < HEADER_SIZE) {
-        to_read = HEADER_SIZE - rx_buffer_length;
-      } else {
-        MessageHeader *msg = reinterpret_cast<MessageHeader *>(rx_buffer);
-        to_read = msg->getMessageSize() - rx_buffer_length;
-      }
 
       fd_set read_fds;
       FD_ZERO(&read_fds);
@@ -266,72 +283,156 @@ static void transport_task_(std::string server, uint32_t port, std::shared_ptr<C
         ESP_LOGE("transport", "select() error: errno %d", errno);
         xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
         break;
-      } else if (sel == 0) {
-        // Timeout, nothing ready to read
-      } else if (FD_ISSET(sock, &read_fds)) {
-        tv_t now = tv_t::now();
+      }
 
-        int len = recv(sock, (char *) rx_buffer + rx_buffer_length, to_read, 0);
-        if (len < 0) {
-          int err = errno;
-          ESP_LOGW("transport", "recv() returned -1, errno=%d (%s)", err, strerror(err));
+      if (sel > 0 && FD_ISSET(sock, &read_fds)) {
+        // Capture timestamp ASAP when we learn "readable"
+        if (!have_rx_stamp) {
+          rx_stamp = tv_t::now();
+          have_rx_stamp = true;
+        }
+        int64_t t0 = esp_timer_get_time();  // us
+        const int64_t budget_us = 2000;     // 2ms
+        while (true) {
+          if (esp_timer_get_time() - t0 > budget_us) {
+            break;  // time budget is up, leave inner loop even if more data is queued
+          }
+          // If we are discarding a too-large / unbufferable message, just drain bytes.
+          if (discarding) {
+            if (discard_remaining == 0) {
+              discarding = false;
+              // reset for next header
+              header_have = 0;
+              have_rx_stamp = false;
+              continue;
+            }
 
-          if (err == EAGAIN || err == EWOULDBLOCK) {
-            // Non-blocking socket: no data available right now.
-            // Just continue the loop.
+            const size_t want = std::min(discard_remaining, sizeof(discard_buf));
+            int r = lwip_recv(sock, (char *) discard_buf, want, 0);
+            if (r > 0) {
+              discard_remaining -= (size_t) r;
+              continue;
+            }
+            if (r == 0) {
+              ESP_LOGI("transport", "recv() EOF (peer closed)");
+              xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
+              goto connection_done;
+            }
+            int e = errno;
+            if (e == EAGAIN || e == EWOULDBLOCK)
+              break;
+            ESP_LOGE("transport", "recv(discard) error: errno=%d (%s)", e, strerror(e));
+            xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
+            goto connection_done;
+          }
+
+          // If we don't have a ringbuffer chunk yet, we must be reading header.
+          if (rb_chunk == nullptr) {
+            if (header_have < HEADER_SIZE) {
+              int r = lwip_recv(sock, (char *) (header_buf + header_have), HEADER_SIZE - header_have, 0);
+              if (r > 0) {
+                header_have += (size_t) r;
+                // keep looping; maybe more data available
+              } else if (r == 0) {
+                ESP_LOGI("transport", "recv() EOF (peer closed)");
+                xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
+                goto connection_done;
+              } else {
+                int e = errno;
+                if (e == EAGAIN || e == EWOULDBLOCK)
+                  break;  // no more for now
+                ESP_LOGE("transport", "recv(header) error: errno=%d (%s)", e, strerror(e));
+                xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
+                goto connection_done;
+              }
+            }
+
+            // Header complete? Acquire ringbuffer chunk for whole message.
+            if (header_have == HEADER_SIZE) {
+              auto *hdr = reinterpret_cast<MessageHeader *>(header_buf);
+              msg_size = hdr->getMessageSize();
+
+              // Basic sanity (avoid absurd sizes / corrupted header)
+              if (msg_size < HEADER_SIZE || msg_size > MAX_ALLOWED_MSG_SIZE) {
+                ESP_LOGW("transport", "Invalid msg_size=%u, discarding", (unsigned) msg_size);
+                // Header seems to be corrupted, reconnect
+                goto connection_done;
+              }
+
+              // Acquire a chunk of exactly msg_size
+              ring_buffer->acquire_write_chunk(&rb_chunk, msg_size, 0);
+              if (!rb_chunk) {
+                // ringbuffer full; discard the remainder of this message (body bytes)
+                ESP_LOGW("transport", "Ringbuffer full, discarding message (%u bytes)", (unsigned) msg_size);
+                discarding = true;
+                discard_remaining = msg_size - HEADER_SIZE;
+                header_have = 0;
+                have_rx_stamp = false;
+                continue;
+              }
+
+              // Copy header into ringbuffer chunk
+              memcpy(rb_chunk, header_buf, HEADER_SIZE);
+              msg_have = HEADER_SIZE;
+
+              // Apply the captured "readable" timestamp to the header
+              auto *out_hdr = reinterpret_cast<MessageHeader *>(rb_chunk);
+              out_hdr->received = rx_stamp;
+
+              // Clear header staging for next message
+              header_have = 0;
+              // Keep have_rx_stamp true until we finish this message
+            }
+
+            // If we just acquired chunk, fall through and start reading body
+            if (rb_chunk == nullptr) {
+              // still collecting header
+              continue;
+            }
+          }
+
+          // We have rb_chunk => read body directly into it
+          const size_t remaining = msg_size - msg_have;
+          if (remaining == 0) {
+            // Completed message; publish it
+            ring_buffer->release_write_chunk(rb_chunk, msg_size);
+            rb_chunk = nullptr;
+            msg_size = 0;
+            msg_have = 0;
+            have_rx_stamp = false;  // next message gets its own stamp
             continue;
           }
 
-          int so_err = 0;
-          socklen_t so_err_len = sizeof(so_err);
-          if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &so_err, &so_err_len) == 0) {
-            ESP_LOGE("transport", "SO_ERROR=%d (%s)", so_err, strerror(so_err));
-          } else {
-            ESP_LOGE("transport", "getsockopt(SO_ERROR) failed: errno=%d (%s)", errno, strerror(errno));
-          }
-
-          // Real error -> treat as disconnect
-          xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
-          break;
-        }
-
-        if (len == 0) {
-          // Peer closed gracefully (FIN)
-          ESP_LOGI("transport", "recv() EOF (peer closed)");
-          xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
-          break;
-        }
-
-        rx_buffer_length += len;
-
-        // Do we have a full header yet?
-        if (rx_buffer_length >= HEADER_SIZE) {
-          MessageHeader *msg = reinterpret_cast<MessageHeader *>(rx_buffer);
-
-          if (!time_set) {
-            msg->received = now;
-            time_set = true;
-          }
-
-          // Do we have a full message yet?
-          if (rx_buffer_length >= msg->getMessageSize()) {
-            // At this point, rx_buffer has a complete message
-
-            // Push raw message to ring buffer or queue
-            uint8_t *chunk = nullptr;
-            size_t total_size = msg->getMessageSize();
-            ring_buffer->acquire_write_chunk(&chunk, total_size, 0);
-            if (chunk) {
-              memcpy(chunk, rx_buffer, total_size);
-              ring_buffer->release_write_chunk(chunk, total_size);
-            } else {
-              // Ring buffer full! Dropping packet.
+          int r = lwip_recv(sock, (char *) (rb_chunk + msg_have), remaining, 0);
+          if (r > 0) {
+            msg_have += (size_t) r;
+            if (msg_have == msg_size) {
+              ring_buffer->release_write_chunk(rb_chunk, msg_size);
+              rb_chunk = nullptr;
+              msg_size = 0;
+              msg_have = 0;
+              have_rx_stamp = false;
             }
-            // Reset for next message
-            rx_buffer_length = 0;
-            time_set = false;
+            continue;  // maybe more data still available
           }
+
+          if (r == 0) {
+            ESP_LOGI("transport", "recv() EOF (peer closed)");
+            xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
+            goto connection_done;
+          }
+
+          int e = errno;
+          if (e == EAGAIN || e == EWOULDBLOCK) {
+            // no more data right now; keep partial message state and return to select()
+            break;
+          }
+
+          ESP_LOGE("transport", "recv(body) error: errno=%d (%s)", e, strerror(e));
+          xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
+          goto connection_done;
         }
+        taskYIELD();
       }
 
       SnapcastMessage *msg;
@@ -344,10 +445,21 @@ static void transport_task_(std::string server, uint32_t port, std::shared_ptr<C
         }
         delete msg;  // Free the message after serialization
       }
+    }  // connected loop
+  connection_done:
+    if (rb_chunk) {
+      auto *h = reinterpret_cast<MessageHeader *>(rb_chunk);
+      h->type = static_cast<uint16_t>(message_type::kBase);  // receiver will drop
+      h->typed_message_size = 0;
+      ring_buffer->release_write_chunk(rb_chunk, msg_size);
+      rb_chunk = nullptr;
     }
     close(sock);
     xTaskNotify(stream_task_handle, CONNECTION_CLOSED_BIT, eSetBits);
+    if (stop_requested)
+      break;
   }
+  free(tx_buffer);
   xTaskNotify(stream_task_handle, TASK_CLOSING_BIT, eSetBits);
 }
 
@@ -372,7 +484,7 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
     }
 
     MessageHeader *msg = reinterpret_cast<MessageHeader *>(chunk);
-    if (len < msg->getMessageSize()) {
+    if (msg->getMessageType() == message_type::kBase || len < msg->getMessageSize()) {
       // incomplete message, drop it
       read_ring_buffer->release_read_chunk(chunk);
       vTaskDelay(pdMS_TO_TICKS(1));
@@ -502,10 +614,8 @@ void SnapcastStream::stream_task_() {
     return;
   }
 
-  // For example: allow up to 10 pending messages
-  outgoing_queue = xQueueCreate(10, sizeof(SnapcastMessage *));
-
-  if (outgoing_queue == NULL) {
+  this->outgoing_queue_ = xQueueCreate(10, sizeof(SnapcastMessage *));
+  if (this->outgoing_queue_ == NULL) {
     ESP_LOGE(TAG, "Failed to create outgoing queue!");
     return;
   }
@@ -516,6 +626,7 @@ void SnapcastStream::stream_task_() {
     uint32_t port;
     TaskHandle_t stream_task_handle;
     TimeStats *time_stats_;
+    QueueHandle_t outgoing_queue;
   };
 
   ReadTaskArgs *args = new ReadTaskArgs();
@@ -524,12 +635,14 @@ void SnapcastStream::stream_task_() {
   args->port = this->port_;
   args->stream_task_handle = xTaskGetCurrentTaskHandle();
   args->time_stats_ = &this->time_stats_;  // Pass the time stats reference
+  args->outgoing_queue = this->outgoing_queue_;
 
   TaskHandle_t transport_task_handle = nullptr;
   BaseType_t result = xTaskCreatePinnedToCore(
       [](void *param) {
         auto *args = static_cast<ReadTaskArgs *>(param);
-        transport_task_(args->server, args->port, args->buffer, args->stream_task_handle, args->time_stats_);
+        transport_task_(args->server, args->port, args->buffer, args->stream_task_handle, args->time_stats_,
+                        args->outgoing_queue);
         delete args;
         vTaskDelete(nullptr);  // Task cleans itself up after loop exits
       },
@@ -548,6 +661,7 @@ void SnapcastStream::stream_task_() {
   constexpr TickType_t STREAMING_WAIT = pdMS_TO_TICKS(5);
   constexpr TickType_t IDLE_WAIT = pdMS_TO_TICKS(100);
 
+  bool reconnect_pending = false;
   uint32_t notify_value;
   this->set_state_(StreamState::DISCONNECTED);
   while (true) {
@@ -573,7 +687,7 @@ void SnapcastStream::stream_task_() {
       }
 
       if (notify_value & SEND_REPORT_BIT) {
-        if (this->state_ != StreamState::DISCONNECTED && outgoing_queue != nullptr) {
+        if (this->state_ != StreamState::DISCONNECTED) {
           this->send_report_();
         }
       }
@@ -588,25 +702,35 @@ void SnapcastStream::stream_task_() {
         }
       }
 
-      if (notify_value & CONNECTION_CLOSED_BIT) {
-        this->set_state_(StreamState::DISCONNECTED);
-      }
-
       if (notify_value & TASK_CLOSING_BIT) {
         // tx_rx task is closing, we can exit the loop
         this->set_state_(StreamState::DISCONNECTED);
         break;
       }
-
-      if (notify_value & CONNECTION_FAILED_BIT || notify_value & CONNECTION_DROPPED_BIT) {
+      if (notify_value & CONNECTION_FAILED_BIT) {
         if (this->reconnect_on_error_()) {
-          this->error_msg_ = "Failed to connect or connection dropped";
           this->set_state_(StreamState::RECONNECTING);
           vTaskDelay(pdMS_TO_TICKS(1000));
           xTaskNotify(transport_task_handle, CONNECT_BIT, eSetBits);
+        }
+      }
+
+      if (notify_value & CONNECTION_DROPPED_BIT) {
+        if (this->reconnect_on_error_()) {
+          this->error_msg_ = "Failed to connect or connection dropped";
+          this->set_state_(StreamState::RECONNECTING);
+          reconnect_pending = true;
         } else {
           this->error_msg_ = "Failed to connect or connection dropped";
           this->set_state_(StreamState::ERROR);
+        }
+      }
+
+      if (notify_value & CONNECTION_CLOSED_BIT) {
+        this->set_state_(StreamState::DISCONNECTED);
+        if (reconnect_pending) {
+          reconnect_pending = false;
+          xTaskNotify(transport_task_handle, CONNECT_BIT, eSetBits);
         }
       }
     }
@@ -618,10 +742,22 @@ void SnapcastStream::stream_task_() {
         this->error_msg_ = "Error reading or processing messages, initiating a new session";
         this->set_state_(StreamState::RECONNECTING);
         this->start_after_connecting_ = true;
-        xTaskNotify(transport_task_handle, DISCONNECT_BIT | CONNECT_BIT, eSetBits);
+        reconnect_pending = true;
+        xTaskNotify(transport_task_handle, DISCONNECT_BIT, eSetBits);
       }
     }
   }
+
+  if (this->outgoing_queue_) {
+    // Drain and delete any pending messages so they don't leak.
+    SnapcastMessage *m = nullptr;
+    while (xQueueReceive(this->outgoing_queue_, &m, 0) == pdPASS) {
+      delete m;
+    }
+    vQueueDelete(this->outgoing_queue_);
+    this->outgoing_queue_ = nullptr;
+  }
+
   this->set_state_(StreamState::DESTROYED);
 }
 
@@ -666,8 +802,12 @@ void SnapcastStream::stop_streaming_() {
 }
 
 void SnapcastStream::send_message_(SnapcastMessage *msg) {
-  assert(msg->getMessageSize() <= sizeof(tx_buffer));
-  if (xQueueSend(outgoing_queue, &msg, 0) != pdPASS) {
+  auto q = this->outgoing_queue_;
+  if (!q || msg->getMessageSize() > TX_BUFFER_SIZE) {
+    delete msg;
+    return;
+  }
+  if (xQueueSend(q, &msg, 0) != pdPASS) {
     delete msg;  // Clean up if failed
   }
 }
@@ -678,14 +818,16 @@ void SnapcastStream::send_hello_() {
 }
 
 void SnapcastStream::send_report_() {
-  SnapcastMessage *msg = new ClientInfoMessage(this->volume_, this->muted_);
+  const uint8_t vol = this->volume_.load(std::memory_order_relaxed);
+  const bool muted = this->muted_.load(std::memory_order_relaxed);
+  SnapcastMessage *msg = new ClientInfoMessage(vol, muted);
   this->send_message_(msg);
 }
 
 void SnapcastStream::send_time_sync_() {
   uint32_t sync_interval = TIME_SYNC_INTERVAL_MS;
   if (!this->time_stats_.is_ready()) {
-    sync_interval = 0;
+    sync_interval = 500;
     SnapcastMessage *time_sync_msg0 = new TimeMessage();
     this->send_message_(time_sync_msg0);
   }
@@ -701,12 +843,13 @@ void SnapcastStream::on_time_msg_(MessageHeader msg, tv_t latency_c2s) {
   // latency_s2c = t_client-recv - t_server-sent + t_network_latency
   // time diff between server and client as (latency_c2s - latency_s2c) / 2
   tv_t latency_s2c = msg.received - msg.sent;
-  time_stats_.add_offset(msg.refersTo, (latency_c2s - latency_s2c) / 2, msg.received);
+  const tv_t offset_sample = (latency_c2s - latency_s2c) / 2;
+  time_stats_.add_offset(msg.refersTo, offset_sample, msg.received);
   const tv_t est_offset = time_stats_.get_estimate();
   this->est_time_diff_.store(est_offset, std::memory_order_relaxed);
 #if SNAPCAST_DEBUG
-  printf("msg.id: %d, msg.sent: %lld, msg.received: %lld\n", msg.id, msg.sent.to_microseconds(),
-         msg.received.to_microseconds());
+  printf("msg.id: %d, msg.sent: %lld, msg.received: %lld sample: %lld\n", msg.id, msg.sent.to_microseconds(),
+         msg.received.to_microseconds(), est_offset.to_microseconds());
   printf("latency_c2s: %lld at-curr-est: %lld\n", latency_c2s.to_microseconds(),
          (latency_c2s - est_offset).to_microseconds());
   printf("latency_s2c: %lld = %lld - %lld at-curr-est: %lld\n", latency_s2c.to_microseconds(),
@@ -730,10 +873,12 @@ void SnapcastStream::on_time_msg_(MessageHeader msg, tv_t latency_c2s) {
 void SnapcastStream::on_server_settings_msg_(const ServerSettingsMessage &msg) {
   this->server_buffer_size_ = msg.buffer_ms_;
   this->latency_ = msg.latency_;
-  this->volume_ = msg.volume_;
-  this->muted_ = msg.muted_;
+  this->volume_.store(msg.volume_, std::memory_order_relaxed);
+  this->muted_.store(msg.muted_, std::memory_order_relaxed);
+
   if (this->on_status_update_) {
-    this->on_status_update_(this->state_, this->volume_, this->muted_);
+    this->on_status_update_(this->state_, this->volume_.load(std::memory_order_relaxed),
+                            this->muted_.load(std::memory_order_relaxed));
   }
 }
 

--- a/esphome/components/snapcast/snapcast_stream.h
+++ b/esphome/components/snapcast/snapcast_stream.h
@@ -108,8 +108,8 @@ class SnapcastStream {
   uint32_t port_;
   uint32_t server_buffer_size_{0};
   int32_t latency_{0};
-  uint8_t volume_{0};
-  bool muted_{false};
+  std::atomic<uint8_t> volume_{0};
+  std::atomic<bool> muted_{false};
   uint32_t reconnect_counter_{0};
 
   StreamState state_{StreamState::DESTROYED};
@@ -132,6 +132,7 @@ class SnapcastStream {
   TaskHandle_t stream_task_handle_{nullptr};
   StaticTask_t task_stack_;
   StackType_t *task_stack_buffer_{nullptr};
+  QueueHandle_t outgoing_queue_{nullptr};
 
   void stream_task_();
 

--- a/esphome/components/snapcast/time_stats.h
+++ b/esphome/components/snapcast/time_stats.h
@@ -92,6 +92,7 @@ class TimeStats {
   void set_request_time(uint16_t msg_id, tv_t request_time) {
     const int64_t us = request_time.to_microseconds();
 
+    xSemaphoreTake(req_mu_, portMAX_DELAY);
     if (pending_req_send_us_.size() >= MAX_PENDING_REQ) {
       // Drop the oldest entry (simple O(n) fallback; MAX_PENDING_REQ is tiny)
       auto oldest = pending_req_send_us_.begin();
@@ -101,7 +102,7 @@ class TimeStats {
       }
       pending_req_send_us_.erase(oldest);
     }
-    xSemaphoreTake(req_mu_, portMAX_DELAY);
+
     pending_req_send_us_[msg_id] = us;
     xSemaphoreGive(req_mu_);
   }
@@ -218,6 +219,9 @@ class TimeStats {
     reset_kalman_state_();
 
     smoothing_ = base_smoothing_ = cfg_.base_smoothing;
+    xSemaphoreTake(req_mu_, portMAX_DELAY);
+    pending_req_send_us_.clear();
+    xSemaphoreGive(req_mu_);
   }
 
   size_t outliers() const { return outlier_count_; }
@@ -257,7 +261,7 @@ class TimeStats {
   // ---------------- RTT adaptive stats ----------------
   SemaphoreHandle_t req_mu_ = xSemaphoreCreateMutex();
   std::unordered_map<uint16_t, int64_t> pending_req_send_us_;
-  static constexpr size_t MAX_PENDING_REQ = 8;
+  static constexpr size_t MAX_PENDING_REQ = 32;
   bool rtt_inited_ = false;
   int64_t min_rtt_us_ = 0;
   int64_t last_rtt_us_ = 0;


### PR DESCRIPTION
This PR addresses issues that occur when the Satellite1 gets forced to reconnect multiple times, e.g. due to snapcast server restarts.
It also changes to read messages directly into ring-buffer chunks instead of into a rx_buffer first. There was a potential buffer overflow which got fixed with this change.
