### PR TITLE
Fusb302b: fix rounding error in contract string

### DIFF
--- a/config/common/home_assistant.yaml
+++ b/config/common/home_assistant.yaml
@@ -64,7 +64,7 @@ switch:
 text_sensor:
   - platform: template
     id: pd_state_text
-    name: "USB-C Power Draw"
+    name: "USB-C Power Supply"
     icon: "mdi:usb-c-port"
     entity_category: "diagnostic"
     update_interval: never

--- a/esphome/components/fusb302b/pd.cpp
+++ b/esphome/components/fusb302b/pd.cpp
@@ -145,8 +145,8 @@ bool PowerDelivery::check_ams() {
 std::string PowerDelivery::get_contract_string(pd_contract_t contract) const {
   std::ostringstream oss;
   oss.precision(3);
-  oss << (contract.max_i / 100);
-  oss << "A @ ";
+  oss << (static_cast<float>(contract.max_i) / 100.f);
+  oss << "A (max) @ ";
   oss << contract.max_v * 5 / 100;
   oss << "V";
   return oss.str();
@@ -156,6 +156,7 @@ void PowerDelivery::set_contract_(pd_contract_t contract) {
   this->accepted_contract_ = contract;
   this->contract = this->get_contract_string(contract);
   this->contract_voltage = contract.max_v * 5 / 100;
+  this->contract_max_current = static_cast<float>(contract.max_i) / 100.f;
   this->contract_timer_ = millis();
 }
 

--- a/esphome/components/fusb302b/pd.h
+++ b/esphome/components/fusb302b/pd.h
@@ -134,7 +134,8 @@ class PowerDelivery {
  public:
   PowerDeliveryState state{PD_STATE_DISCONNECTED};
   int contract_voltage{5};
-  std::string contract{"0.5A @ 5V"};
+  float contract_max_current{.5f};
+  std::string contract{"0.5A (max) @ 5V"};
   PowerDeliveryState prev_state_{PD_STATE_DISCONNECTED};
 
   bool request_voltage(int voltage);


### PR DESCRIPTION
- fixes a rounding error in the PD contract string (used by the HA text sensor) 
- add `contract_max_current` property
- rename text sensor to USB-C Power Supply
- add `(max)` to contract string

The previous sensor name was potentially misleading, as it could be interpreted as the actual current being drawn. These changes clarify that the value represents the maximum current available from the power source, not the real-time current consumption.