### PR TITLE
Migrate to ESPHome 2026.2

### DIFF
--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -18,7 +18,7 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2026.1.5
+      esphome-version: 2026.2.0
       release-summary: develop-branch
       release-url:
       release-version:

--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -18,7 +18,7 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2026.2.0
+      esphome-version: 2026.2.4
       release-summary: develop-branch
       release-url:
       release-version:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -80,7 +80,7 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2026.1.5
+      esphome-version: 2026.2.0
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
   push-tag:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -80,7 +80,7 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2026.2.0
+      esphome-version: 2026.2.4
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
   push-tag:

--- a/config/common/timer.yaml
+++ b/config/common/timer.yaml
@@ -88,10 +88,10 @@ script:
     then:
       - lambda: |
           const auto timers = id(va).get_timers();
-          auto output_timer = timers.begin()->second;
-          for (auto &iterable_timer : timers) {
-            if (iterable_timer.second.is_active && iterable_timer.second.seconds_left <= output_timer.seconds_left) {
-              output_timer = iterable_timer.second;
+          auto output_timer = *timers.begin();
+          for (const auto &timer : timers) {
+            if (timer.is_active && timer.seconds_left <= output_timer.seconds_left) {
+              output_timer = timer;
             }
           }
           id(first_active_timer) = output_timer;
@@ -102,11 +102,9 @@ script:
       - lambda: |
           const auto timers = id(va).get_timers();
           bool output = false;
-          if (timers.size() > 0) {
-            for (auto &iterable_timer : timers) {
-              if(iterable_timer.second.is_active) {
-                output = true;
-              }
+          for (const auto &timer : timers) {
+            if (timer.is_active) {
+              output = true;
             }
           }
           id(is_timer_active) = output;

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -36,7 +36,7 @@ esphome:
   name: ${node_name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2026.1.0
+  min_version: 2026.2.0
 
   project:
     name: ${company_name}.${project_name}

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -325,7 +325,7 @@ void MicroWakeWord::loop() {
           ESP_LOGD(TAG, "Detected '%s' with sliding average probability is %.2f and max probability is %.2f",
                    detection_event.wake_word->c_str(), (detection_event.average_probability / uint8_to_float_divisor),
                    (detection_event.max_probability / uint8_to_float_divisor));
-          this->wake_word_detected_trigger_->trigger(*detection_event.wake_word);
+          this->wake_word_detected_trigger_.trigger(*detection_event.wake_word);
           if (this->stop_after_detection_) {
             this->stop();
           }

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -60,7 +60,7 @@ class MicroWakeWord : public Component
 
   void set_stop_after_detection(bool stop_after_detection) { this->stop_after_detection_ = stop_after_detection; }
 
-  Trigger<std::string> *get_wake_word_detected_trigger() const { return this->wake_word_detected_trigger_; }
+  Trigger<std::string> *get_wake_word_detected_trigger() { return &this->wake_word_detected_trigger_; }
 
   void add_wake_word_model(WakeWordModel *model);
 
@@ -78,7 +78,7 @@ class MicroWakeWord : public Component
 
  protected:
   microphone::MicrophoneSource *microphone_source_{nullptr};
-  Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();
+  Trigger<std::string> wake_word_detected_trigger_;
   State state_{State::STOPPED};
 
   std::weak_ptr<RingBuffer> ring_buffer_;

--- a/esphome/components/mixer/speaker/automation.h
+++ b/esphome/components/mixer/speaker/automation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/automation.h"
 #include "mixer_speaker.h"
 
 #ifdef USE_ESP32

--- a/esphome/components/pcm5122/pcm5122.h
+++ b/esphome/components/pcm5122/pcm5122.h
@@ -13,7 +13,6 @@ class PCM5122 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   bool set_mute_off() override;
   bool set_mute_on() override;

--- a/esphome/components/resampler/speaker/resampler_speaker.h
+++ b/esphome/components/resampler/speaker/resampler_speaker.h
@@ -16,7 +16,6 @@ namespace resampler {
 
 class ResamplerSpeaker : public Component, public speaker::Speaker {
  public:
-  float get_setup_priority() const override { return esphome::setup_priority::DATA; }
   void setup() override;
   void loop() override;
 

--- a/esphome/components/satellite1/audio_dac/dac_proxy.cpp
+++ b/esphome/components/satellite1/audio_dac/dac_proxy.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "dac_proxy";
 
 void DACProxy::setup() {
   ESP_LOGD(TAG, "Setting up DACProxy...");
-  this->pref_ = global_preferences->make_preference<DACProxyRestoreState>(this->get_preference_hash());
+  this->pref_ = this->make_entity_preference<DACProxyRestoreState>();
 
   if (this->pref_.load(&this->restore_state_)) {
     ESP_LOGD(TAG, "Read preferences from flash");

--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -24,7 +24,6 @@
 #include "esp_transport.h"
 #include "esp_transport_tcp.h"
 
-
 #include "esp_mac.h"
 #include "mdns.h"
 #include <cstring>

--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -24,6 +24,7 @@
 #include "esp_transport.h"
 #include "esp_transport_tcp.h"
 
+
 #include "esp_mac.h"
 #include "mdns.h"
 #include <cstring>
@@ -247,7 +248,7 @@ static void mdns_print_results(mdns_result_t *results) {
 }
 
 static bool test_tcp_connect(const esp_ip4_addr_t &ip, uint16_t port, uint32_t timeout_ms) {
-  int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+  int sock = lwip_socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
   if (sock < 0) {
     return false;
   }

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -290,7 +290,7 @@ static void transport_task_(SnapcastStream *self, std::shared_ptr<ChunkedRingBuf
     }
 
     // === Create socket and connect ===
-    int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    int sock = lwip_socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if (sock < 0) {
       ESP_LOGE("transport", "Failed to create socket: errno %d", errno);
       xTaskNotify(stream_task_handle, CONNECTION_CLOSED_BIT, eSetBits);

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -2,7 +2,7 @@ from esphome import automation
 import esphome.codegen as cg
 from esphome.components import audio, audio_dac
 import esphome.config_validation as cv
-from esphome.const import CONF_DATA, CONF_ID, CONF_VOLUME
+from esphome.const import CONF_AUDIO_DAC, CONF_DATA, CONF_ID, CONF_VOLUME
 from esphome.core import CORE
 from esphome.coroutine import coroutine_with_priority
 
@@ -10,8 +10,6 @@ AUTO_LOAD = ["audio"]
 CODEOWNERS = ["@jesserockz", "@kahrendt"]
 
 IS_PLATFORM_COMPONENT = True
-
-CONF_AUDIO_DAC = "audio_dac"
 
 speaker_ns = cg.esphome_ns.namespace("speaker")
 

--- a/esphome/components/speaker/media_player/__init__.py
+++ b/esphome/components/speaker/media_player/__init__.py
@@ -162,8 +162,14 @@ def _read_audio_file_and_type(file_config):
 
     import puremagic
 
-    file_type: str = puremagic.from_string(data)
-    file_type = file_type.removeprefix(".")
+    try:
+        file_type: str = puremagic.from_string(data)
+        file_type = file_type.removeprefix(".")
+    except puremagic.PureError as e:
+        raise cv.Invalid(
+            f"Unable to determine audio file type of '{path}'. "
+            f"Try re-encoding the file into a supported format. Details: {e}"
+        )
 
     media_file_type = audio.AUDIO_FILE_TYPE_ENUM["NONE"]
     if file_type in ("wav"):

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -550,9 +550,9 @@ void SpeakerMediaPlayer::set_mute_state_(bool mute_state, bool restore_only) {
 
   if (old_mute_state != mute_state) {
     if (mute_state) {
-      this->defer([this]() { this->mute_trigger_->trigger(); });
+      this->defer([this]() { this->mute_trigger_.trigger(); });
     } else {
-      this->defer([this]() { this->unmute_trigger_->trigger(); });
+      this->defer([this]() { this->unmute_trigger_.trigger(); });
     }
   }
 #if USE_SNAPCAST
@@ -591,7 +591,7 @@ void SpeakerMediaPlayer::set_volume_(float volume, bool publish, bool restore_on
     this->snapcast_client_->report_volume(volume, this->is_muted_);
   }
 #endif
-  this->defer([this, volume]() { this->volume_trigger_->trigger(volume); });
+  this->defer([this, volume]() { this->volume_trigger_.trigger(volume); });
 }
 
 }  // namespace speaker

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -113,6 +113,20 @@ void SpeakerMediaPlayer::set_playlist_delay_ms(AudioPipelineType pipeline_type, 
   }
 }
 
+void SpeakerMediaPlayer::stop_and_unpause_media_() {
+  this->media_pipeline_->stop();
+  this->unpause_media_remaining_ = 3;
+  this->set_interval("unpause_med", 50, [this]() {
+    if (this->media_pipeline_state_ == AudioPipelineState::STOPPED) {
+      this->cancel_interval("unpause_med");
+      this->media_pipeline_->set_pause_state(false);
+      this->is_paused_ = false;
+    } else if (--this->unpause_media_remaining_ == 0) {
+      this->cancel_interval("unpause_med");
+    }
+  });
+}
+
 void SpeakerMediaPlayer::watch_media_commands_() {
   if (!this->is_ready()) {
     return;
@@ -150,16 +164,9 @@ void SpeakerMediaPlayer::watch_media_commands_() {
           if (this->is_paused_) {
             // If paused, stop the media pipeline and unpause it after confirming its stopped. This avoids playing a
             // short segment of the paused file before starting the new one.
-            this->media_pipeline_->stop();
-            this->set_retry("unpause_med", 50, 3, [this](const uint8_t remaining_attempts) {
-              if (this->media_pipeline_state_ == AudioPipelineState::STOPPED) {
-                this->media_pipeline_->set_pause_state(false);
-                this->is_paused_ = false;
-                return RetryResult::DONE;
-              }
-              return RetryResult::RETRY;
-            });
+            this->stop_and_unpause_media_();
           }
+          // TODO: do we still need this extra stop?
           this->media_pipeline_->stop();
         }
         this->media_playlist_.push_back(playlist_item);
@@ -189,27 +196,21 @@ void SpeakerMediaPlayer::watch_media_commands_() {
               this->cancel_timeout("next_ann");
               this->announcement_playlist_.clear();
               this->announcement_pipeline_->stop();
-              this->set_retry("unpause_ann", 50, 3, [this](const uint8_t remaining_attempts) {
+              this->unpause_announcement_remaining_ = 3;
+              this->set_interval("unpause_ann", 50, [this]() {
                 if (this->announcement_pipeline_state_ == AudioPipelineState::STOPPED) {
+                  this->cancel_interval("unpause_ann");
                   this->announcement_pipeline_->set_pause_state(false);
-                  return RetryResult::DONE;
+                } else if (--this->unpause_announcement_remaining_ == 0) {
+                  this->cancel_interval("unpause_ann");
                 }
-                return RetryResult::RETRY;
               });
             }
           } else {
             if (this->media_pipeline_ != nullptr) {
               this->cancel_timeout("next_media");
               this->media_playlist_.clear();
-              this->media_pipeline_->stop();
-              this->set_retry("unpause_med", 50, 3, [this](const uint8_t remaining_attempts) {
-                if (this->media_pipeline_state_ == AudioPipelineState::STOPPED) {
-                  this->media_pipeline_->set_pause_state(false);
-                  this->is_paused_ = false;
-                  return RetryResult::DONE;
-                }
-                return RetryResult::RETRY;
-              });
+              this->stop_and_unpause_media_();
             }
           }
 

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -123,6 +123,9 @@ class SpeakerMediaPlayer : public Component,
   /// media pipelines are defined.
   inline bool single_pipeline_() { return (this->media_speaker_ == nullptr); }
 
+  /// Stops the media pipeline and polls until stopped to unpause it, avoiding an audible glitch.
+  void stop_and_unpause_media_();
+
   // Processes commands from media_control_command_queue_.
   void watch_media_commands_();
 
@@ -156,6 +159,8 @@ class SpeakerMediaPlayer : public Component,
 
   bool is_paused_{false};
   bool is_muted_{false};
+  uint8_t unpause_media_remaining_{0};
+  uint8_t unpause_announcement_remaining_{0};
 
   // The amount to change the volume on volume up/down commands
   float volume_increment_;

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -94,9 +94,9 @@ class SpeakerMediaPlayer : public Component,
   }
 #endif
 
-  Trigger<> *get_mute_trigger() const { return this->mute_trigger_; }
-  Trigger<> *get_unmute_trigger() const { return this->unmute_trigger_; }
-  Trigger<float> *get_volume_trigger() const { return this->volume_trigger_; }
+  Trigger<> *get_mute_trigger() { return &this->mute_trigger_; }
+  Trigger<> *get_unmute_trigger() { return &this->unmute_trigger_; }
+  Trigger<float> *get_volume_trigger() { return &this->volume_trigger_; }
 
   void play_file(audio::AudioFile *media_file, bool announcement, bool enqueue);
 #if USE_SNAPCAST
@@ -166,9 +166,9 @@ class SpeakerMediaPlayer : public Component,
   // Used to save volume/mute state for restoration on reboot
   ESPPreferenceObject pref_;
 
-  Trigger<> *mute_trigger_ = new Trigger<>();
-  Trigger<> *unmute_trigger_ = new Trigger<>();
-  Trigger<float> *volume_trigger_ = new Trigger<float>();
+  Trigger<> mute_trigger_;
+  Trigger<> unmute_trigger_;
+  Trigger<float> volume_trigger_;
 };
 
 }  // namespace speaker

--- a/esphome/components/tas2780/tas2780.h
+++ b/esphome/components/tas2780/tas2780.h
@@ -15,7 +15,6 @@ class TAS2780 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void loop() override;
 
   void init();

--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -15,7 +15,6 @@ void VersionTextSensor::setup() {
     this->publish_state(ESPHOME_VERSION "+" + this->git_commit_ + " " + App.get_compilation_time());
   }
 }
-float VersionTextSensor::get_setup_priority() const { return setup_priority::DATA; }
 void VersionTextSensor::set_hide_timestamp(bool hide_timestamp) { this->hide_timestamp_ = hide_timestamp; }
 void VersionTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Version Text Sensor", this); }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-esphome==2026.1.5
+esphome==2026.2.0
 setuptools
 yamllint
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-esphome==2026.2.0
+esphome==2026.2.4
 setuptools
 yamllint
 pre-commit


### PR DESCRIPTION
- Adapt to breaking change in VoiceAssistant-Timer (#13857)
- explicitly use of lwip_socket
- migrate to use `this->make_entity_preference`
- bump to ESPHome 2026.2.0

TODO:
- [ ] ~~check whether to use ESPHome socket component~~
   => won't do now, shouldn't delay merging this PR 
- [x] check all customized components for upstream changes