### PR TITLE
Snapcast: Further cleanups and fixes

### DIFF
--- a/esphome/components/audio/audio_reader.cpp
+++ b/esphome/components/audio/audio_reader.cpp
@@ -373,7 +373,7 @@ AudioReaderState AudioReader::http_read_() {
 #if USE_SNAPCAST
 AudioReaderState AudioReader::snapcast_read_() {
   uint32_t state_value;
-  if (xTaskNotifyWait(0, 0, &state_value, pdMS_TO_TICKS(500)) == pdTRUE) {
+  if (xTaskNotifyWait(0, 0, &state_value, pdMS_TO_TICKS(50)) == pdTRUE) {
     snapcast::StreamState new_state = static_cast<snapcast::StreamState>(state_value);
     if (new_state == snapcast::StreamState::ERROR) {
       return AudioReaderState::FAILED;
@@ -388,8 +388,8 @@ AudioReaderState AudioReader::snapcast_read_() {
 
 esp_err_t AudioReader::stop() {
 #if USE_SNAPCAST
-  if (this->snapcast_stream_) {
-    this->snapcast_stream_->stop_streaming();
+  if (this->snapcast_client_) {
+    this->snapcast_client_->stop_streaming();
   }
 #endif
   auto rb = this->output_ring_buffer_.lock();

--- a/esphome/components/audio/audio_reader.cpp
+++ b/esphome/components/audio/audio_reader.cpp
@@ -199,15 +199,15 @@ esp_err_t AudioReader::start(const std::string &uri, AudioFileType &file_type) {
   return ESP_OK;
 }
 #if USE_SNAPCAST
-esp_err_t AudioReader::start(snapcast::SnapcastStream *stream, AudioFileType &file_type) {
+esp_err_t AudioReader::start(snapcast::SnapcastClient *client, AudioFileType &file_type) {
   if (this->snapcast_stream_ != nullptr) {
     return ESP_FAIL;
   }
-  if (stream == nullptr) {
+  if (client == nullptr) {
     return ESP_FAIL;
   }
-
-  this->snapcast_stream_ = stream;
+  this->snapcast_client_ = client;
+  this->snapcast_stream_ = client->get_stream();
   this->audio_file_type_ = AudioFileType::FLAC;
   file_type = AudioFileType::FLAC;
   this->snapcast_stream_->start_with_notify(this->output_ring_buffer_, xTaskGetCurrentTaskHandle());

--- a/esphome/components/audio/audio_reader.cpp
+++ b/esphome/components/audio/audio_reader.cpp
@@ -210,14 +210,24 @@ esp_err_t AudioReader::start(snapcast::SnapcastStream *stream, AudioFileType &fi
   this->snapcast_stream_ = stream;
   this->audio_file_type_ = AudioFileType::FLAC;
   file_type = AudioFileType::FLAC;
-
-  auto rb = this->output_ring_buffer_.lock();
-  if (rb) {
-    rb->reset();
-  }
-
   this->snapcast_stream_->start_with_notify(this->output_ring_buffer_, xTaskGetCurrentTaskHandle());
 
+  uint32_t timeout_at = millis() + 2000;
+  while (true) {
+    uint32_t state_value;
+    if (xTaskNotifyWait(0, 0xFFFFFFFFUL, &state_value, pdMS_TO_TICKS(500)) == pdTRUE) {
+      snapcast::StreamState new_state = static_cast<snapcast::StreamState>(state_value);
+      if (new_state == snapcast::StreamState::ERROR) {
+        return -1;
+      }
+      if (new_state == snapcast::StreamState::STREAMING) {
+        return ESP_OK;
+      }
+    }
+    if (millis() > timeout_at) {
+      return -1;
+    }
+  }
   return ESP_OK;
 }
 #endif
@@ -368,7 +378,7 @@ AudioReaderState AudioReader::snapcast_read_() {
     if (new_state == snapcast::StreamState::ERROR) {
       return AudioReaderState::FAILED;
     }
-    if (new_state == snapcast::StreamState::CONNECTED_IDLE) {
+    if (new_state == snapcast::StreamState::CONNECTED_IDLE || new_state == snapcast::StreamState::DESTROYED) {
       return AudioReaderState::FINISHED;
     }
   }

--- a/esphome/components/audio/audio_reader.h
+++ b/esphome/components/audio/audio_reader.h
@@ -7,6 +7,7 @@
 #include "chunked_ring_buffer.h"
 
 #if USE_SNAPCAST
+#include "esphome/components/snapcast/snapcast_client.h"
 #include "esphome/components/snapcast/snapcast_stream.h"
 #endif
 
@@ -54,7 +55,7 @@ class AudioReader {
   /// @param stream Pointer to a snapcast stream
   /// @param file_type AudioFileType variable passed-by-reference indicating the type of file being read.
   /// @return ESP_OK
-  esp_err_t start(snapcast::SnapcastStream *stream, AudioFileType &file_type);
+  esp_err_t start(snapcast::SnapcastClient *client, AudioFileType &file_type);
 #endif
 
   /// @brief Reads new file data from the source and sends to the ring buffer sink.
@@ -94,6 +95,7 @@ class AudioReader {
 
 #if USE_SNAPCAST
   snapcast::SnapcastStream *snapcast_stream_{nullptr};
+  snapcast::SnapcastClient *snapcast_client_{nullptr};
 #endif
 };
 }  // namespace audio

--- a/esphome/components/snapcast/__init__.py
+++ b/esphome/components/snapcast/__init__.py
@@ -1,4 +1,5 @@
 import esphome.config_validation as cv
+from esphome.components import socket
 import esphome.codegen as cg
 from esphome import automation
 from esphome.const import CONF_ID
@@ -9,6 +10,12 @@ DEPENDENCIES = ["network", "audio"]
 CODEOWNERS = ["@gnumpi"]
 
 CONF_SERVER_IP = "server_ip"
+
+def _consume_sockets(config):
+    """Register socket needs for this component."""
+    # Example: 1 mdns scan + 2 concurrent client connections
+    socket.consume_sockets(3, "snapcast")(config)
+    return config
 
 def AUTO_LOAD():
     if CORE.is_esp8266 or CORE.is_libretiny:
@@ -27,11 +34,13 @@ DisableAction = snapcast_ns.class_(
     "DisableAction", automation.Action, cg.Parented.template(SnapcastClient)
 )
 
-CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(): cv.declare_id(SnapcastClient),
-    cv.Optional(CONF_SERVER_IP) : cv.ipaddress
-})
-
+CONFIG_SCHEMA = cv.All(
+    cv.Schema({
+        cv.GenerateID(): cv.declare_id(SnapcastClient),
+        cv.Optional(CONF_SERVER_IP) : cv.ipaddress
+    }),
+     _consume_sockets,
+)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/esphome/components/snapcast/messages.h
+++ b/esphome/components/snapcast/messages.h
@@ -326,7 +326,7 @@ class ClientInfoMessage : public JsonMessage {
   }
   void construct_json_(JsonObject root) const override {
     root["volume"] = this->volume_;
-    root["muted"] = this->muted_ ? "true" : "false";
+    root["muted"] = this->muted_;
   }
 
  protected:

--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -33,11 +33,23 @@ namespace snapcast {
 
 static const char *const TAG = "snapcast_client";
 
+constexpr uint32_t STREAM_INIT_INTERVAL_MS = 500;
+constexpr uint32_t MAX_STREAM_INIT_RETRIES = 5;
+constexpr uint32_t CONNECTING_INTERVAL_MS = 2000;  // short drops are handled internally inside the stream task
+
 void SnapcastClient::setup() { this->network_initialized_ = false; }
 
 void SnapcastClient::loop() {
-  if (!this->enabled_) {
-    this->disable_loop();
+  if (this->disable_requested_ || this->stream_.is_terminating()) {
+    if (this->stream_.finalize_termination()) {
+      this->disable_requested_ = false;
+      this->play_requested_ = false;
+      this->stop_playing_requested_ = false;
+      this->state_ = SnapcastClientState::UNINITIALIZED;
+      if (!this->enabled_) {
+        this->disable_loop();
+      }
+    }
     return;
   }
 
@@ -49,19 +61,73 @@ void SnapcastClient::loop() {
     }
     return;
   }
+  
+  switch (this->state_) {
+    case SnapcastClientState::UNINITIALIZED:
+      if (this->next_stream_init_at_ > millis()) {
+        return;
+      }
+      if (this->stream_.init() == ESP_OK) {
+        this->stream_init_counter_ = 0;
+        this->state_ = SnapcastClientState::DISCONNECTED;
+      } else {
+        this->next_stream_init_at_ = millis() + STREAM_INIT_INTERVAL_MS;
+        this->stream_init_counter_++;
+        if (this->stream_init_counter_ > MAX_STREAM_INIT_RETRIES) {
+          ESP_LOGE(TAG, "Reached maximum number of tries to init stream instance, giving up...");
+          this->disable_requested_ = true;
+          return;
+        }
+      }
+      break;
 
-  if (this->state_ == SnapcastClientState::DISCONNECTED) {
-    if (this->server_) {
-      auto &s = *this->server_;
-      this->state_ = SnapcastClientState::CONNECTING;
-      this->connect_to_server(s.server_ip, s.stream_port, s.rpc_port);
-    } else if (!this->cfg_server_ip_.empty()) {
-      this->server_.emplace(SnapcastServer{.server_ip = this->cfg_server_ip_});
-    } else if (millis() > this->mdns_last_scan_ + this->mdns_scan_interval_ms_) {
-      this->start_mdns_scan_();
-    }
+    case SnapcastClientState::DISCONNECTED:
+      if (this->server_ && millis() > this->next_connecting_at_) {
+        auto &s = *this->server_;
+        this->next_connecting_at_ = millis() + CONNECTING_INTERVAL_MS;
+        ESP_LOGI(TAG, "Trying to connect to %s : %d", s.server_ip.c_str(), s.stream_port);
+        if (this->connect_to_server(s.server_ip, s.stream_port, s.rpc_port) == ESP_OK) {
+          this->state_ = SnapcastClientState::CONNECTING;
+        }
+      } else if (!this->cfg_server_ip_.empty()) {
+        this->server_.emplace(SnapcastServer{.server_ip = this->cfg_server_ip_});
+      } else if (millis() > this->mdns_last_scan_ + this->mdns_scan_interval_ms_) {
+        this->start_mdns_scan_();
+      }
+      break;
+
+    case SnapcastClientState::CONNECTING:
+      if (this->stream_.is_connected() && this->cntrl_session_.is_connected()) {
+        this->state_ = SnapcastClientState::CONNECTED;
+      } else if (millis() > this->connection_timeout_at_) {
+        auto &s = *this->server_;
+        ESP_LOGE(TAG, "Reached timeout while trying to connect to %s", s.server_ip.c_str());
+        this->server_.reset();
+        this->state_ = SnapcastClientState::DISCONNECTED;
+      }
+      break;
+
+    case SnapcastClientState::CONNECTED:
+      if (this->stream_.server_is_lost()) {
+        auto &s = *this->server_;
+        ESP_LOGW(TAG, "Connection to %s lost", s.server_ip.c_str());
+        this->server_.reset();
+        this->next_connecting_at_ = millis() + CONNECTING_INTERVAL_MS;
+        this->state_ = SnapcastClientState::DISCONNECTED;
+      } else if (this->play_requested_ && !this->stream_.is_streaming()) {
+        this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
+        this->stop_playing_requested_ = false;
+        this->play_requested_ = false;
+      } else if (this->stop_playing_requested_) {
+        this->stream_.stop_streaming();
+        this->stop_playing_requested_ = false;
+      }      
+      break;
+
+    default:
+      break;
   }
-}
+};
 
 void SnapcastClient::on_network_ready_() {
   this->client_id_ = get_mac_address_pretty();
@@ -79,19 +145,31 @@ void SnapcastClient::on_network_ready_() {
 }
 
 error_t SnapcastClient::connect_to_server(std::string url, uint32_t stream_port, uint32_t rpc_port) {
-  // establish a binary stream connection to the snapcast server, MA only shows connected clients as players
-  err_t res = this->stream_.connect(url, stream_port);
-  if (res != ESP_OK)
+  // establish a stream connection to the snapcast server, MA only shows connected clients as players
+  esp_err_t res = this->stream_.connect(url, stream_port);
+  if (res != ESP_OK){
+    ESP_LOGW(TAG, "Failed connecting to %s:%d err:%d\n", url.c_str(), stream_port, res);
     return res;
-
+  }
+    
   // register for snapcast control events, used to control the media player component
-  this->cntrl_session_.connect(url, rpc_port);
-
+  res = this->cntrl_session_.connect(url, rpc_port);
+  if (res != ESP_OK){
+    ESP_LOGW(TAG, "Failed connecting to %s:%d err:%d\n", url.c_str(), rpc_port, res);
+    return res;
+  }
+  
+  this->connection_timeout_at_ = millis() + CONNECTING_INTERVAL_MS;
   this->curr_server_url_.server_ip = url;
   this->curr_server_url_.stream_port = stream_port;
   this->curr_server_url_.rpc_port = rpc_port;
   return ESP_OK;
 }
+
+void SnapcastClient::stop_streaming(){
+  this->cntrl_session_.request_stop();
+}
+
 
 void SnapcastClient::report_volume(float volume, bool muted) {
   if (this->stream_.is_connected()) {
@@ -114,46 +192,49 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
   }
 
   ESP_LOGD(TAG, "Stream component changed to state %d.", stream_state);
-  switch (stream_state) {
-    case StreamState::ERROR:
-      ESP_LOGE(TAG, "stream: %s", this->stream_.error_msg_.c_str());
-      // this->stream_.disconnect();
-      // this->cntrl_session_.disconnect();
-      // this->server_.reset();
-      // this->enable_loop();
-      // this->state_ = SnapcastClientState::DISCONNECTING;
-      break;
-    case StreamState::RECONNECTING:
-      ESP_LOGI(TAG, "Reconnecting after error: %s", this->stream_.error_msg_.c_str());
-      this->state_ = SnapcastClientState::CONNECTING;
-      break;
-    case StreamState::DESTROYED:
-      this->state_ = SnapcastClientState::DISCONNECTED;
-      this->cntrl_session_.disconnect();
-      this->server_.reset();
-      this->play_requested_ = false;
-
-      if (this->enabled_) {
-        this->enable_loop();
-      }
-      break;
-    case StreamState::CONNECTED_IDLE:
-      this->state_ = SnapcastClientState::IDLE;
-      if (this->play_requested_) {
-        ESP_LOGD(TAG, "Calling MediaPlayer Play from on_stream_state_update");
-        this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
-        this->play_requested_ = false;
-      }
-      ESP_LOGD(TAG, "Disabling loop.");
-      this->disable_loop();
-      break;
-    case StreamState::STREAMING:
-      this->state_ = SnapcastClientState::PLAYING;
-      this->play_requested_ = false;
-      break;
-    default:
-      break;
+  if (stream_state == StreamState::ERROR){
+    ESP_LOGE(TAG, "stream: %s", this->stream_.error_msg_.c_str());
   }
+  // switch (stream_state) {
+  //   case StreamState::ERROR:
+      
+  //     // this->stream_.disconnect();
+  //     // this->cntrl_session_.disconnect();
+  //     // this->server_.reset();
+  //     // this->enable_loop();
+  //     // this->state_ = SnapcastClientState::DISCONNECTING;
+  //     break;
+  //   // case StreamState::RECONNECTING:
+  //   //   ESP_LOGI(TAG, "Reconnecting after error: %s", this->stream_.error_msg_.c_str());
+  //   //   this->state_ = SnapcastClientState::CONNECTING;
+  //   //   break;
+  //   // case StreamState::DESTROYED:
+  //   //   this->state_ = SnapcastClientState::DISCONNECTED;
+  //   //   this->cntrl_session_.disconnect();
+  //   //   this->server_.reset();
+  //   //   this->play_requested_ = false;
+
+  //   //   if (this->enabled_) {
+  //   //     this->enable_loop();
+  //   //   }
+  //   //   break;
+  //   // case StreamState::CONNECTED_IDLE:
+  //   //   this->state_ = SnapcastClientState::IDLE;
+  //   //   if (this->play_requested_) {
+  //   //     ESP_LOGD(TAG, "Calling MediaPlayer Play from on_stream_state_update");
+  //   //     this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
+  //   //     this->play_requested_ = false;
+  //   //   }
+  //   //   ESP_LOGD(TAG, "Disabling loop.");
+  //   //   this->disable_loop();
+  //   //   break;
+  //   // case StreamState::STREAMING:
+  //   //   this->state_ = SnapcastClientState::PLAYING;
+  //   //   this->play_requested_ = false;
+  //   //   break;
+  //   default:
+  //     break;
+  // }
 }
 
 void SnapcastClient::on_stream_update_msg(StreamStatus status, std::string stream_id) {
@@ -162,21 +243,23 @@ void SnapcastClient::on_stream_update_msg(StreamStatus status, std::string strea
     if (status == StreamStatus::PLAYING) {
       ESP_LOGI(TAG, "Playing stream: %s\n", stream_id.c_str());
       this->curr_server_url_.stream_name = stream_id;
-      if (this->state_ == SnapcastClientState::IDLE && !this->play_requested_) {
-        ESP_LOGD(TAG, "Calling MediaPlayer Play from on_stream_update_msg");
-        this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
-      } else {
-        this->play_requested_ = true;
-      }
+      this->play_requested_ = true;
+      // if (this->state_ == SnapcastClientState::IDLE && !this->play_requested_) {
+      //   ESP_LOGD(TAG, "Calling MediaPlayer Play from on_stream_update_msg");
+      //   this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
+      // } else {
+      //   this->play_requested_ = true;
+      // }
     } else if (status == StreamStatus::IDLE) {
       this->play_requested_ = false;
-      if (this->state_ == SnapcastClientState::PLAYING) {
-        // this->media_player_->make_call()
-        //     .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
-        //     .perform();
-        this->stream_.stop_streaming();
-        ESP_LOGI(TAG, "Stopping stream: %s\n", stream_id.c_str());
-      }
+      this->stop_playing_requested_ = true;
+      // if (this->state_ == SnapcastClientState::PLAYING) {
+      //   // this->media_player_->make_call()
+      //   //     .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
+      //   //     .perform();
+      //   this->stream_.stop_streaming();
+      //   ESP_LOGI(TAG, "Stopping stream: %s\n", stream_id.c_str());
+      // }
     }
   }
 }

--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -61,7 +61,7 @@ void SnapcastClient::loop() {
     }
     return;
   }
-  
+
   switch (this->state_) {
     case SnapcastClientState::UNINITIALIZED:
       if (this->next_stream_init_at_ > millis()) {
@@ -121,7 +121,7 @@ void SnapcastClient::loop() {
       } else if (this->stop_playing_requested_) {
         this->stream_.stop_streaming();
         this->stop_playing_requested_ = false;
-      }      
+      }
       break;
 
     default:
@@ -147,18 +147,18 @@ void SnapcastClient::on_network_ready_() {
 error_t SnapcastClient::connect_to_server(std::string url, uint32_t stream_port, uint32_t rpc_port) {
   // establish a stream connection to the snapcast server, MA only shows connected clients as players
   esp_err_t res = this->stream_.connect(url, stream_port);
-  if (res != ESP_OK){
+  if (res != ESP_OK) {
     ESP_LOGW(TAG, "Failed connecting to %s:%d err:%d\n", url.c_str(), stream_port, res);
     return res;
   }
-    
+
   // register for snapcast control events, used to control the media player component
   res = this->cntrl_session_.connect(url, rpc_port);
-  if (res != ESP_OK){
+  if (res != ESP_OK) {
     ESP_LOGW(TAG, "Failed connecting to %s:%d err:%d\n", url.c_str(), rpc_port, res);
     return res;
   }
-  
+
   this->connection_timeout_at_ = millis() + CONNECTING_INTERVAL_MS;
   this->curr_server_url_.server_ip = url;
   this->curr_server_url_.stream_port = stream_port;
@@ -166,10 +166,7 @@ error_t SnapcastClient::connect_to_server(std::string url, uint32_t stream_port,
   return ESP_OK;
 }
 
-void SnapcastClient::stop_streaming(){
-  this->cntrl_session_.request_stop();
-}
-
+void SnapcastClient::stop_streaming() { this->cntrl_session_.request_stop(); }
 
 void SnapcastClient::report_volume(float volume, bool muted) {
   if (this->stream_.is_connected()) {
@@ -180,7 +177,7 @@ void SnapcastClient::report_volume(float volume, bool muted) {
 }
 
 void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t volume, bool muted) {
-  ESP_LOGD(TAG, "Stream component called: %d volume: %d muted: %d.", stream_state, volume, muted);
+  ESP_LOGD(TAG, "Stream component called sate: %d volume: %d muted: %d.", stream_state, volume, muted);
   if ((stream_state == StreamState::STREAMING || stream_state == StreamState::CONNECTED_IDLE) &&
       this->media_player_ != nullptr && volume >= 0 && volume <= 100) {
     this->media_player_->make_call()
@@ -191,50 +188,9 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
     return;
   }
 
-  ESP_LOGD(TAG, "Stream component changed to state %d.", stream_state);
-  if (stream_state == StreamState::ERROR){
+  if (stream_state == StreamState::ERROR) {
     ESP_LOGE(TAG, "stream: %s", this->stream_.error_msg_.c_str());
   }
-  // switch (stream_state) {
-  //   case StreamState::ERROR:
-      
-  //     // this->stream_.disconnect();
-  //     // this->cntrl_session_.disconnect();
-  //     // this->server_.reset();
-  //     // this->enable_loop();
-  //     // this->state_ = SnapcastClientState::DISCONNECTING;
-  //     break;
-  //   // case StreamState::RECONNECTING:
-  //   //   ESP_LOGI(TAG, "Reconnecting after error: %s", this->stream_.error_msg_.c_str());
-  //   //   this->state_ = SnapcastClientState::CONNECTING;
-  //   //   break;
-  //   // case StreamState::DESTROYED:
-  //   //   this->state_ = SnapcastClientState::DISCONNECTED;
-  //   //   this->cntrl_session_.disconnect();
-  //   //   this->server_.reset();
-  //   //   this->play_requested_ = false;
-
-  //   //   if (this->enabled_) {
-  //   //     this->enable_loop();
-  //   //   }
-  //   //   break;
-  //   // case StreamState::CONNECTED_IDLE:
-  //   //   this->state_ = SnapcastClientState::IDLE;
-  //   //   if (this->play_requested_) {
-  //   //     ESP_LOGD(TAG, "Calling MediaPlayer Play from on_stream_state_update");
-  //   //     this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
-  //   //     this->play_requested_ = false;
-  //   //   }
-  //   //   ESP_LOGD(TAG, "Disabling loop.");
-  //   //   this->disable_loop();
-  //   //   break;
-  //   // case StreamState::STREAMING:
-  //   //   this->state_ = SnapcastClientState::PLAYING;
-  //   //   this->play_requested_ = false;
-  //   //   break;
-  //   default:
-  //     break;
-  // }
 }
 
 void SnapcastClient::on_stream_update_msg(StreamStatus status, std::string stream_id) {
@@ -244,22 +200,9 @@ void SnapcastClient::on_stream_update_msg(StreamStatus status, std::string strea
       ESP_LOGI(TAG, "Playing stream: %s\n", stream_id.c_str());
       this->curr_server_url_.stream_name = stream_id;
       this->play_requested_ = true;
-      // if (this->state_ == SnapcastClientState::IDLE && !this->play_requested_) {
-      //   ESP_LOGD(TAG, "Calling MediaPlayer Play from on_stream_update_msg");
-      //   this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
-      // } else {
-      //   this->play_requested_ = true;
-      // }
     } else if (status == StreamStatus::IDLE) {
       this->play_requested_ = false;
       this->stop_playing_requested_ = true;
-      // if (this->state_ == SnapcastClientState::PLAYING) {
-      //   // this->media_player_->make_call()
-      //   //     .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
-      //   //     .perform();
-      //   this->stream_.stop_streaming();
-      //   ESP_LOGI(TAG, "Stopping stream: %s\n", stream_id.c_str());
-      // }
     }
   }
 }

--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -73,8 +73,9 @@ void SnapcastClient::on_network_ready_() {
   });
 
   // callback on status changes, received from snapcast control (RPC) stream
-  this->cntrl_session_.set_on_stream_update(
-      [this](const StreamInfo &info) { this->defer([this, info]() { this->on_stream_update_msg(info); }); });
+  this->cntrl_session_.set_on_stream_update([this](StreamStatus status, std::string stream_id) {
+    this->defer([this, status, stream_id]() { this->on_stream_update_msg(status, stream_id); });
+  });
 }
 
 error_t SnapcastClient::connect_to_server(std::string url, uint32_t stream_port, uint32_t rpc_port) {
@@ -130,6 +131,7 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
       this->state_ = SnapcastClientState::DISCONNECTED;
       this->cntrl_session_.disconnect();
       this->server_.reset();
+      this->play_requested_ = false;
 
       if (this->enabled_) {
         this->enable_loop();
@@ -138,6 +140,7 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
     case StreamState::CONNECTED_IDLE:
       this->state_ = SnapcastClientState::IDLE;
       if (this->play_requested_) {
+        ESP_LOGD(TAG, "Calling MediaPlayer Play from on_stream_state_update");
         this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
         this->play_requested_ = false;
       }
@@ -146,33 +149,32 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
       break;
     case StreamState::STREAMING:
       this->state_ = SnapcastClientState::PLAYING;
+      this->play_requested_ = false;
       break;
     default:
       break;
   }
 }
 
-void SnapcastClient::on_stream_update_msg(const StreamInfo &info) {
-  ESP_LOGI(TAG, "Snapcast-stream updated: status=%s", info.status.c_str());
-  if (info.status == "unknown") {
-    return;
-  }
+void SnapcastClient::on_stream_update_msg(StreamStatus status, std::string stream_id) {
+  ESP_LOGI(TAG, "Snapcast-stream updated: status=%d", status);
   if (this->media_player_ != nullptr) {
-    if (info.status == "playing") {
-      ESP_LOGI(TAG, "Playing stream: %s\n", info.id.c_str());
-      this->curr_server_url_.stream_name = info.id;
+    if (status == StreamStatus::PLAYING) {
+      ESP_LOGI(TAG, "Playing stream: %s\n", stream_id.c_str());
+      this->curr_server_url_.stream_name = stream_id;
       if (this->state_ == SnapcastClientState::IDLE && !this->play_requested_) {
+        ESP_LOGD(TAG, "Calling MediaPlayer Play from on_stream_update_msg");
         this->media_player_->make_call().set_media_url(this->curr_server_url_.to_str()).perform();
       } else {
         this->play_requested_ = true;
       }
-    } else if (info.status != "playing") {
+    } else if (status == StreamStatus::IDLE) {
       this->play_requested_ = false;
       if (this->state_ == SnapcastClientState::PLAYING) {
         this->media_player_->make_call()
             .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
             .perform();
-        ESP_LOGI(TAG, "Stopping stream: %s\n", info.id.c_str());
+        ESP_LOGI(TAG, "Stopping stream: %s\n", stream_id.c_str());
       }
     }
   }

--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -128,6 +128,9 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
       break;
     case StreamState::DESTROYED:
       this->state_ = SnapcastClientState::DISCONNECTED;
+      this->cntrl_session_.disconnect();
+      this->server_.reset();
+
       if (this->enabled_) {
         this->enable_loop();
       }

--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -117,11 +117,11 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
   switch (stream_state) {
     case StreamState::ERROR:
       ESP_LOGE(TAG, "stream: %s", this->stream_.error_msg_.c_str());
-      this->stream_.disconnect();
-      this->cntrl_session_.disconnect();
-      this->server_.reset();
-      this->enable_loop();
-      this->state_ = SnapcastClientState::DISCONNECTING;
+      // this->stream_.disconnect();
+      // this->cntrl_session_.disconnect();
+      // this->server_.reset();
+      // this->enable_loop();
+      // this->state_ = SnapcastClientState::DISCONNECTING;
       break;
     case StreamState::RECONNECTING:
       ESP_LOGI(TAG, "Reconnecting after error: %s", this->stream_.error_msg_.c_str());
@@ -171,9 +171,10 @@ void SnapcastClient::on_stream_update_msg(StreamStatus status, std::string strea
     } else if (status == StreamStatus::IDLE) {
       this->play_requested_ = false;
       if (this->state_ == SnapcastClientState::PLAYING) {
-        this->media_player_->make_call()
-            .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
-            .perform();
+        // this->media_player_->make_call()
+        //     .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
+        //     .perform();
+        this->stream_.stop_streaming();
         ESP_LOGI(TAG, "Stopping stream: %s\n", stream_id.c_str());
       }
     }

--- a/esphome/components/snapcast/snapcast_client.h
+++ b/esphome/components/snapcast/snapcast_client.h
@@ -43,10 +43,10 @@ struct SnapcastServer {
 };
 
 enum class SnapcastClientState {
+  UNINITIALIZED,
   DISCONNECTED,
   CONNECTING,
-  IDLE,
-  PLAYING,
+  CONNECTED,
   DISCONNECTING,
 };
 
@@ -76,18 +76,31 @@ class SnapcastClient : public Component {
   };
   void disable() {
     this->enabled_ = false;
-    this->stream_.disconnect();
-    this->cntrl_session_.disconnect();
+    this->disable_requested_ = true;
+    this->stream_.terminate();
+    this->cntrl_session_.disconnect();    
   };
   error_t connect_to_url(std::string url) { return ESP_OK; }
   bool is_snapcast_url(std::string url) { return url.starts_with("snapcast://"); }
 
+  void stop_streaming();
+
  protected:
   bool enabled_{true};
+  bool disable_requested_{false};
   bool network_initialized_{false};
-  void on_network_ready_();
-  SnapcastClientState state_{SnapcastClientState::DISCONNECTED};
   bool play_requested_{false};
+  bool stop_playing_requested_{false};
+
+  uint32_t next_stream_init_at_{0};
+  uint32_t stream_init_counter_{0};
+  uint32_t next_connecting_at_{0};
+  uint32_t connection_timeout_at_{0};
+
+  
+  void on_network_ready_();
+  SnapcastClientState state_{SnapcastClientState::UNINITIALIZED};
+  
 
   error_t start_mdns_scan_();
   error_t mdns_task_();

--- a/esphome/components/snapcast/snapcast_client.h
+++ b/esphome/components/snapcast/snapcast_client.h
@@ -67,7 +67,7 @@ class SnapcastClient : public Component {
 
   // report volume to the snapcast server via the binary stream connection
   void report_volume(float volume, bool muted);
-  void on_stream_update_msg(const StreamInfo &info);
+  void on_stream_update_msg(StreamStatus status, std::string stream_id);
   void on_stream_state_update(StreamState state, uint8_t volume, bool muted);
 
   void enable() {

--- a/esphome/components/snapcast/snapcast_client.h
+++ b/esphome/components/snapcast/snapcast_client.h
@@ -26,7 +26,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/component.h"
 
-#include "esphome/components/speaker/media_player/speaker_media_player.h"
+#include "esphome/components/media_player/media_player.h"
 
 #include "messages.h"
 #include "snapcast_stream.h"
@@ -61,7 +61,7 @@ class SnapcastClient : public Component {
   void loop() override;
 
   error_t connect_to_server(std::string url, uint32_t stream_port = 1704, uint32_t rpc_port = 1705);
-  void set_media_player(esphome::speaker::SpeakerMediaPlayer *media_player) { this->media_player_ = media_player; }
+  void set_media_player(media_player::MediaPlayer *media_player) { this->media_player_ = media_player; }
   void set_server_ip(std::string server_ip) { this->cfg_server_ip_ = server_ip; }
   SnapcastStream *get_stream() { return &this->stream_; }
 
@@ -104,7 +104,7 @@ class SnapcastClient : public Component {
   SnapcastUrl curr_server_url_;
   SnapcastStream stream_;
   SnapcastControlSession cntrl_session_;
-  esphome::speaker::SpeakerMediaPlayer *media_player_;
+  media_player::MediaPlayer *media_player_;
 };
 
 }  // namespace snapcast

--- a/esphome/components/snapcast/snapcast_client.h
+++ b/esphome/components/snapcast/snapcast_client.h
@@ -78,7 +78,7 @@ class SnapcastClient : public Component {
     this->enabled_ = false;
     this->disable_requested_ = true;
     this->stream_.terminate();
-    this->cntrl_session_.disconnect();    
+    this->cntrl_session_.disconnect();
   };
   error_t connect_to_url(std::string url) { return ESP_OK; }
   bool is_snapcast_url(std::string url) { return url.starts_with("snapcast://"); }
@@ -97,10 +97,8 @@ class SnapcastClient : public Component {
   uint32_t next_connecting_at_{0};
   uint32_t connection_timeout_at_{0};
 
-  
   void on_network_ready_();
   SnapcastClientState state_{SnapcastClientState::UNINITIALIZED};
-  
 
   error_t start_mdns_scan_();
   error_t mdns_task_();

--- a/esphome/components/snapcast/snapcast_rpc.cpp
+++ b/esphome/components/snapcast/snapcast_rpc.cpp
@@ -26,8 +26,6 @@
 namespace esphome {
 namespace snapcast {
 
-
-
 static const char *const TAG = "snapcast_rpc";
 
 static const size_t TASK_STACK_SIZE = 4 * 1024;
@@ -38,126 +36,8 @@ enum RPCTaskBits : uint32_t {
   RECONNECT_BIT = (1 << 1),
 };
 
-#if 0
-esp_err_t SnapcastControlSession::init() {
-  if (this->task_handle_ != nullptr) {
-    if (!this->task_is_exiting_) {
-      // task already running
-      return ESP_OK;
-    }
-    if (!this->finalize_termination()) {
-      ESP_LOGW(TAG, "Exiting task still in progress");
-      return ESP_ERR_INVALID_STATE;
-    }
-  }
-
-  if (this->task_stack_buffer_ == nullptr) {
-    RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-    this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
-    if (this->task_stack_buffer_ == nullptr) {
-      this->set_state_(StreamState::ERROR);
-      return ESP_ERR_NO_MEM;
-    }
-  }
-
-  if (!this->config_mutex_) {
-    this->config_mutex_ = xSemaphoreCreateMutex();
-    if (!this->config_mutex_)
-      return ESP_FAIL;
-  }
-  
-  if (!this->rpc_queue_) {
-    this->rpc_queue_ = xQueueCreate(4, sizeof(RpcRequest *));
-  }
-
-  this->task_handle_ = xTaskCreateStatic(
-      [](void *param) {
-        auto *session = static_cast<SnapcastControlSession *>(param);
-        session->notification_loop();
-      },
-      "snap_rpc_task", TASK_STACK_SIZE, (void *) this, STREAM_TASK_PRIORITY, this->task_stack_buffer_,
-      &this->task_stack_);
-  
-  if (this->task_handle_ == nullptr) {
-    return ESP_FAIL;
-  }
-
-  this->task_exiting_ = false;
-  return ESP_OK;
-}
-
-esp_err_t SnapcastControlSession::terminate() {
-  this->want_connected_ = false;
-
-  // close connection and stop all running tasks
-  ESP_LOGI(TAG, "terminate() prev state=%d", this->state_);
-  if (this->task_handle_) {
-    this->task_exiting_ = true;
-    xTaskNotify(this->task_handle_, STOP_BIT, eSetBits);
-  }
-  return ESP_OK;
-}
-
-bool SnapcastControlSession::finalize_termination() {
-  if (this->task_handle_ == nullptr) {
-    return true;
-  }
-  auto st = eTaskGetState(this->task_handle_);
-  if (st != eDeleted && st != eInvalid) {
-    // task hasn't terminated yet
-    return false;
-  }
-
-  // TODO: also free stack memory
-
-  // TODO: free queue
-
-  this->task_handle_ = nullptr;
-  this->task_exiting_ = false;
-  return true;
-}
-
-
-
-esp_err_t SnapcastControlSession::disconnect() {
-  if (!this->stream_task_handle_ || this->stream_task_exiting_) {
-    return ESP_ERR_INVALID_STATE;
-  }
-  xTaskNotify(this->stream_task_handle_, DISCONNECT_BIT, eSetBits);
-  return ESP_OK;
-}
-
-esp_err_t SnapcastControlSession::connect(std::string server, uint32_t port) {
-  this->server_ = server;
-  this->port_ = port;
-
-  if (!rpc_queue_) {
-    rpc_queue_ = xQueueCreate(4, sizeof(RpcRequest *));
-  }
-
-  // Start the notification handling task
-  this->notification_task_should_run_ = true;
-  if (this->notification_task_handle_ == nullptr) {
-    xTaskCreate(
-        [](void *param) {
-          auto *session = static_cast<SnapcastControlSession *>(param);
-          session->notification_loop();
-          session->notification_task_handle_ = nullptr;
-          vTaskDelete(nullptr);
-        },
-        "snapcast_notify", 4096, this, 5, &this->notification_task_handle_);
-  } else {
-    xTaskNotify(this->notification_task_handle_, RECONNECT_BIT, eSetBits);
-  }
-  return ESP_OK;
-}
-
-
-
-#endif
-
 esp_err_t SnapcastControlSession::connect(const std::string &server, uint32_t port) {
-  if (this->task_exiting_ && this->task_handle_){
+  if (this->task_exiting_ && this->task_handle_) {
     auto st = eTaskGetState(this->task_handle_);
     if (st != eDeleted && st != eInvalid) {
       // task hasn't terminated yet
@@ -167,7 +47,7 @@ esp_err_t SnapcastControlSession::connect(const std::string &server, uint32_t po
       this->task_exiting_ = false;
     }
   }
-  
+
   if (!this->config_mutex_) {
     this->config_mutex_ = xSemaphoreCreateMutex();
     if (!this->config_mutex_)
@@ -185,39 +65,38 @@ esp_err_t SnapcastControlSession::connect(const std::string &server, uint32_t po
     this->task_should_run_ = true;
     xSemaphoreGive(this->config_mutex_);
   }
-  
+
   if (!this->rpc_queue_) {
     this->rpc_queue_ = xQueueCreate(4, sizeof(RpcRequest *));
   }
 
   if (this->task_stack_buffer_ == nullptr) {
-    RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
+    RAMAllocator<StackType_t> stack_allocator;
     this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
     if (this->task_stack_buffer_ == nullptr) {
       return ESP_ERR_NO_MEM;
     }
   }
 
-  if( !this->task_handle_){
+  if (!this->task_handle_) {
     this->task_handle_ = xTaskCreateStatic(
-      [](void *param) {
-        auto *session = static_cast<SnapcastControlSession *>(param);
-        session->notification_loop();
-      },
-      "snap_rpc_task", TASK_STACK_SIZE, (void *) this, RPC_TASK_PRIORITY, this->task_stack_buffer_,
-      &this->task_stack_);
-  
+        [](void *param) {
+          auto *session = static_cast<SnapcastControlSession *>(param);
+          session->notification_loop();
+          vTaskDelete(nullptr);
+        },
+        "snap_rpc_task", TASK_STACK_SIZE, (void *) this, RPC_TASK_PRIORITY, this->task_stack_buffer_,
+        &this->task_stack_);
+
     if (this->task_handle_ == nullptr) {
       return ESP_FAIL;
     }
-  } else if( server_has_changed){
+  } else if (server_has_changed) {
     xTaskNotify(this->task_handle_, RECONNECT_BIT, eSetBits);
   }
-  
+
   return ESP_OK;
 }
-
-
 
 esp_err_t SnapcastControlSession::disconnect() {
   this->task_should_run_ = false;
@@ -270,11 +149,11 @@ void SnapcastControlSession::drain_rpc_queue_() {
     size_t n = serializeJson(doc, buf, sizeof(buf));
     if (n + 1 < sizeof(buf))
       buf[n++] = '\n';
-    
+
     esp_transport_write(transport_, buf, n, 1000);
     // buf[n] = '\0';
-    // printf( "sent: %s", buf );
-    
+    // printf("sent: %s", buf);
+
     // Register callback
     if (req->on_response) {
       pending_[req->id] = PendingCb{
@@ -308,7 +187,7 @@ void SnapcastControlSession::update_from_server_obj_(const JsonObject &server_ob
   }
   bool found = new_state.from_groups_json(server_obj["groups"], this->client_id_);
 
-#if  SNAPCAST_DEBUG
+#if SNAPCAST_DEBUG
   if (found) {
     printf("group_id: %s stream_id: %s\n", new_state.group_id.c_str(), new_state.stream_id.c_str());
     printf("Group members (%zu):\n", new_state.group_members.size());
@@ -318,20 +197,23 @@ void SnapcastControlSession::update_from_server_obj_(const JsonObject &server_ob
   }
 #endif
 
-  ClientState &state = new_state;
-  const char *curr_stream = state.stream_id.c_str();
-  StreamInfo *curr_sInfo = nullptr;
   JsonArray streams = server_obj["streams"];
-  known_streams_.clear();
+  auto &streams_map = new_state.known_streams;
+  streams_map.clear();
   for (JsonObject stream_obj : streams) {
     const char *stream_id = stream_obj["id"].as<const char *>();
     if (!stream_id)
       continue;
-    StreamInfo &sInfo = this->known_streams_[stream_id];
+    StreamInfo &sInfo = streams_map[stream_id];
     sInfo.from_json(stream_obj);
-    if (strcmp(curr_stream, stream_id) == 0) {
-      curr_sInfo = &sInfo;
-    }
+  }
+
+  StreamStatus status = StreamStatus::UNKNOWN;
+  std::string stream_id;
+  auto it = streams_map.find(new_state.stream_id);
+  if (it != streams_map.end()) {
+    status = it->second.status;
+    stream_id = it->second.id;
   }
 
   {
@@ -340,12 +222,12 @@ void SnapcastControlSession::update_from_server_obj_(const JsonObject &server_ob
     xSemaphoreGive(state_mutex_);
   }
 
-  if (!curr_sInfo || !this->on_stream_update_) {
+  if (!this->on_stream_update_) {
     return;
   }
-  StreamInfo &sInfo = *curr_sInfo;
-  if (sInfo.status != StreamStatus::UNKNOWN) {
-    this->on_stream_update_(sInfo.status, sInfo.id);
+
+  if (status != StreamStatus::UNKNOWN) {
+    this->on_stream_update_(status, stream_id);
   }
 }
 
@@ -381,7 +263,12 @@ void SnapcastControlSession::notification_loop() {
     this->connected_ = true;
     this->request_server_info_();
 
-    this->known_streams_.clear();
+    {
+      xSemaphoreTake(state_mutex_, portMAX_DELAY);
+      this->client_state_.clear();
+      xSemaphoreGive(state_mutex_);
+    }
+
     this->recv_buffer_.clear();
     this->line_buffer_.clear();
     bool skipping_oversize_ = false;
@@ -465,51 +352,65 @@ void SnapcastControlSession::notification_loop() {
                   return false;
                 if (strcmp(method, "Server.OnUpdate") == 0) {
                   this->update_from_server_obj_(root["params"]["server"].as<JsonObject>());
-#if 0  // leave processing of stream properties for later              
-                } else if (strcmp(method, "Stream.OnProperties") == 0) {
-                  JsonObject params = root["params"];
-                  const char *stream_id = params["id"].as<const char *>();
-                  if (!stream_id)
-                    return false;
-                  if (strcmp(stream_id, this->client_state_.stream_id.c_str()) == 0) {
-                    StreamInfo &sInfo = this->known_streams_[this->client_state_.stream_id];
-                    sInfo.from_stream_properties(params["properties"]);
-                    if (this->on_stream_update_ && sInfo.status != StreamStatus::UNKNOWN) {
-                      this->on_stream_update_(sInfo.status, sInfo.id);
-                    }
-                  }
-#endif
                 } else if (strcmp(method, "Group.OnStreamChanged") == 0) {
                   JsonObject params = root["params"];
                   const char *group_id = params["id"].as<const char *>();
                   if (!group_id)
                     return false;
-                  if (strcmp(group_id, this->client_state_.group_id.c_str()) == 0) {
-                    const char *stream_id = params["stream_id"].as<const char *>();
-                    if (!stream_id)
-                      return false;
-                    if (strcmp(stream_id, this->client_state_.stream_id.c_str()) != 0) {
-                      this->client_state_.stream_id = stream_id;
-                      StreamInfo &sInfo = this->known_streams_[this->client_state_.stream_id];
-                      if (sInfo.id.empty()) {
-                        sInfo.set_id(this->client_state_.stream_id);
-                        request_server_info_();
-                      } else if (this->on_stream_update_ && sInfo.status != StreamStatus::UNKNOWN) {
-                        this->on_stream_update_(sInfo.status, sInfo.id);
+                  const char *stream_id = params["stream_id"].as<const char *>();
+                  if (!stream_id)
+                    return false;
+
+                  StreamStatus status = StreamStatus::UNKNOWN;
+                  bool new_stream_unknown = false;
+                  {
+                    xSemaphoreTake(state_mutex_, portMAX_DELAY);
+                    if (strcmp(group_id, this->client_state_.group_id.c_str()) == 0 &&
+                        strcmp(stream_id, this->client_state_.stream_id.c_str()) != 0) {
+                      auto &streams_map = this->client_state_.known_streams;
+                      auto it = streams_map.find(stream_id);
+                      if (it != streams_map.end()) {
+                        this->client_state_.stream_id = stream_id;
+                        status = it->second.status;
+                      } else {
+                        new_stream_unknown = true;
                       }
                     }
+                    xSemaphoreGive(state_mutex_);
                   }
+                  if (new_stream_unknown) {
+                    request_server_info_();
+                  } else if (this->on_stream_update_ && status != StreamStatus::UNKNOWN) {
+                    this->on_stream_update_(status, stream_id);
+                  }
+
                 } else if (strcmp(method, "Stream.OnUpdate") == 0) {
                   JsonObject params = root["params"];
                   const char *stream_id = params["id"].as<const char *>();
                   if (!stream_id)
                     return false;
-                  if (strcmp(stream_id, this->client_state_.stream_id.c_str()) == 0) {
-                    StreamInfo &sInfo = this->known_streams_[stream_id];
-                    sInfo.from_json(params["stream"]);
-                    if (this->on_stream_update_ && sInfo.status != StreamStatus::UNKNOWN) {
-                      this->on_stream_update_(sInfo.status, sInfo.id);
+
+                  StreamInfo sInfo;
+                  sInfo.from_json(params["stream"]);
+                  StreamStatus status = sInfo.status;
+
+                  bool notify = false;
+                  {
+                    xSemaphoreTake(state_mutex_, portMAX_DELAY);
+
+                    auto &streams_map = this->client_state_.known_streams;
+                    streams_map.insert_or_assign(stream_id, std::move(sInfo));
+
+                    if (strcmp(stream_id, this->client_state_.stream_id.c_str()) == 0 &&
+                        status != StreamStatus::UNKNOWN) {
+                      notify = true;
                     }
+
+                    xSemaphoreGive(state_mutex_);
+                  }
+
+                  if (notify && this->on_stream_update_) {
+                    this->on_stream_update_(status, stream_id);
                   }
                 }
               }
@@ -549,11 +450,10 @@ void SnapcastControlSession::request_server_info_(std::function<void(const Clien
 }
 
 void SnapcastControlSession::set_group_stream_(const std::string &stream_id) {
-  ClientState snap = this->state_snapshot();
-  auto gid = std::move(snap.group_id);
+  std::string gid = this->grp_id_snapshot();
   this->send_rpc_async(
       "Group.SetStream",
-      [gid, sid = std::string(stream_id)](JsonObject params) {
+      [gid = std::move(gid), sid = stream_id](JsonObject params) {
         params["id"] = gid;
         params["stream_id"] = sid;
       },
@@ -561,31 +461,33 @@ void SnapcastControlSession::set_group_stream_(const std::string &stream_id) {
 }
 
 void SnapcastControlSession::group_request_stop(const ClientState &state) {
-  if (state.sInfo.canControl) {
+  auto it = state.known_streams.find(state.stream_id);
+  if (it == state.known_streams.end()) {
+    return;
+  }
+  const StreamInfo &sInfo = it->second;
+  if (sInfo.canControl) {
+    std::string stream_id = state.stream_id;
     this->send_rpc_async(
         "Stream.Control",
-        [state](JsonObject params) {
-          params["id"] = state.sInfo.id;
+        [sId = std::move(stream_id)](JsonObject params) {
+          params["id"] = sId;
           params["command"] = "stop";
           JsonArray cmd_params = params["clients"].to<JsonArray>();
         },
-        {}, 
-        2000
-    );
+        {}, 2000);
     return;
   }
   // stream doesn't support direct control, set to default stream instead.
-  const char *stream_id = state.default_streamid.c_str();
+  std::string grp_id = state.group_id;
+  std::string default_stream = state.default_streamid;
   this->send_rpc_async(
       "Group.SetStream",
-      [state](JsonObject params) {
-        params["id"] = state.group_id;
-        params["stream_id"] = state.default_streamid;
+      [gid = std::move(grp_id), sid = std::move(default_stream)](JsonObject params) {
+        params["id"] = gid;
+        params["stream_id"] = sid;
       },
-      [this](JsonObject root) mutable {          
-        this->request_server_info_({});
-      },
-      2000);
+      [this](JsonObject root) mutable { this->request_server_info_({}); }, 2000);
 }
 
 void SnapcastControlSession::isolate_client_(std::function<void(const ClientState &state)> cb) {

--- a/esphome/components/snapcast/snapcast_rpc.cpp
+++ b/esphome/components/snapcast/snapcast_rpc.cpp
@@ -198,7 +198,7 @@ void SnapcastControlSession::notification_loop() {
                 } else if (method == "Stream.OnProperties") {
                   JsonObject params = root["params"];
                   if (params["id"].as<std::string>() == this->client_state_.stream_id) {
-                    StreamInfo sInfo;
+                    StreamInfo &sInfo = this->known_streams_[this->client_state_.stream_id];
                     sInfo.from_stream_properties(params["properties"]);
                     if (this->on_stream_update_) {
                       this->on_stream_update_(sInfo);
@@ -231,16 +231,6 @@ void SnapcastControlSession::notification_loop() {
                     if (this->on_stream_update_) {
                       this->on_stream_update_(sInfo);
                     }
-                  }
-                } else if (method == "Client.OnConnect") {
-                  JsonObject params = root["params"];
-                  if (params["id"].as<std::string>() == this->client_id_) {
-                    this->send_rpc_request_(
-                        "Server.GetStatus",
-                        [](JsonObject params) {
-                          // no params
-                        },
-                        static_cast<uint32_t>(RequestId::GetServerStatus));
                   }
                 }
               }

--- a/esphome/components/snapcast/snapcast_rpc.cpp
+++ b/esphome/components/snapcast/snapcast_rpc.cpp
@@ -23,28 +23,118 @@
 #include "esphome/core/log.h"
 #include "esphome/components/network/util.h"
 
-
-
-
 namespace esphome {
 namespace snapcast {
 
+
+
 static const char *const TAG = "snapcast_rpc";
 
+static const size_t TASK_STACK_SIZE = 4 * 1024;
+static const uint8_t RPC_TASK_PRIORITY = 5;
 
 enum RPCTaskBits : uint32_t {
   DISCONNECT_BIT = (1 << 0),
   RECONNECT_BIT = (1 << 1),
 };
 
+#if 0
+esp_err_t SnapcastControlSession::init() {
+  if (this->task_handle_ != nullptr) {
+    if (!this->task_is_exiting_) {
+      // task already running
+      return ESP_OK;
+    }
+    if (!this->finalize_termination()) {
+      ESP_LOGW(TAG, "Exiting task still in progress");
+      return ESP_ERR_INVALID_STATE;
+    }
+  }
+
+  if (this->task_stack_buffer_ == nullptr) {
+    RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
+    this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
+    if (this->task_stack_buffer_ == nullptr) {
+      this->set_state_(StreamState::ERROR);
+      return ESP_ERR_NO_MEM;
+    }
+  }
+
+  if (!this->config_mutex_) {
+    this->config_mutex_ = xSemaphoreCreateMutex();
+    if (!this->config_mutex_)
+      return ESP_FAIL;
+  }
+  
+  if (!this->rpc_queue_) {
+    this->rpc_queue_ = xQueueCreate(4, sizeof(RpcRequest *));
+  }
+
+  this->task_handle_ = xTaskCreateStatic(
+      [](void *param) {
+        auto *session = static_cast<SnapcastControlSession *>(param);
+        session->notification_loop();
+      },
+      "snap_rpc_task", TASK_STACK_SIZE, (void *) this, STREAM_TASK_PRIORITY, this->task_stack_buffer_,
+      &this->task_stack_);
+  
+  if (this->task_handle_ == nullptr) {
+    return ESP_FAIL;
+  }
+
+  this->task_exiting_ = false;
+  return ESP_OK;
+}
+
+esp_err_t SnapcastControlSession::terminate() {
+  this->want_connected_ = false;
+
+  // close connection and stop all running tasks
+  ESP_LOGI(TAG, "terminate() prev state=%d", this->state_);
+  if (this->task_handle_) {
+    this->task_exiting_ = true;
+    xTaskNotify(this->task_handle_, STOP_BIT, eSetBits);
+  }
+  return ESP_OK;
+}
+
+bool SnapcastControlSession::finalize_termination() {
+  if (this->task_handle_ == nullptr) {
+    return true;
+  }
+  auto st = eTaskGetState(this->task_handle_);
+  if (st != eDeleted && st != eInvalid) {
+    // task hasn't terminated yet
+    return false;
+  }
+
+  // TODO: also free stack memory
+
+  // TODO: free queue
+
+  this->task_handle_ = nullptr;
+  this->task_exiting_ = false;
+  return true;
+}
+
+
+
+esp_err_t SnapcastControlSession::disconnect() {
+  if (!this->stream_task_handle_ || this->stream_task_exiting_) {
+    return ESP_ERR_INVALID_STATE;
+  }
+  xTaskNotify(this->stream_task_handle_, DISCONNECT_BIT, eSetBits);
+  return ESP_OK;
+}
+
 esp_err_t SnapcastControlSession::connect(std::string server, uint32_t port) {
   this->server_ = server;
   this->port_ = port;
 
   if (!rpc_queue_) {
-    rpc_queue_ = xQueueCreate(4, sizeof(RpcRequest*));
+    rpc_queue_ = xQueueCreate(4, sizeof(RpcRequest *));
   }
-  
+
   // Start the notification handling task
   this->notification_task_should_run_ = true;
   if (this->notification_task_handle_ == nullptr) {
@@ -62,21 +152,85 @@ esp_err_t SnapcastControlSession::connect(std::string server, uint32_t port) {
   return ESP_OK;
 }
 
+
+
+#endif
+
+esp_err_t SnapcastControlSession::connect(const std::string &server, uint32_t port) {
+  if (this->task_exiting_ && this->task_handle_){
+    auto st = eTaskGetState(this->task_handle_);
+    if (st != eDeleted && st != eInvalid) {
+      // task hasn't terminated yet
+      return ESP_ERR_INVALID_STATE;
+    } else {
+      this->task_handle_ = nullptr;
+      this->task_exiting_ = false;
+    }
+  }
+  
+  if (!this->config_mutex_) {
+    this->config_mutex_ = xSemaphoreCreateMutex();
+    if (!this->config_mutex_)
+      return ESP_FAIL;
+  }
+
+  bool server_has_changed = false;
+  {
+    if (xSemaphoreTake(this->config_mutex_, 0) != pdTRUE) {
+      return ESP_ERR_TIMEOUT;
+    }
+    server_has_changed = (server != this->server_) || (port != this->port_);
+    this->server_ = server;
+    this->port_ = port;
+    this->task_should_run_ = true;
+    xSemaphoreGive(this->config_mutex_);
+  }
+  
+  if (!this->rpc_queue_) {
+    this->rpc_queue_ = xQueueCreate(4, sizeof(RpcRequest *));
+  }
+
+  if (this->task_stack_buffer_ == nullptr) {
+    RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
+    this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
+    if (this->task_stack_buffer_ == nullptr) {
+      return ESP_ERR_NO_MEM;
+    }
+  }
+
+  if( !this->task_handle_){
+    this->task_handle_ = xTaskCreateStatic(
+      [](void *param) {
+        auto *session = static_cast<SnapcastControlSession *>(param);
+        session->notification_loop();
+      },
+      "snap_rpc_task", TASK_STACK_SIZE, (void *) this, RPC_TASK_PRIORITY, this->task_stack_buffer_,
+      &this->task_stack_);
+  
+    if (this->task_handle_ == nullptr) {
+      return ESP_FAIL;
+    }
+  } else if( server_has_changed){
+    xTaskNotify(this->task_handle_, RECONNECT_BIT, eSetBits);
+  }
+  
+  return ESP_OK;
+}
+
+
+
 esp_err_t SnapcastControlSession::disconnect() {
-  this->notification_task_should_run_ = false;
-  if (this->notification_task_handle_) {
-    xTaskNotify(this->notification_task_handle_, DISCONNECT_BIT, eSetBits);
+  this->task_should_run_ = false;
+  if (this->task_handle_) {
+    xTaskNotify(this->task_handle_, DISCONNECT_BIT, eSetBits);
   }
   return ESP_OK;
 }
 
-bool SnapcastControlSession::send_rpc_async(
-    const std::string &method,
-    std::function<void(JsonObject)> fill_params,
-    RpcResponseCb on_response,
-    uint32_t timeout_ms)
-{
-  if (!this->rpc_queue_) return false;
+bool SnapcastControlSession::send_rpc_async(const std::string &method, std::function<void(JsonObject)> fill_params,
+                                            RpcResponseCb on_response, uint32_t timeout_ms) {
+  if (!this->rpc_queue_)
+    return false;
 
   auto *req = new RpcRequest{
       .method = method,
@@ -108,15 +262,19 @@ void SnapcastControlSession::drain_rpc_queue_() {
     doc["id"] = req->id;
     doc["method"] = req->method;
     JsonObject params = doc["params"].to<JsonObject>();
-    if (req->fill_params) req->fill_params(params);
+    if (req->fill_params)
+      req->fill_params(params);
 
     // Serialize
     static char buf[768];  // adjust to your message sizes
     size_t n = serializeJson(doc, buf, sizeof(buf));
-    if (n + 1 < sizeof(buf)) buf[n++] = '\n';
-
+    if (n + 1 < sizeof(buf))
+      buf[n++] = '\n';
+    
     esp_transport_write(transport_, buf, n, 1000);
-
+    // buf[n] = '\0';
+    // printf( "sent: %s", buf );
+    
     // Register callback
     if (req->on_response) {
       pending_[req->id] = PendingCb{
@@ -149,18 +307,18 @@ void SnapcastControlSession::update_from_server_obj_(const JsonObject &server_ob
     xSemaphoreGive(state_mutex_);
   }
   bool found = new_state.from_groups_json(server_obj["groups"], this->client_id_);
-  
-#if 1 //SNAPCAST_DEBUG
+
+#if  SNAPCAST_DEBUG
   if (found) {
     printf("group_id: %s stream_id: %s\n", new_state.group_id.c_str(), new_state.stream_id.c_str());
     printf("Group members (%zu):\n", new_state.group_members.size());
-    for (const auto& id : new_state.group_members) {
+    for (const auto &id : new_state.group_members) {
       printf("  member: %s\n", id.c_str());
     }
   }
 #endif
-  
-ClientState &state = new_state;
+
+  ClientState &state = new_state;
   const char *curr_stream = state.stream_id.c_str();
   StreamInfo *curr_sInfo = nullptr;
   JsonArray streams = server_obj["streams"];
@@ -175,7 +333,7 @@ ClientState &state = new_state;
       curr_sInfo = &sInfo;
     }
   }
-  
+
   {
     xSemaphoreTake(state_mutex_, portMAX_DELAY);
     this->client_state_ = std::move(new_state);
@@ -193,7 +351,7 @@ ClientState &state = new_state;
 
 void SnapcastControlSession::notification_loop() {
   this->line_buffer_.reserve(1024);
-  while (this->notification_task_should_run_) {
+  while (this->task_should_run_) {
     // Initialize transport
     if (this->transport_ != nullptr) {
       esp_transport_close(this->transport_);
@@ -220,7 +378,7 @@ void SnapcastControlSession::notification_loop() {
       vTaskDelay(pdMS_TO_TICKS(10000));
       continue;
     }
-
+    this->connected_ = true;
     this->request_server_info_();
 
     this->known_streams_.clear();
@@ -231,13 +389,13 @@ void SnapcastControlSession::notification_loop() {
     static constexpr size_t MAX_LINE = 16 * 1024;
     while (true) {
       uint32_t notify_value = 0;
-      if (xTaskNotifyWait(0, RECONNECT_BIT, &notify_value, 0) > 0) {
+      if (xTaskNotifyWait(0, RECONNECT_BIT | DISCONNECT_BIT, &notify_value, 0) > 0) {
         break;
       }
 
       drain_rpc_queue_();
       expire_pending_();
-      
+
       char chunk[128];  // small read buffer
       int len = esp_transport_read(this->transport_, chunk, sizeof(chunk), 100);
       if (len < 0) {
@@ -280,7 +438,7 @@ void SnapcastControlSession::notification_loop() {
           while ((pos = this->recv_buffer_.find('\n')) != std::string::npos) {
             this->line_buffer_.assign(this->recv_buffer_, 0, pos);
 
-#if 1 //SNAPCAST_DEBUG
+#if SNAPCAST_DEBUG
             printf("JSON: %s\n", this->line_buffer_.c_str());
 #endif
             this->recv_buffer_.erase(0, pos + 1);
@@ -292,13 +450,13 @@ void SnapcastControlSession::notification_loop() {
                 if (it != pending_.end()) {
                   auto cb = std::move(it->second.cb);
                   pending_.erase(it);
-                  if (root["result"].is<JsonObject>()){
+                  if (root["result"].is<JsonObject>()) {
                     cb(root);
-                  } else if (root["error"].is<JsonObject>()) { 
+                  } else if (root["error"].is<JsonObject>()) {
                     JsonObject err = root["error"];
                     int code = err["code"] | 0;
-                    const char* msg = err["message"] | "<no message>";
-                    ESP_LOGW(TAG, "RPC error id=%u code=%d message=\"%s\"", id, code, msg);  
+                    const char *msg = err["message"] | "<no message>";
+                    ESP_LOGW(TAG, "RPC error id=%u code=%d message=\"%s\"", id, code, msg);
                   }
                 }
               } else {
@@ -367,92 +525,103 @@ void SnapcastControlSession::notification_loop() {
     esp_transport_close(this->transport_);
     esp_transport_destroy(this->transport_);
     this->transport_ = nullptr;
+    this->connected_ = false;
   }
+  this->task_exiting_ = true;
 }
 
-void SnapcastControlSession::request_server_info_(std::function<void(const ClientState& state)> cb){
+void SnapcastControlSession::request_server_info_(std::function<void(const ClientState &state)> cb) {
   this->send_rpc_async(
       "Server.GetStatus",
       [](JsonObject params) {
         // no params
       },
-      [this, cb](JsonObject root){
+      [this, cb = std::move(cb)](JsonObject root) {
+        JsonObject server = root["result"]["server"];
+        if (!server)
+          return;
         this->update_from_server_obj_(root["result"]["server"].as<JsonObject>());
         if (cb) {
           cb(this->client_state_);
         }
       },
-      2000
-    );
+      2000);
 }
 
-void SnapcastControlSession::set_group_stream_(const std::string &stream_id){
+void SnapcastControlSession::set_group_stream_(const std::string &stream_id) {
+  ClientState snap = this->state_snapshot();
+  auto gid = std::move(snap.group_id);
   this->send_rpc_async(
       "Group.SetStream",
-      [this, stream_id](JsonObject params) {
-        params["id"] = this->client_state_.group_id;
-        params["stream_id"] = stream_id;
+      [gid, sid = std::string(stream_id)](JsonObject params) {
+        params["id"] = gid;
+        params["stream_id"] = sid;
       },
-      {},
-      2000
-  );
+      {}, 2000);
 }
 
-// void SnapcastControlSession::group_request_stop_streaming_(){
-  
-//   this->send_rpc_async(
-//       "Group.SetStream",
-//       [this, stream_id](JsonObject params) {
-//         params["id"] = this->client_state_.group_id;
-//         params["stream_id"] = stream_id;
-//       },
-//       {},
-//       2000
-//   );
-// }
+void SnapcastControlSession::group_request_stop(const ClientState &state) {
+  if (state.sInfo.canControl) {
+    this->send_rpc_async(
+        "Stream.Control",
+        [state](JsonObject params) {
+          params["id"] = state.sInfo.id;
+          params["command"] = "stop";
+          JsonArray cmd_params = params["clients"].to<JsonArray>();
+        },
+        {}, 
+        2000
+    );
+    return;
+  }
+  // stream doesn't support direct control, set to default stream instead.
+  const char *stream_id = state.default_streamid.c_str();
+  this->send_rpc_async(
+      "Group.SetStream",
+      [state](JsonObject params) {
+        params["id"] = state.group_id;
+        params["stream_id"] = state.default_streamid;
+      },
+      [this](JsonObject root) mutable {          
+        this->request_server_info_({});
+      },
+      2000);
+}
 
-void SnapcastControlSession::isolate_client_(std::function<void(const ClientState& state)> cb){
+void SnapcastControlSession::isolate_client_(std::function<void(const ClientState &state)> cb) {
+  auto snap = this->state_snapshot();
+  auto gid = snap.group_id;
+  auto self_id = this->client_id_;
+  auto members = snap.group_members;
   this->send_rpc_async(
       "Group.SetClients",
-      [this](JsonObject params) {
-        params["id"] = this->client_state_.group_id;
+      [gid, self_id, members = std::move(members)](JsonObject params) {
+        params["id"] = gid;
         JsonArray clients = params["clients"].to<JsonArray>();
-        for (const auto& cli_id : this->client_state_.group_members) {
-          if ( cli_id != this->client_id_ ){
-            clients.add(cli_id.c_str());
-          }            
+        for (const auto &cli_id : members) {
+          if (cli_id != self_id)
+            clients.add(cli_id);
         }
       },
-      [this, cb](JsonObject root){
-        this->request_server_info_(cb);
+      [this, cb = std::move(cb)](JsonObject root) mutable {
+        if (cb)
+          this->request_server_info_(std::move(cb));
+        else
+          this->request_server_info_({});
       },
-      2000
-  );
+      2000);
 }
 
-
-void SnapcastControlSession::request_stopping(){
-  // if (this->client_state_.group_members.size() > 1){
-  //   // is member of a group, isolate client first
-  //   this->send_rpc_request_(
-  //     "Group.SetClients",
-  //       [this](JsonObject params) {
-  //         params["id"] = this->client_state_.group_id;
-  //         JsonArray clients = params["clients"].to<JsonArray>();
-  //         for (const auto& cli_id : this->client_state_.group_members) {
-  //           if ( cli_id != this->client_id_ ){
-  //             clients.add(cli_id.c_str());
-  //           }            
-  //         }
-  //       },
-  //       static_cast<uint32_t>(10)
-  //   );
-  // }
-  // StreamInfo &sInfo = this->known_streams_[this->client_state_.stream_id];
-  // if (sInfo.id.empty()) return;
-
+void SnapcastControlSession::request_stop() {
+  const ClientState state = this->state_snapshot();
+  if (state.group_members.size() > 1) {
+    // is member of a group, isolate client first
+    this->isolate_client_([this](const ClientState &state) { this->group_request_stop(state); });
+  } else {
+    // is only group memmber
+    this->group_request_stop(state);
+  }
 }
-
 
 }  // namespace snapcast
 }  // namespace esphome

--- a/esphome/components/snapcast/snapcast_rpc.cpp
+++ b/esphome/components/snapcast/snapcast_rpc.cpp
@@ -19,13 +19,18 @@
 #include "snapcast_rpc.h"
 #include "esp_transport_tcp.h"
 
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "esphome/components/network/util.h"
+
+
+
 
 namespace esphome {
 namespace snapcast {
 
 static const char *const TAG = "snapcast_rpc";
+
 
 enum RPCTaskBits : uint32_t {
   DISCONNECT_BIT = (1 << 0),
@@ -36,6 +41,10 @@ esp_err_t SnapcastControlSession::connect(std::string server, uint32_t port) {
   this->server_ = server;
   this->port_ = port;
 
+  if (!rpc_queue_) {
+    rpc_queue_ = xQueueCreate(4, sizeof(RpcRequest*));
+  }
+  
   // Start the notification handling task
   this->notification_task_should_run_ = true;
   if (this->notification_task_handle_ == nullptr) {
@@ -61,13 +70,97 @@ esp_err_t SnapcastControlSession::disconnect() {
   return ESP_OK;
 }
 
-void SnapcastControlSession::update_from_server_obj_(const JsonObject &server_obj) {
-  ClientState &state = this->client_state_;
-  if (state.from_groups_json(server_obj["groups"], get_mac_address_pretty())) {
-#if SNAPCAST_DEBUG
-    printf("group_id: %s stream_id: %s\n", state.group_id.c_str(), state.stream_id.c_str());
-#endif
+bool SnapcastControlSession::send_rpc_async(
+    const std::string &method,
+    std::function<void(JsonObject)> fill_params,
+    RpcResponseCb on_response,
+    uint32_t timeout_ms)
+{
+  if (!this->rpc_queue_) return false;
+
+  auto *req = new RpcRequest{
+      .method = method,
+      .id = next_id_.fetch_add(1, std::memory_order_relaxed),
+      .fill_params = std::move(fill_params),
+      .on_response = std::move(on_response),
+      .timeout_ms = timeout_ms,
+  };
+
+  if (xQueueSend(rpc_queue_, &req, 0) != pdTRUE) {
+    delete req;
+    return false;
   }
+  return true;
+}
+
+void SnapcastControlSession::drain_rpc_queue_() {
+  RpcRequest *req = nullptr;
+
+  while (xQueueReceive(rpc_queue_, &req, 0) == pdTRUE) {
+    if (!this->transport_) {  // not connected
+      delete req;
+      continue;
+    }
+
+    // Build JSON-RPC
+    JsonDocument doc;
+    doc["jsonrpc"] = "2.0";
+    doc["id"] = req->id;
+    doc["method"] = req->method;
+    JsonObject params = doc["params"].to<JsonObject>();
+    if (req->fill_params) req->fill_params(params);
+
+    // Serialize
+    static char buf[768];  // adjust to your message sizes
+    size_t n = serializeJson(doc, buf, sizeof(buf));
+    if (n + 1 < sizeof(buf)) buf[n++] = '\n';
+
+    esp_transport_write(transport_, buf, n, 1000);
+
+    // Register callback
+    if (req->on_response) {
+      pending_[req->id] = PendingCb{
+          .cb = std::move(req->on_response),
+          .expires_ms = millis() + req->timeout_ms,
+      };
+    }
+
+    delete req;
+  }
+}
+
+void SnapcastControlSession::expire_pending_() {
+  uint32_t now = millis();
+  for (auto it = pending_.begin(); it != pending_.end();) {
+    if (now >= it->second.expires_ms) {
+      // just drop
+      it = pending_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void SnapcastControlSession::update_from_server_obj_(const JsonObject &server_obj) {
+  ClientState new_state;
+  {
+    xSemaphoreTake(state_mutex_, portMAX_DELAY);
+    new_state = this->client_state_;
+    xSemaphoreGive(state_mutex_);
+  }
+  bool found = new_state.from_groups_json(server_obj["groups"], this->client_id_);
+  
+#if 1 //SNAPCAST_DEBUG
+  if (found) {
+    printf("group_id: %s stream_id: %s\n", new_state.group_id.c_str(), new_state.stream_id.c_str());
+    printf("Group members (%zu):\n", new_state.group_members.size());
+    for (const auto& id : new_state.group_members) {
+      printf("  member: %s\n", id.c_str());
+    }
+  }
+#endif
+  
+ClientState &state = new_state;
   const char *curr_stream = state.stream_id.c_str();
   StreamInfo *curr_sInfo = nullptr;
   JsonArray streams = server_obj["streams"];
@@ -82,6 +175,13 @@ void SnapcastControlSession::update_from_server_obj_(const JsonObject &server_ob
       curr_sInfo = &sInfo;
     }
   }
+  
+  {
+    xSemaphoreTake(state_mutex_, portMAX_DELAY);
+    this->client_state_ = std::move(new_state);
+    xSemaphoreGive(state_mutex_);
+  }
+
   if (!curr_sInfo || !this->on_stream_update_) {
     return;
   }
@@ -121,13 +221,7 @@ void SnapcastControlSession::notification_loop() {
       continue;
     }
 
-    // Send initial request after connecting
-    this->send_rpc_request_(
-        "Server.GetStatus",
-        [](JsonObject params) {
-          // no params
-        },
-        static_cast<uint32_t>(RequestId::GetServerStatus));
+    this->request_server_info_();
 
     this->known_streams_.clear();
     this->recv_buffer_.clear();
@@ -141,6 +235,9 @@ void SnapcastControlSession::notification_loop() {
         break;
       }
 
+      drain_rpc_queue_();
+      expire_pending_();
+      
       char chunk[128];  // small read buffer
       int len = esp_transport_read(this->transport_, chunk, sizeof(chunk), 100);
       if (len < 0) {
@@ -183,22 +280,26 @@ void SnapcastControlSession::notification_loop() {
           while ((pos = this->recv_buffer_.find('\n')) != std::string::npos) {
             this->line_buffer_.assign(this->recv_buffer_, 0, pos);
 
-#if SNAPCAST_DEBUG
+#if 1 //SNAPCAST_DEBUG
             printf("JSON: %s\n", this->line_buffer_.c_str());
 #endif
             this->recv_buffer_.erase(0, pos + 1);
 
             json::parse_json(this->line_buffer_, [this](JsonObject root) -> bool {
-              if (root["result"].is<JsonObject>() && root["id"].is<uint32_t>()) {
-                uint32_t id = root["id"];
-                switch (static_cast<RequestId>(id)) {
-                  case RequestId::GetServerStatus: {
-                    ClientState &state = this->client_state_;
-                    state.from_groups_json(root["result"]["server"]["groups"], this->client_id_);
-                    this->update_from_server_obj_(root["result"]["server"].as<JsonObject>());
-                  } break;
-                  default:
-                    ESP_LOGW(TAG, "Unknown request ID: %u", id);
+              if (root["id"].is<uint32_t>()) {
+                uint32_t id = root["id"].as<uint32_t>();
+                auto it = pending_.find(id);
+                if (it != pending_.end()) {
+                  auto cb = std::move(it->second.cb);
+                  pending_.erase(it);
+                  if (root["result"].is<JsonObject>()){
+                    cb(root);
+                  } else if (root["error"].is<JsonObject>()) { 
+                    JsonObject err = root["error"];
+                    int code = err["code"] | 0;
+                    const char* msg = err["message"] | "<no message>";
+                    ESP_LOGW(TAG, "RPC error id=%u code=%d message=\"%s\"", id, code, msg);  
+                  }
                 }
               } else {
                 const char *method = root["method"].as<const char *>();
@@ -234,12 +335,7 @@ void SnapcastControlSession::notification_loop() {
                       StreamInfo &sInfo = this->known_streams_[this->client_state_.stream_id];
                       if (sInfo.id.empty()) {
                         sInfo.set_id(this->client_state_.stream_id);
-                        this->send_rpc_request_(
-                            "Server.GetStatus",
-                            [](JsonObject params) {
-                              // no params
-                            },
-                            static_cast<uint32_t>(RequestId::GetServerStatus));
+                        request_server_info_();
                       } else if (this->on_stream_update_ && sInfo.status != StreamStatus::UNKNOWN) {
                         this->on_stream_update_(sInfo.status, sInfo.id);
                       }
@@ -274,20 +370,89 @@ void SnapcastControlSession::notification_loop() {
   }
 }
 
-void SnapcastControlSession::send_rpc_request_(const std::string &method, std::function<void(JsonObject)> fill_params,
-                                               uint32_t id) {
-  JsonDocument doc;
-  doc["jsonrpc"] = "2.0";
-  doc["id"] = id;
-  doc["method"] = method;
-  JsonObject params = doc["params"].to<JsonObject>();
-  fill_params(params);
-
-  static char json_buf[512];
-  size_t len = serializeJson(doc, json_buf, sizeof(json_buf));
-  json_buf[len++] = '\n';
-  esp_transport_write(this->transport_, json_buf, len, 1000);
+void SnapcastControlSession::request_server_info_(std::function<void(const ClientState& state)> cb){
+  this->send_rpc_async(
+      "Server.GetStatus",
+      [](JsonObject params) {
+        // no params
+      },
+      [this, cb](JsonObject root){
+        this->update_from_server_obj_(root["result"]["server"].as<JsonObject>());
+        if (cb) {
+          cb(this->client_state_);
+        }
+      },
+      2000
+    );
 }
+
+void SnapcastControlSession::set_group_stream_(const std::string &stream_id){
+  this->send_rpc_async(
+      "Group.SetStream",
+      [this, stream_id](JsonObject params) {
+        params["id"] = this->client_state_.group_id;
+        params["stream_id"] = stream_id;
+      },
+      {},
+      2000
+  );
+}
+
+// void SnapcastControlSession::group_request_stop_streaming_(){
+  
+//   this->send_rpc_async(
+//       "Group.SetStream",
+//       [this, stream_id](JsonObject params) {
+//         params["id"] = this->client_state_.group_id;
+//         params["stream_id"] = stream_id;
+//       },
+//       {},
+//       2000
+//   );
+// }
+
+void SnapcastControlSession::isolate_client_(std::function<void(const ClientState& state)> cb){
+  this->send_rpc_async(
+      "Group.SetClients",
+      [this](JsonObject params) {
+        params["id"] = this->client_state_.group_id;
+        JsonArray clients = params["clients"].to<JsonArray>();
+        for (const auto& cli_id : this->client_state_.group_members) {
+          if ( cli_id != this->client_id_ ){
+            clients.add(cli_id.c_str());
+          }            
+        }
+      },
+      [this, cb](JsonObject root){
+        this->request_server_info_(cb);
+      },
+      2000
+  );
+}
+
+
+void SnapcastControlSession::request_stopping(){
+  // if (this->client_state_.group_members.size() > 1){
+  //   // is member of a group, isolate client first
+  //   this->send_rpc_request_(
+  //     "Group.SetClients",
+  //       [this](JsonObject params) {
+  //         params["id"] = this->client_state_.group_id;
+  //         JsonArray clients = params["clients"].to<JsonArray>();
+  //         for (const auto& cli_id : this->client_state_.group_members) {
+  //           if ( cli_id != this->client_id_ ){
+  //             clients.add(cli_id.c_str());
+  //           }            
+  //         }
+  //       },
+  //       static_cast<uint32_t>(10)
+  //   );
+  // }
+  // StreamInfo &sInfo = this->known_streams_[this->client_state_.stream_id];
+  // if (sInfo.id.empty()) return;
+
+}
+
 
 }  // namespace snapcast
 }  // namespace esphome

--- a/esphome/components/snapcast/snapcast_rpc.cpp
+++ b/esphome/components/snapcast/snapcast_rpc.cpp
@@ -516,13 +516,14 @@ void SnapcastControlSession::isolate_client_(std::function<void(const ClientStat
 
 void SnapcastControlSession::request_stop() {
   const ClientState state = this->state_snapshot();
-  if (state.group_members.size() > 1) {
-    // is member of a group, isolate client first
-    this->isolate_client_([this](const ClientState &state) { this->group_request_stop(state); });
-  } else {
-    // is only group memmber
-    this->group_request_stop(state);
-  }
+  this->group_request_stop(state);
+  // if (state.group_members.size() > 1) {
+  //   // is member of a group, isolate client first
+  //   this->isolate_client_([this](const ClientState &state) { this->group_request_stop(state); });
+  // } else {
+  //   // is only group memmber
+  //   this->group_request_stop(state);
+  // }
 }
 
 }  // namespace snapcast

--- a/esphome/components/snapcast/snapcast_rpc.cpp
+++ b/esphome/components/snapcast/snapcast_rpc.cpp
@@ -68,19 +68,26 @@ void SnapcastControlSession::update_from_server_obj_(const JsonObject &server_ob
     printf("group_id: %s stream_id: %s\n", state.group_id.c_str(), state.stream_id.c_str());
 #endif
   }
-
+  const char *curr_stream = state.stream_id.c_str();
+  StreamInfo *curr_sInfo = nullptr;
   JsonArray streams = server_obj["streams"];
   known_streams_.clear();
   for (JsonObject stream_obj : streams) {
-    if (!stream_obj["id"].is<std::string>())
+    const char *stream_id = stream_obj["id"].as<const char *>();
+    if (!stream_id)
       continue;
-    StreamInfo sInfo;
+    StreamInfo &sInfo = this->known_streams_[stream_id];
     sInfo.from_json(stream_obj);
-    this->known_streams_[stream_obj["id"].as<std::string>()] = sInfo;
+    if (strcmp(curr_stream, stream_id) == 0) {
+      curr_sInfo = &sInfo;
+    }
   }
-  auto it = this->known_streams_.find(state.stream_id);
-  if (it != this->known_streams_.end() && this->on_stream_update_) {
-    this->on_stream_update_(it->second);
+  if (!curr_sInfo || !this->on_stream_update_) {
+    return;
+  }
+  StreamInfo &sInfo = *curr_sInfo;
+  if (sInfo.status != StreamStatus::UNKNOWN) {
+    this->on_stream_update_(sInfo.status, sInfo.id);
   }
 }
 
@@ -122,6 +129,9 @@ void SnapcastControlSession::notification_loop() {
         },
         static_cast<uint32_t>(RequestId::GetServerStatus));
 
+    this->known_streams_.clear();
+    this->recv_buffer_.clear();
+    this->line_buffer_.clear();
     bool skipping_oversize_ = false;
     size_t dropped_bytes_ = 0;
     static constexpr size_t MAX_LINE = 16 * 1024;
@@ -134,6 +144,9 @@ void SnapcastControlSession::notification_loop() {
       char chunk[128];  // small read buffer
       int len = esp_transport_read(this->transport_, chunk, sizeof(chunk), 100);
       if (len < 0) {
+        if (errno == EAGAIN || errno == ETIMEDOUT) {
+          continue;
+        }
         vTaskDelay(pdMS_TO_TICKS(1000));
         break;
       }
@@ -182,33 +195,42 @@ void SnapcastControlSession::notification_loop() {
                   case RequestId::GetServerStatus: {
                     ClientState &state = this->client_state_;
                     state.from_groups_json(root["result"]["server"]["groups"], this->client_id_);
-                    StreamInfo sInfo;
-                    sInfo.from_streams_json(root["result"]["server"]["streams"], state.stream_id);
                     this->update_from_server_obj_(root["result"]["server"].as<JsonObject>());
                   } break;
                   default:
                     ESP_LOGW(TAG, "Unknown request ID: %u", id);
                 }
-
-              } else if (root["method"].is<std::string>()) {
-                std::string method = root["method"].as<std::string>();
-                if (method == "Server.OnUpdate") {
+              } else {
+                const char *method = root["method"].as<const char *>();
+                if (!method)
+                  return false;
+                if (strcmp(method, "Server.OnUpdate") == 0) {
                   this->update_from_server_obj_(root["params"]["server"].as<JsonObject>());
-
-                } else if (method == "Stream.OnProperties") {
+#if 0  // leave processing of stream properties for later              
+                } else if (strcmp(method, "Stream.OnProperties") == 0) {
                   JsonObject params = root["params"];
-                  if (params["id"].as<std::string>() == this->client_state_.stream_id) {
+                  const char *stream_id = params["id"].as<const char *>();
+                  if (!stream_id)
+                    return false;
+                  if (strcmp(stream_id, this->client_state_.stream_id.c_str()) == 0) {
                     StreamInfo &sInfo = this->known_streams_[this->client_state_.stream_id];
                     sInfo.from_stream_properties(params["properties"]);
-                    if (this->on_stream_update_) {
-                      this->on_stream_update_(sInfo);
+                    if (this->on_stream_update_ && sInfo.status != StreamStatus::UNKNOWN) {
+                      this->on_stream_update_(sInfo.status, sInfo.id);
                     }
                   }
-                } else if (method == "Group.OnStreamChanged") {
+#endif
+                } else if (strcmp(method, "Group.OnStreamChanged") == 0) {
                   JsonObject params = root["params"];
-                  if (params["id"].as<std::string>() == this->client_state_.group_id) {
-                    if (this->client_state_.stream_id != params["stream_id"].as<std::string>()) {
-                      this->client_state_.stream_id = params["stream_id"].as<std::string>();
+                  const char *group_id = params["id"].as<const char *>();
+                  if (!group_id)
+                    return false;
+                  if (strcmp(group_id, this->client_state_.group_id.c_str()) == 0) {
+                    const char *stream_id = params["stream_id"].as<const char *>();
+                    if (!stream_id)
+                      return false;
+                    if (strcmp(stream_id, this->client_state_.stream_id.c_str()) != 0) {
+                      this->client_state_.stream_id = stream_id;
                       StreamInfo &sInfo = this->known_streams_[this->client_state_.stream_id];
                       if (sInfo.id.empty()) {
                         sInfo.set_id(this->client_state_.stream_id);
@@ -218,18 +240,21 @@ void SnapcastControlSession::notification_loop() {
                               // no params
                             },
                             static_cast<uint32_t>(RequestId::GetServerStatus));
-                      } else if (this->on_stream_update_) {
-                        this->on_stream_update_(sInfo);
+                      } else if (this->on_stream_update_ && sInfo.status != StreamStatus::UNKNOWN) {
+                        this->on_stream_update_(sInfo.status, sInfo.id);
                       }
                     }
                   }
-                } else if (method == "Stream.OnUpdate") {
+                } else if (strcmp(method, "Stream.OnUpdate") == 0) {
                   JsonObject params = root["params"];
-                  if (params["id"].as<std::string>() == this->client_state_.stream_id) {
-                    StreamInfo &sInfo = this->known_streams_[params["id"].as<std::string>()];
+                  const char *stream_id = params["id"].as<const char *>();
+                  if (!stream_id)
+                    return false;
+                  if (strcmp(stream_id, this->client_state_.stream_id.c_str()) == 0) {
+                    StreamInfo &sInfo = this->known_streams_[stream_id];
                     sInfo.from_json(params["stream"]);
-                    if (this->on_stream_update_) {
-                      this->on_stream_update_(sInfo);
+                    if (this->on_stream_update_ && sInfo.status != StreamStatus::UNKNOWN) {
+                      this->on_stream_update_(sInfo.status, sInfo.id);
                     }
                   }
                 }
@@ -258,7 +283,7 @@ void SnapcastControlSession::send_rpc_request_(const std::string &method, std::f
   JsonObject params = doc["params"].to<JsonObject>();
   fill_params(params);
 
-  char json_buf[512];
+  static char json_buf[512];
   size_t len = serializeJson(doc, json_buf, sizeof(json_buf));
   json_buf[len++] = '\n';
   esp_transport_write(this->transport_, json_buf, len, 1000);

--- a/esphome/components/snapcast/snapcast_rpc.h
+++ b/esphome/components/snapcast/snapcast_rpc.h
@@ -49,6 +49,7 @@ static inline StreamStatus parse_status(const char* s) {
 struct StreamInfo {
   std::string id;
   StreamStatus status{StreamStatus::UNKNOWN};
+  bool canControl{false};
   bool canPlay{false};
   bool canPause{false};
   bool canSeek{false};
@@ -68,6 +69,7 @@ struct StreamInfo {
     id = sid;
     
     status = parse_status(stream_obj["status"].as<const char*>());
+    canControl = stream_obj["canControl"] | false;
     canPlay = stream_obj["canPlay"] | false;
     canPause = stream_obj["canPause"] | false;
     canSeek = stream_obj["canSeek"] | false;
@@ -96,12 +98,13 @@ struct StreamInfo {
 
 struct ClientState {
   std::string group_id;
+  StreamInfo sInfo;
   std::string stream_id;
+  std::string default_streamid{"default"};
   std::vector<std::string> group_members;
   int32_t latency = 0;
   uint8_t volume_percent = 100;
   bool muted = false;
-
 
   bool from_groups_json(JsonArray groups, std::string &client_id) {
     this->group_members.clear();
@@ -151,8 +154,9 @@ class SnapcastClient;
 
 class SnapcastControlSession {
  public:
-  esp_err_t connect(std::string server, uint32_t port);
+  esp_err_t connect(const std::string& server, uint32_t port);
   esp_err_t disconnect();
+  bool is_connected() const { return this->connected_; }
 
   void notification_loop();
 
@@ -160,7 +164,7 @@ class SnapcastControlSession {
     this->on_stream_update_ = std::move(cb);
   }
 
-  void request_stopping();
+  void request_stop();
   bool send_rpc_async(
     const std::string &method,
     std::function<void(JsonObject)> fill_params,
@@ -168,7 +172,7 @@ class SnapcastControlSession {
     uint32_t timeout_ms
   );
 
-  ClientState snapshot() {
+  ClientState state_snapshot() {
     xSemaphoreTake(state_mutex_, portMAX_DELAY);
     ClientState copy = this->client_state_;
     xSemaphoreGive(state_mutex_);
@@ -178,15 +182,23 @@ class SnapcastControlSession {
  protected:
   friend SnapcastClient;
 
+  SemaphoreHandle_t config_mutex_{nullptr};
   std::string server_;
   uint32_t port_;
   std::string client_id_;
+  bool connected_{false};
+  
+  TaskHandle_t task_handle_{nullptr};
+  StackType_t *task_stack_buffer_{nullptr};
+  StaticTask_t task_stack_;
+  bool task_exiting_{false};
+  bool task_should_run_{false};
+
   esp_transport_handle_t transport_{nullptr};
-  bool notification_task_should_run_{false};
-  TaskHandle_t notification_task_handle_{nullptr};
   std::string recv_buffer_;
   std::string line_buffer_;
   ClientState client_state_;
+  
   SemaphoreHandle_t state_mutex_{xSemaphoreCreateMutex()};
   std::map<std::string, StreamInfo> known_streams_;
   std::function<void(StreamStatus status, std::string stream_id)> on_stream_update_;
@@ -194,12 +206,14 @@ class SnapcastControlSession {
   QueueHandle_t rpc_queue_{nullptr}; 
   std::unordered_map<uint32_t, PendingCb> pending_;
   std::atomic<uint32_t> next_id_{1};
+  
   void drain_rpc_queue_();
   void expire_pending_();
 
   void request_server_info_(std::function<void(const ClientState&)> cb = nullptr);
   void set_group_stream_(const std::string &stream_id);
   void isolate_client_(std::function<void(const ClientState&)> cb = nullptr);
+  void group_request_stop(const ClientState &state);
 
   void update_from_server_obj_(const JsonObject &server_obj);
 

--- a/esphome/components/snapcast/snapcast_rpc.h
+++ b/esphome/components/snapcast/snapcast_rpc.h
@@ -39,10 +39,13 @@ enum class StreamStatus : uint8_t {
   PLAYING = 2,
 };
 
-static inline StreamStatus parse_status(const char* s) {
-  if (!s) return StreamStatus::UNKNOWN;
-  if (s[0] == 'i') return StreamStatus::IDLE;
-  if (s[0] == 'p') return StreamStatus::PLAYING;
+static inline StreamStatus parse_status(const char *s) {
+  if (!s)
+    return StreamStatus::UNKNOWN;
+  if (s[0] == 'i')
+    return StreamStatus::IDLE;
+  if (s[0] == 'p')
+    return StreamStatus::PLAYING;
   return StreamStatus::UNKNOWN;
 }
 
@@ -56,52 +59,32 @@ struct StreamInfo {
   bool canGoNext{false};
   bool canGoPrevious{false};
 
-  bool init_from_json(JsonObject stream_obj) {
-    const char* sid = stream_obj["id"].as<const char*>();
-    if (!sid) return false;
-    id = sid;
-    return from_json(stream_obj);
-  }
-
   bool from_json(JsonObject stream_obj) {
-    const char* sid = stream_obj["id"].as<const char*>();
-    if (!sid) return false;
+    const char *sid = stream_obj["id"].as<const char *>();
+    if (!sid)
+      return false;
     id = sid;
-    
-    status = parse_status(stream_obj["status"].as<const char*>());
-    canControl = stream_obj["canControl"] | false;
-    canPlay = stream_obj["canPlay"] | false;
-    canPause = stream_obj["canPause"] | false;
-    canSeek = stream_obj["canSeek"] | false;
-    canGoNext = stream_obj["canGoNext"] | false;
-    canGoPrevious = stream_obj["canGoPrevious"] | false;
+    status = parse_status(stream_obj["status"].as<const char *>());
+
+    if (stream_obj["properties"].is<JsonObject>()) {
+      const JsonObject &props = stream_obj["properties"];
+      canControl = props["canControl"].as<bool>();
+      canPlay = props["canPlay"].as<bool>();
+      canPause = props["canPause"].as<bool>();
+      canSeek = props["canSeek"].as<bool>();
+      canGoNext = props["canGoNext"].as<bool>();
+      canGoPrevious = props["canGoPrevious"].as<bool>();
+    }
     return true;
   }
-
-  bool update_from_stream_properties(JsonObject properties) {
-    status = parse_status(properties["playbackStatus"].as<const char*>());
-    canPlay = properties["canPlay"] | false;
-    canPause = properties["canPause"] | false;
-    canSeek = properties["canSeek"] | false;
-    canGoNext = properties["canGoNext"] | false;
-    canGoPrevious = properties["canGoPrevious"] | false;
-    return true;
-  }
-
-  bool set_id(const std::string& stream_id) {
-    id = stream_id;
-    status = StreamStatus::IDLE;
-    return true;
-  }    
 };
-
 
 struct ClientState {
   std::string group_id;
-  StreamInfo sInfo;
   std::string stream_id;
   std::string default_streamid{"default"};
   std::vector<std::string> group_members;
+  std::map<std::string, StreamInfo> known_streams;
   int32_t latency = 0;
   uint8_t volume_percent = 100;
   bool muted = false;
@@ -111,16 +94,17 @@ struct ClientState {
     for (JsonObject group_obj : groups) {
       JsonArray clients = group_obj["clients"].as<JsonArray>();
       for (JsonObject client_obj : clients) {
-        const char* id = client_obj["id"].as<const char*>();
-        if (!id) continue;
+        const char *id = client_obj["id"].as<const char *>();
+        if (!id)
+          continue;
         if (id == client_id) {
-          group_id = group_obj["id"].as<const char*>();
-          stream_id = group_obj["stream_id"].as<const char*>();
+          group_id = group_obj["id"].as<const char *>();
+          stream_id = group_obj["stream_id"].as<const char *>();
           latency = client_obj["config"]["latency"].as<int32_t>();
           volume_percent = client_obj["config"]["volume"]["percent"].as<uint8_t>();
           muted = client_obj["config"]["volume"]["muted"].as<bool>();
           for (JsonObject member : clients) {
-            const char* member_id = member["id"].as<const char*>();
+            const char *member_id = member["id"].as<const char *>();
             if (member_id) {
               group_members.emplace_back(member_id);
             }
@@ -131,8 +115,11 @@ struct ClientState {
     }
     return false;
   }
+  void clear() {
+    group_members.clear();
+    known_streams.clear();
+  }
 };
-
 
 using RpcResponseCb = std::function<void(JsonObject root)>;
 
@@ -140,7 +127,7 @@ struct RpcRequest {
   std::string method;
   uint32_t id;
   std::function<void(JsonObject params)> fill_params;
-  RpcResponseCb on_response;     // optional
+  RpcResponseCb on_response;  // optional
   uint32_t timeout_ms;
 };
 
@@ -149,12 +136,11 @@ struct PendingCb {
   uint32_t expires_ms;
 };
 
-
 class SnapcastClient;
 
 class SnapcastControlSession {
  public:
-  esp_err_t connect(const std::string& server, uint32_t port);
+  esp_err_t connect(const std::string &server, uint32_t port);
   esp_err_t disconnect();
   bool is_connected() const { return this->connected_; }
 
@@ -165,16 +151,19 @@ class SnapcastControlSession {
   }
 
   void request_stop();
-  bool send_rpc_async(
-    const std::string &method,
-    std::function<void(JsonObject)> fill_params,
-    RpcResponseCb on_response,
-    uint32_t timeout_ms
-  );
+  bool send_rpc_async(const std::string &method, std::function<void(JsonObject)> fill_params, RpcResponseCb on_response,
+                      uint32_t timeout_ms);
 
   ClientState state_snapshot() {
     xSemaphoreTake(state_mutex_, portMAX_DELAY);
     ClientState copy = this->client_state_;
+    xSemaphoreGive(state_mutex_);
+    return copy;
+  }
+
+  std::string grp_id_snapshot() {
+    xSemaphoreTake(state_mutex_, portMAX_DELAY);
+    std::string copy = this->client_state_.group_id;
     xSemaphoreGive(state_mutex_);
     return copy;
   }
@@ -187,7 +176,7 @@ class SnapcastControlSession {
   uint32_t port_;
   std::string client_id_;
   bool connected_{false};
-  
+
   TaskHandle_t task_handle_{nullptr};
   StackType_t *task_stack_buffer_{nullptr};
   StaticTask_t task_stack_;
@@ -197,26 +186,25 @@ class SnapcastControlSession {
   esp_transport_handle_t transport_{nullptr};
   std::string recv_buffer_;
   std::string line_buffer_;
-  ClientState client_state_;
-  
+
   SemaphoreHandle_t state_mutex_{xSemaphoreCreateMutex()};
-  std::map<std::string, StreamInfo> known_streams_;
+  ClientState client_state_;
+
   std::function<void(StreamStatus status, std::string stream_id)> on_stream_update_;
 
-  QueueHandle_t rpc_queue_{nullptr}; 
+  QueueHandle_t rpc_queue_{nullptr};
   std::unordered_map<uint32_t, PendingCb> pending_;
   std::atomic<uint32_t> next_id_{1};
-  
+
   void drain_rpc_queue_();
   void expire_pending_();
 
-  void request_server_info_(std::function<void(const ClientState&)> cb = nullptr);
+  void request_server_info_(std::function<void(const ClientState &)> cb = nullptr);
   void set_group_stream_(const std::string &stream_id);
-  void isolate_client_(std::function<void(const ClientState&)> cb = nullptr);
+  void isolate_client_(std::function<void(const ClientState &)> cb = nullptr);
   void group_request_stop(const ClientState &state);
 
   void update_from_server_obj_(const JsonObject &server_obj);
-
 };
 
 }  // namespace snapcast

--- a/esphome/components/snapcast/snapcast_rpc.h
+++ b/esphome/components/snapcast/snapcast_rpc.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <map>
+#include <atomic>
 #include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
 
@@ -32,34 +33,95 @@
 namespace esphome {
 namespace snapcast {
 
-enum class RequestId : uint32_t {
-  GetServerStatus = 1,
-  GetGroupStatus = 2,
-  // etc.
-};
-
 enum class StreamStatus : uint8_t {
   UNKNOWN = 0,
   IDLE = 1,
   PLAYING = 2,
 };
 
+static inline StreamStatus parse_status(const char* s) {
+  if (!s) return StreamStatus::UNKNOWN;
+  if (s[0] == 'i') return StreamStatus::IDLE;
+  if (s[0] == 'p') return StreamStatus::PLAYING;
+  return StreamStatus::UNKNOWN;
+}
+
+struct StreamInfo {
+  std::string id;
+  StreamStatus status{StreamStatus::UNKNOWN};
+  bool canPlay{false};
+  bool canPause{false};
+  bool canSeek{false};
+  bool canGoNext{false};
+  bool canGoPrevious{false};
+
+  bool init_from_json(JsonObject stream_obj) {
+    const char* sid = stream_obj["id"].as<const char*>();
+    if (!sid) return false;
+    id = sid;
+    return from_json(stream_obj);
+  }
+
+  bool from_json(JsonObject stream_obj) {
+    const char* sid = stream_obj["id"].as<const char*>();
+    if (!sid) return false;
+    id = sid;
+    
+    status = parse_status(stream_obj["status"].as<const char*>());
+    canPlay = stream_obj["canPlay"] | false;
+    canPause = stream_obj["canPause"] | false;
+    canSeek = stream_obj["canSeek"] | false;
+    canGoNext = stream_obj["canGoNext"] | false;
+    canGoPrevious = stream_obj["canGoPrevious"] | false;
+    return true;
+  }
+
+  bool update_from_stream_properties(JsonObject properties) {
+    status = parse_status(properties["playbackStatus"].as<const char*>());
+    canPlay = properties["canPlay"] | false;
+    canPause = properties["canPause"] | false;
+    canSeek = properties["canSeek"] | false;
+    canGoNext = properties["canGoNext"] | false;
+    canGoPrevious = properties["canGoPrevious"] | false;
+    return true;
+  }
+
+  bool set_id(const std::string& stream_id) {
+    id = stream_id;
+    status = StreamStatus::IDLE;
+    return true;
+  }    
+};
+
+
 struct ClientState {
   std::string group_id;
   std::string stream_id;
+  std::vector<std::string> group_members;
   int32_t latency = 0;
   uint8_t volume_percent = 100;
   bool muted = false;
 
-  bool from_groups_json(JsonArray groups, std::string client_id) {
+
+  bool from_groups_json(JsonArray groups, std::string &client_id) {
+    this->group_members.clear();
     for (JsonObject group_obj : groups) {
-      for (JsonObject client_obj : group_obj["clients"].as<JsonArray>()) {
-        if (client_obj["id"].as<std::string>() == client_id) {
-          group_id = group_obj["id"].as<std::string>();
-          stream_id = group_obj["stream_id"].as<std::string>();
+      JsonArray clients = group_obj["clients"].as<JsonArray>();
+      for (JsonObject client_obj : clients) {
+        const char* id = client_obj["id"].as<const char*>();
+        if (!id) continue;
+        if (id == client_id) {
+          group_id = group_obj["id"].as<const char*>();
+          stream_id = group_obj["stream_id"].as<const char*>();
           latency = client_obj["config"]["latency"].as<int32_t>();
           volume_percent = client_obj["config"]["volume"]["percent"].as<uint8_t>();
           muted = client_obj["config"]["volume"]["muted"].as<bool>();
+          for (JsonObject member : clients) {
+            const char* member_id = member["id"].as<const char*>();
+            if (member_id) {
+              group_members.emplace_back(member_id);
+            }
+          }
           return true;
         }
       }
@@ -68,74 +130,22 @@ struct ClientState {
   }
 };
 
-struct StreamInfo {
-  std::string id;
-  StreamStatus status;
-  bool canPlay;
-  bool canPause;
-  bool canSeek;
-  bool canGoNext;
-  bool canGoPrevious;
 
-  bool from_json(JsonObject stream_obj) {
-    if (!stream_obj["id"].is<std::string>())
-      return false;
+using RpcResponseCb = std::function<void(JsonObject root)>;
 
-    id = stream_obj["id"].as<std::string>();
-    const char *status_str = stream_obj["status"].as<const char *>();
-    if (!status_str)
-      return false;
-    if (strcmp(status_str, "idle") == 0) {
-      status = StreamStatus::IDLE;
-    } else if (strcmp(status_str, "playing") == 0) {
-      status = StreamStatus::PLAYING;
-    } else {
-      status = StreamStatus::UNKNOWN;
-    }
-    canPlay = stream_obj["canPlay"].as<bool>();
-    canPause = stream_obj["canPause"].as<bool>();
-    canSeek = stream_obj["canSeek"].as<bool>();
-    canGoNext = stream_obj["canGoNext"].as<bool>();
-    canGoPrevious = stream_obj["canGoPrevious"].as<bool>();
-    return true;
-  }
-
-  bool from_streams_json(JsonArray streams, std::string stream_id) {
-    for (JsonObject stream_obj : streams) {
-      if (stream_obj["id"].as<std::string>() == stream_id) {
-        return this->from_json(stream_obj);
-      }
-    }
-    return false;
-  }
-
-  bool from_stream_properties(JsonObject properties) {
-    const char *status_str = properties["playbackStatus"].as<const char *>();
-    if (!status_str)
-      return false;
-    if (strcmp(status_str, "idle") == 0) {
-      status = StreamStatus::IDLE;
-    } else if (strcmp(status_str, "playing") == 0) {
-      status = StreamStatus::PLAYING;
-    } else {
-      status = StreamStatus::UNKNOWN;
-    }
-    canPlay = properties["canPlay"].as<bool>();
-    canPause = properties["canPause"].as<bool>();
-    canSeek = properties["canSeek"].as<bool>();
-    canGoNext = properties["canGoNext"].as<bool>();
-    canGoPrevious = properties["canGoPrevious"].as<bool>();
-    return true;
-  }
-
-  bool set_id(std::string stream_id) {
-    id = stream_id;
-    status = StreamStatus::IDLE;
-    return true;
-  }
-
-  bool set_to_default() { return this->set_id("default"); }
+struct RpcRequest {
+  std::string method;
+  uint32_t id;
+  std::function<void(JsonObject params)> fill_params;
+  RpcResponseCb on_response;     // optional
+  uint32_t timeout_ms;
 };
+
+struct PendingCb {
+  RpcResponseCb cb;
+  uint32_t expires_ms;
+};
+
 
 class SnapcastClient;
 
@@ -150,10 +160,23 @@ class SnapcastControlSession {
     this->on_stream_update_ = std::move(cb);
   }
 
+  void request_stopping();
+  bool send_rpc_async(
+    const std::string &method,
+    std::function<void(JsonObject)> fill_params,
+    RpcResponseCb on_response,
+    uint32_t timeout_ms
+  );
+
+  ClientState snapshot() {
+    xSemaphoreTake(state_mutex_, portMAX_DELAY);
+    ClientState copy = this->client_state_;
+    xSemaphoreGive(state_mutex_);
+    return copy;
+  }
+
  protected:
   friend SnapcastClient;
-  void send_rpc_request_(const std::string &method, std::function<void(JsonObject)> fill_params, uint32_t id);
-  void update_from_server_obj_(const JsonObject &server_obj);
 
   std::string server_;
   uint32_t port_;
@@ -164,8 +187,22 @@ class SnapcastControlSession {
   std::string recv_buffer_;
   std::string line_buffer_;
   ClientState client_state_;
+  SemaphoreHandle_t state_mutex_{xSemaphoreCreateMutex()};
   std::map<std::string, StreamInfo> known_streams_;
   std::function<void(StreamStatus status, std::string stream_id)> on_stream_update_;
+
+  QueueHandle_t rpc_queue_{nullptr}; 
+  std::unordered_map<uint32_t, PendingCb> pending_;
+  std::atomic<uint32_t> next_id_{1};
+  void drain_rpc_queue_();
+  void expire_pending_();
+
+  void request_server_info_(std::function<void(const ClientState&)> cb = nullptr);
+  void set_group_stream_(const std::string &stream_id);
+  void isolate_client_(std::function<void(const ClientState&)> cb = nullptr);
+
+  void update_from_server_obj_(const JsonObject &server_obj);
+
 };
 
 }  // namespace snapcast

--- a/esphome/components/snapcast/snapcast_rpc.h
+++ b/esphome/components/snapcast/snapcast_rpc.h
@@ -38,6 +38,12 @@ enum class RequestId : uint32_t {
   // etc.
 };
 
+enum class StreamStatus : uint8_t {
+  UNKNOWN = 0,
+  IDLE = 1,
+  PLAYING = 2,
+};
+
 struct ClientState {
   std::string group_id;
   std::string stream_id;
@@ -64,7 +70,7 @@ struct ClientState {
 
 struct StreamInfo {
   std::string id;
-  std::string status;
+  StreamStatus status;
   bool canPlay;
   bool canPause;
   bool canSeek;
@@ -76,7 +82,16 @@ struct StreamInfo {
       return false;
 
     id = stream_obj["id"].as<std::string>();
-    status = stream_obj["status"].as<std::string>();
+    const char *status_str = stream_obj["status"].as<const char *>();
+    if (!status_str)
+      return false;
+    if (strcmp(status_str, "idle") == 0) {
+      status = StreamStatus::IDLE;
+    } else if (strcmp(status_str, "playing") == 0) {
+      status = StreamStatus::PLAYING;
+    } else {
+      status = StreamStatus::UNKNOWN;
+    }
     canPlay = stream_obj["canPlay"].as<bool>();
     canPause = stream_obj["canPause"].as<bool>();
     canSeek = stream_obj["canSeek"].as<bool>();
@@ -95,7 +110,16 @@ struct StreamInfo {
   }
 
   bool from_stream_properties(JsonObject properties) {
-    status = properties["playbackStatus"].as<std::string>();
+    const char *status_str = properties["playbackStatus"].as<const char *>();
+    if (!status_str)
+      return false;
+    if (strcmp(status_str, "idle") == 0) {
+      status = StreamStatus::IDLE;
+    } else if (strcmp(status_str, "playing") == 0) {
+      status = StreamStatus::PLAYING;
+    } else {
+      status = StreamStatus::UNKNOWN;
+    }
     canPlay = properties["canPlay"].as<bool>();
     canPause = properties["canPause"].as<bool>();
     canSeek = properties["canSeek"].as<bool>();
@@ -106,7 +130,7 @@ struct StreamInfo {
 
   bool set_id(std::string stream_id) {
     id = stream_id;
-    status = "idle";
+    status = StreamStatus::IDLE;
     return true;
   }
 
@@ -122,7 +146,9 @@ class SnapcastControlSession {
 
   void notification_loop();
 
-  void set_on_stream_update(std::function<void(const StreamInfo &)> cb) { this->on_stream_update_ = std::move(cb); }
+  void set_on_stream_update(std::function<void(StreamStatus, std::string)> cb) {
+    this->on_stream_update_ = std::move(cb);
+  }
 
  protected:
   friend SnapcastClient;
@@ -139,7 +165,7 @@ class SnapcastControlSession {
   std::string line_buffer_;
   ClientState client_state_;
   std::map<std::string, StreamInfo> known_streams_;
-  std::function<void(const StreamInfo &)> on_stream_update_;
+  std::function<void(StreamStatus status, std::string stream_id)> on_stream_update_;
 };
 
 }  // namespace snapcast

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -148,14 +148,10 @@ esp_err_t SnapcastStream::terminate() {
   this->want_connected_ = false;
 
   // close connection and stop all running tasks
-  ESP_LOGI(TAG, "terminate() prev state=%d", this->state_);
   if (this->stream_task_handle_) {
     this->stream_task_exiting_ = true;
     this->set_state_(StreamState::STOPPING);
     xTaskNotify(this->stream_task_handle_, STOP_BIT, eSetBits);
-    auto st = eTaskGetState(this->stream_task_handle_);
-    ESP_LOGI(TAG, "stream task state=%d", (int) st);
-    ESP_LOGI(TAG, "stream stack watermark=%u", uxTaskGetStackHighWaterMark(this->stream_task_handle_));
   }
   return ESP_OK;
 }
@@ -318,12 +314,7 @@ static void transport_task_(SnapcastStream *self, std::shared_ptr<ChunkedRingBuf
     int one = 1;
     setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof(one));
-    // #ifdef TCP_KEEPIDLE
-    //     int idle = 30, intvl = 5, cnt = 3;
-    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
-    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
-    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
-    // #endif
+
     int flags = lwip_fcntl(sock, F_GETFL, 0);
     lwip_fcntl(sock, F_SETFL, flags | O_NONBLOCK);
 
@@ -835,7 +826,7 @@ void SnapcastStream::stream_task_() {
   uint32_t notify_value;
   this->set_state_(StreamState::DISCONNECTED);
   while (true) {
-#if SNAPCAST_DEBUG    
+#if SNAPCAST_DEBUG
     static uint32_t last_log = 0;
     if (millis() - last_log > 10000) {
       ESP_LOGI(TAG, "state=%d destroy=%d desired_conn=%d", this->state_, destroy_requested, this->want_connected_);
@@ -863,7 +854,7 @@ void SnapcastStream::stream_task_() {
     //   return;
     // }
 #endif
-    
+
     TickType_t wait_time = (this->state_ == StreamState::STREAMING) ? STREAMING_WAIT : IDLE_WAIT;
     if (xTaskNotifyWait(0, 0xFFFFFFFF, &notify_value, wait_time)) {
       ESP_LOGI(TAG, "stream notify=0x%08" PRIx32, notify_value);

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -98,59 +98,121 @@ typedef struct {
   int sock;
 } esp_transport_tcp_t;
 
-esp_err_t SnapcastStream::connect(std::string server, uint32_t port) {
-  this->server_ = server;
-  this->port_ = port;
-  if (this->stream_task_handle_ == nullptr) {
+esp_err_t SnapcastStream::init() {
+  if (this->stream_task_handle_ != nullptr) {
+    if (!this->stream_task_exiting_) {
+      // stream task already running
+      return ESP_OK;
+    }
+    if (!this->finalize_termination()) {
+      ESP_LOGW(TAG, "Exiting stream task still in progress");
+      return ESP_ERR_INVALID_STATE;
+    }
+  }
+
+  if (this->task_stack_buffer_ == nullptr) {
     RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
     this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
     if (this->task_stack_buffer_ == nullptr) {
-      ESP_LOGE(TAG, "Failed to allocate memory.");
       this->set_state_(StreamState::ERROR);
       return ESP_ERR_NO_MEM;
     }
-
-    this->set_state_(StreamState::CONNECTING);
-    this->stream_task_handle_ = xTaskCreateStatic(
-        [](void *param) {
-          auto *stream = static_cast<SnapcastStream *>(param);
-          stream->stream_task_();
-          stream->stream_task_handle_ = nullptr;
-          vTaskDelete(nullptr);
-        },
-        "snap_stream_task", TASK_STACK_SIZE, (void *) this, STREAM_TASK_PRIORITY, this->task_stack_buffer_,
-        &this->task_stack_);
-
-    if (this->stream_task_handle_ == nullptr) {
-      ESP_LOGE(TAG, "Failed to create snapcast stream task.");
-      this->set_state_(StreamState::ERROR);
-      return ESP_FAIL;
-    }
   }
+
+  if (!this->config_mutex_) {
+    this->config_mutex_ = xSemaphoreCreateMutex();
+    if (!this->config_mutex_)
+      return ESP_FAIL;
+  }
+
+  this->set_state_(StreamState::STARTING);
+
+  this->stream_task_handle_ = xTaskCreateStatic(
+      [](void *param) {
+        auto *stream = static_cast<SnapcastStream *>(param);
+        stream->stream_task_();
+        vTaskDelete(nullptr);
+      },
+      "snap_stream_task", TASK_STACK_SIZE, (void *) this, STREAM_TASK_PRIORITY, this->task_stack_buffer_,
+      &this->task_stack_);
+  if (this->stream_task_handle_ == nullptr) {
+    this->set_state_(StreamState::ERROR);
+    return ESP_FAIL;
+  }
+
+  this->stream_task_exiting_ = false;
+  return ESP_OK;
+}
+
+esp_err_t SnapcastStream::terminate() {
+  this->want_connected_ = false;
+
+  // close connection and stop all running tasks
+  ESP_LOGI(TAG, "terminate() prev state=%d", this->state_);
+  if (this->stream_task_handle_) {
+    this->stream_task_exiting_ = true;
+    this->set_state_(StreamState::STOPPING);
+    xTaskNotify(this->stream_task_handle_, STOP_BIT, eSetBits);
+    auto st = eTaskGetState(this->stream_task_handle_);
+    ESP_LOGI(TAG, "stream task state=%d", (int) st);
+    ESP_LOGI(TAG, "stream stack watermark=%u", uxTaskGetStackHighWaterMark(this->stream_task_handle_));
+  }
+  return ESP_OK;
+}
+
+bool SnapcastStream::finalize_termination() {
+  if (this->stream_task_handle_ == nullptr) {
+    return true;
+  }
+  auto st = eTaskGetState(this->stream_task_handle_);
+  if (st != eDeleted && st != eInvalid) {
+    // task hasn't terminated yet
+    return false;
+  }
+
+  // TODO: also free stack memory
+
+  this->stream_task_handle_ = nullptr;
+  this->stream_task_exiting_ = false;
+  this->set_state_(StreamState::DESTROYED);
+  return true;
+}
+
+esp_err_t SnapcastStream::connect(const std::string &server, uint32_t port) {
+  if (!this->stream_task_handle_ || this->stream_task_exiting_) {
+    return ESP_ERR_INVALID_STATE;
+  }
+
+  {
+    if (xSemaphoreTake(this->config_mutex_, 0) != pdTRUE) {
+      return ESP_ERR_TIMEOUT;
+    }
+    this->server_ = server;
+    this->port_ = port;
+    this->want_connected_ = true;
+    xSemaphoreGive(this->config_mutex_);
+  }
+
   xTaskNotify(this->stream_task_handle_, CONNECT_BIT, eSetBits);
   return ESP_OK;
 }
 
 esp_err_t SnapcastStream::disconnect() {
-  // close connection and stop all running tasks
-  ESP_LOGI(TAG, "disconnect() prev state=%d", this->state_);
-  if (this->stream_task_handle_) {    
-    this->set_state_(StreamState::STOPPING);
-    xTaskNotify(this->stream_task_handle_, STOP_BIT, eSetBits);
-    auto st = eTaskGetState(this->stream_task_handle_);
-    ESP_LOGI(TAG, "stream task state=%d", (int)st);
-    ESP_LOGI(TAG, "transport stack watermark=%u",
-      uxTaskGetStackHighWaterMark(this->stream_task_handle_));
-                    
-  } else {
-    ESP_LOGI(TAG, "stream_task_handle is null");
-    this->set_state_(StreamState::DESTROYED);
+  if (!this->stream_task_handle_ || this->stream_task_exiting_) {
+    return ESP_ERR_INVALID_STATE;
   }
+
+  this->want_connected_ = false;
+  xTaskNotify(this->stream_task_handle_, DISCONNECT_BIT, eSetBits);
   return ESP_OK;
 }
 
 esp_err_t SnapcastStream::start_with_notify(std::weak_ptr<esphome::TimedRingBuffer> ring_buffer,
                                             TaskHandle_t notification_task) {
+  if (!this->stream_task_handle_ || this->stream_task_exiting_) {
+    return ESP_ERR_INVALID_STATE;
+  }
+
   ESP_LOGD(TAG, "Starting stream...");
   this->write_ring_buffer_ = ring_buffer;
   this->notification_target_ = notification_task;
@@ -159,12 +221,18 @@ esp_err_t SnapcastStream::start_with_notify(std::weak_ptr<esphome::TimedRingBuff
 }
 
 esp_err_t SnapcastStream::stop_streaming() {
+  if (!this->stream_task_handle_ || this->stream_task_exiting_) {
+    return ESP_ERR_INVALID_STATE;
+  }
   ESP_LOGD(TAG, "Stop streaming called...");
   xTaskNotify(this->stream_task_handle_, STOP_STREAM_BIT, eSetBits);
   return ESP_OK;
 }
 
 esp_err_t SnapcastStream::report_volume(uint8_t volume, bool muted) {
+  if (!this->stream_task_handle_ || this->stream_task_exiting_) {
+    return ESP_ERR_INVALID_STATE;
+  }
   const uint8_t old_vol = this->volume_.load(std::memory_order_relaxed);
   const bool old_muted = this->muted_.load(std::memory_order_relaxed);
 
@@ -176,7 +244,7 @@ esp_err_t SnapcastStream::report_volume(uint8_t volume, bool muted) {
   return ESP_OK;
 }
 
-static void transport_task_(const std::string &server, uint32_t port, std::shared_ptr<ChunkedRingBuffer> ring_buffer,
+static void transport_task_(SnapcastStream *self, std::shared_ptr<ChunkedRingBuffer> ring_buffer,
                             TaskHandle_t stream_task_handle, TimeStats *time_stats, QueueHandle_t outgoing_queue) {
   constexpr size_t HEADER_SIZE = sizeof(MessageHeader);
   constexpr size_t MAX_ALLOWED_MSG_SIZE = 8 * 1024;
@@ -204,7 +272,8 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
   size_t discard_remaining = 0;
   uint8_t discard_buf[128];
 
-  volatile bool stop_requested = false;
+  bool stop_requested = false;
+  bool reconnect_requested = false;
   while (!stop_requested) {
     uint32_t notify_value = 0;
     xTaskNotifyWait(0, 0xFFFFFFFFUL, &notify_value, portMAX_DELAY);
@@ -214,6 +283,16 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     if (!(notify_value & CONNECT_BIT)) {
       continue;
     }
+
+    std::string server;
+    uint32_t port;
+    self->get_target_snapshot_(server, port);
+
+    if (server.empty() || port == 0) {
+      // nothing to connect to yet
+      continue;
+    }
+
     // === Create socket and connect ===
     int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if (sock < 0) {
@@ -239,12 +318,12 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     int one = 1;
     setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof(one));
-#ifdef TCP_KEEPIDLE
-    int idle = 30, intvl = 5, cnt = 3;
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
-#endif
+    // #ifdef TCP_KEEPIDLE
+    //     int idle = 30, intvl = 5, cnt = 3;
+    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
+    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
+    // #endif
     int flags = lwip_fcntl(sock, F_GETFL, 0);
     lwip_fcntl(sock, F_SETFL, flags | O_NONBLOCK);
 
@@ -262,13 +341,25 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     while (true) {
       // Check for shutdown signal
       uint32_t notify_value = 0;
-      if (xTaskNotifyWait(0, DISCONNECT_BIT | STOP_BIT, &notify_value, 0) == pdTRUE) {
+      if (xTaskNotifyWait(0, DISCONNECT_BIT | STOP_BIT | CONNECT_BIT, &notify_value, 0) == pdTRUE) {
         if (notify_value & STOP_BIT) {
           stop_requested = true;
           break;
         }
         if (notify_value & DISCONNECT_BIT) {
           break;
+        }
+        if (notify_value & CONNECT_BIT) {
+          std::string new_server;
+          uint32_t new_port;
+          self->get_target_snapshot_(new_server, new_port);
+
+          if (new_server != server || new_port != port) {
+            ESP_LOGI("transport", "Target changed, reconnecting to %s:%lu", new_server.c_str(),
+                     (unsigned long) new_port);
+            reconnect_requested = true;
+            break;
+          }
         }
       }
 
@@ -444,22 +535,22 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
         if (bytes_written < 0) {
           int e = errno;
           ESP_LOGE("transport", "send() failed: errno=%d (%s)", e, strerror(e));
-          if (msg->getMessageType() == message_type::kHello){
+          if (msg->getMessageType() == message_type::kHello) {
             // todo resend hello
           }
           delete msg;
           if (e == EAGAIN || e == EWOULDBLOCK) {
-            // couldn't send right now;         
+            // couldn't send right now;
             goto connection_done;
           }
           goto connection_done;  // fatal send error
         }
-        if ((size_t)bytes_written != want) {
-          ESP_LOGE("transport", "partial send: %d/%u -> reconnect", bytes_written, (unsigned)want);
+        if ((size_t) bytes_written != want) {
+          ESP_LOGE("transport", "partial send: %d/%u -> reconnect", bytes_written, (unsigned) want);
           delete msg;
           goto connection_done;
-        }         
-        
+        }
+
         if (bytes_written > 0 && msg->getMessageType() == message_type::kTime) {
           time_stats->set_request_time(msg->id(), msg->send_time());
         }
@@ -478,6 +569,11 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     xTaskNotify(stream_task_handle, CONNECTION_CLOSED_BIT, eSetBits);
     if (stop_requested)
       break;
+    if (reconnect_requested) {
+      reconnect_requested = false;
+      vTaskDelay(pdMS_TO_TICKS(100));
+      xTaskNotify(xTaskGetCurrentTaskHandle(), CONNECT_BIT, eSetBits);
+    }
   }
   psram_allocator.deallocate(tx_buffer, TX_BUFFER_SIZE);
   xTaskNotify(stream_task_handle, TASK_CLOSING_BIT, eSetBits);
@@ -494,7 +590,7 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
 
   while (millis() < timeout) {
     size_t len = 0;
-    uint8_t *chunk = read_ring_buffer->get_next_chunk(len, timeout_ms);
+    uint8_t *chunk = read_ring_buffer->get_next_chunk(len, pdMS_TO_TICKS(timeout_ms));
     if (len < sizeof(MessageHeader) || chunk == nullptr) {
       // invalid chunk, drop it
       if (chunk != nullptr) {
@@ -644,6 +740,8 @@ void SnapcastStream::stream_task_() {
   std::shared_ptr<ChunkedRingBuffer> stream_package_buffer = ChunkedRingBuffer::create(256 * 1024);
 
   auto on_exit_task = [&]() {
+    this->stream_task_exiting_ = true;
+    ESP_LOGW(TAG, "TASK EXITING FLAG SET");
     if (this->outgoing_queue_) {
       // Drain and delete any pending messages so they don't leak.
       SnapcastMessage *m = nullptr;
@@ -653,11 +751,11 @@ void SnapcastStream::stream_task_() {
       vQueueDelete(this->outgoing_queue_);
       this->outgoing_queue_ = nullptr;
     }
-    this->set_state_(StreamState::DESTROYED);
   };
 
   if (stream_package_buffer == nullptr) {
     ESP_LOGE(TAG, "Failed to create stream package buffer!");
+    this->set_state_(StreamState::ERROR);
     on_exit_task();
     return;
   }
@@ -665,33 +763,31 @@ void SnapcastStream::stream_task_() {
   this->outgoing_queue_ = xQueueCreate(10, sizeof(SnapcastMessage *));
   if (this->outgoing_queue_ == NULL) {
     ESP_LOGE(TAG, "Failed to create outgoing queue!");
+    this->set_state_(StreamState::ERROR);
     on_exit_task();
     return;
   }
 
-  struct ReadTaskArgs {
+  struct TransportTaskArgs {
+    SnapcastStream *self;
     std::shared_ptr<ChunkedRingBuffer> buffer;
-    std::string server;
-    uint32_t port;
     TaskHandle_t stream_task_handle;
-    TimeStats *time_stats_;
+    TimeStats *time_stats;
     QueueHandle_t outgoing_queue;
   };
 
-  ReadTaskArgs *args = new ReadTaskArgs();
+  TransportTaskArgs *args = new TransportTaskArgs();
+  args->self = this;
   args->buffer = stream_package_buffer;
-  args->server = this->server_;
-  args->port = this->port_;
   args->stream_task_handle = xTaskGetCurrentTaskHandle();
-  args->time_stats_ = &this->time_stats_;  // Pass the time stats reference
+  args->time_stats = &this->time_stats_;  // Pass the time stats reference
   args->outgoing_queue = this->outgoing_queue_;
 
   TaskHandle_t transport_task_handle = nullptr;
   BaseType_t result = xTaskCreatePinnedToCore(
       [](void *param) {
-        auto *args = static_cast<ReadTaskArgs *>(param);
-        transport_task_(args->server, args->port, args->buffer, args->stream_task_handle, args->time_stats_,
-                        args->outgoing_queue);
+        auto *args = static_cast<TransportTaskArgs *>(param);
+        transport_task_(args->self, args->buffer, args->stream_task_handle, args->time_stats, args->outgoing_queue);
         delete args;
         vTaskDelete(nullptr);  // Task cleans itself up after loop exits
       },
@@ -705,6 +801,7 @@ void SnapcastStream::stream_task_() {
   if (result != pdPASS) {
     delete args;
     ESP_LOGE(TAG, "Failed to create Snapcast RX/TX task!");
+    this->set_state_(StreamState::ERROR);
     on_exit_task();
     return;
   }
@@ -712,7 +809,6 @@ void SnapcastStream::stream_task_() {
   const uint32_t retry_window_ms = 5000;  // retry for 5 seconds then give up
   const uint32_t max_backoff_ms = 10000;
 
-  bool desired_connected = false;
   bool desired_streaming = false;
   bool destroy_requested = false;
 
@@ -723,8 +819,8 @@ void SnapcastStream::stream_task_() {
     if (destroy_requested)
       return;
     destroy_requested = true;
-    desired_connected = false;
     desired_streaming = false;
+    this->stream_task_exiting_ = true;
     this->set_state_(StreamState::STOPPING);
 
     // Tell transport to stop and exit
@@ -733,36 +829,59 @@ void SnapcastStream::stream_task_() {
 
   constexpr TickType_t STREAMING_WAIT = pdMS_TO_TICKS(5);
   constexpr TickType_t IDLE_WAIT = pdMS_TO_TICKS(10);
+
+  uint32_t last_status_change_repeat = millis();
+
   uint32_t notify_value;
   this->set_state_(StreamState::DISCONNECTED);
   while (true) {
+#if SNAPCAST_DEBUG    
     static uint32_t last_log = 0;
-    
     if (millis() - last_log > 10000) {
-      ESP_LOGI(TAG, "state=%d destroy=%d desired_conn=%d",
-              this->state_, destroy_requested, desired_connected);
-      ESP_LOGI(TAG, "stream stack watermark=%u",
-         uxTaskGetStackHighWaterMark(NULL));
-      if(transport_task_handle){
+      ESP_LOGI(TAG, "state=%d destroy=%d desired_conn=%d", this->state_, destroy_requested, this->want_connected_);
+      ESP_LOGI(TAG, "stream stack watermark=%u", uxTaskGetStackHighWaterMark(NULL));
+      if (transport_task_handle) {
         auto st = eTaskGetState(transport_task_handle);
-        ESP_LOGI(TAG, "transport task state=%d", (int)st);
-        ESP_LOGI(TAG, "transport stack watermark=%u",
-         uxTaskGetStackHighWaterMark(transport_task_handle));
-      }              
+        ESP_LOGI(TAG, "transport task state=%d", (int) st);
+        ESP_LOGI(TAG, "transport stack watermark=%u", uxTaskGetStackHighWaterMark(transport_task_handle));
+      }
+      if (this->notification_target_) {
+        auto st = eTaskGetState(this->notification_target_);
+        ESP_LOGI(TAG, "Notification target state=%d", (int) st);
+        ESP_LOGI(TAG, "Notification target watermark=%u", uxTaskGetStackHighWaterMark(this->notification_target_));
+      }
       last_log = millis();
     }
+
+    // if (millis() - last_status_change_repeat > 60000) {
+    //   ESP_LOGW(TAG, "DEBUG FORCE DISCONNECTING!!!");
+    //   last_status_change_repeat = millis();
+    //   this->set_state_(StreamState::RECONNECTING);
+    //   xTaskNotify(transport_task_handle, DISCONNECT_BIT, eSetBits);
+    //   // this->set_state_( StreamState::ERROR );
+    //   // on_exit_task();
+    //   return;
+    // }
+#endif
     
     TickType_t wait_time = (this->state_ == StreamState::STREAMING) ? STREAMING_WAIT : IDLE_WAIT;
     if (xTaskNotifyWait(0, 0xFFFFFFFF, &notify_value, wait_time)) {
+      ESP_LOGI(TAG, "stream notify=0x%08" PRIx32, notify_value);
+
       if (notify_value & CONNECT_BIT) {
-        desired_connected = true;
         destroy_requested = false;
 
         reconnect_start_ms = 0;
         backoff_ms = 250;
-        // Tell transport to connect
-        this->set_state_(StreamState::CONNECTING);
+        if (this->state_ == StreamState::DISCONNECTED) {
+          // Tell transport to connect
+          this->set_state_(StreamState::CONNECTING);
+        }
         xTaskNotify(transport_task_handle, CONNECT_BIT, eSetBits);
+      }
+
+      if (notify_value & DISCONNECT_BIT) {
+        xTaskNotify(transport_task_handle, DISCONNECT_BIT, eSetBits);
       }
 
       if (notify_value & STOP_BIT) {
@@ -806,10 +925,11 @@ void SnapcastStream::stream_task_() {
       }
 
       if (notify_value & CONNECTION_CLOSED_BIT) {
-        this->set_state_(StreamState::DISCONNECTED);
         this->codec_header_sent_ = false;
-        if (destroy_requested || !desired_connected) {
-          request_destroy();
+        if (destroy_requested) {
+          // pass
+        } else if (!this->want_connected_) {
+          this->set_state_(StreamState::DISCONNECTED);
         } else {
           uint32_t now = millis();
           // start retry window if first failure
@@ -817,8 +937,10 @@ void SnapcastStream::stream_task_() {
             reconnect_start_ms = now;
           // budget check
           if ((now - reconnect_start_ms) > retry_window_ms) {
-            this->error_msg_ = "Reconnect budget exceeded, stopping";
-            request_destroy();
+            ESP_LOGW(TAG, "Reconnect budget exceeded.");
+            stream_package_buffer->reset();
+            this->want_connected_ = false;
+            this->set_state_(StreamState::DISCONNECTED);
           } else {
             // backoff and retry
             vTaskDelay(pdMS_TO_TICKS(backoff_ms));
@@ -836,7 +958,7 @@ void SnapcastStream::stream_task_() {
       if (this->read_and_process_messages_(stream_package_buffer.get(), timeout) == ESP_FAIL) {
         this->set_state_(StreamState::RECONNECTING);
         xTaskNotify(transport_task_handle, DISCONNECT_BIT, eSetBits);
-        ESP_LOGW(TAG, "read_and_process_messages failed, curr_state: %d\n", this->state_ );
+        ESP_LOGW(TAG, "read_and_process_messages failed, curr_state: %d\n", this->state_);
         ESP_LOGW(TAG, "msg: %s\n", this->error_msg_.c_str());
       }
     }
@@ -855,13 +977,21 @@ void SnapcastStream::set_state_(StreamState new_state) {
   }
 }
 
+void SnapcastStream::get_target_snapshot_(std::string &server, uint32_t &port) {
+  xSemaphoreTake(this->config_mutex_, portMAX_DELAY);
+  server = this->server_;
+  port = this->port_;
+  xSemaphoreGive(this->config_mutex_);
+}
+
 void SnapcastStream::start_streaming_() {
   if (this->state_ == StreamState::STREAMING) {
     // notify listeners that already in streaming state
     this->set_state_(StreamState::STREAMING);
     return;
   }
-  if (this->state_ == StreamState::CONNECTED_IDLE || this->state_ == StreamState::RECONNECTING) {
+  if (this->state_ == StreamState::CONNECTED_IDLE || this->state_ == StreamState::RECONNECTING ||
+      this->state_ == StreamState::CONNECTING) {
     auto rb = this->write_ring_buffer_.lock();
     if (!rb) {
       this->error_msg_ = "Ring-buffer not set yet, but trying to start streaming...";
@@ -870,11 +1000,6 @@ void SnapcastStream::start_streaming_() {
     }
     rb->reset();
     this->codec_header_sent_ = false;
-    this->send_hello_();
-    this->set_state_(StreamState::STREAMING);
-    return;
-  }
-  if (this->state_ == StreamState::RECONNECTING) {
     this->send_hello_();
     this->set_state_(StreamState::STREAMING);
     return;

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -209,7 +209,7 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if (sock < 0) {
       ESP_LOGE("transport", "Failed to create socket: errno %d", errno);
-      xTaskNotify(stream_task_handle, CONNECTION_FAILED_BIT, eSetBits);
+      xTaskNotify(stream_task_handle, CONNECTION_CLOSED_BIT, eSetBits);
       continue;
     }
 
@@ -222,7 +222,7 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     if (err != 0) {
       ESP_LOGE("transport", "Socket unable to connect to %s: errno %d", server.c_str(), errno);
       close(sock);
-      xTaskNotify(stream_task_handle, CONNECTION_FAILED_BIT, eSetBits);
+      xTaskNotify(stream_task_handle, CONNECTION_CLOSED_BIT, eSetBits);
       continue;
     }
 
@@ -230,23 +230,17 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     int one = 1;
     setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof(one));
-#ifdef TCP_KEEPIDLE
-    int idle = 30, intvl = 5, cnt = 3;
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
-#endif
+// #ifdef TCP_KEEPIDLE && 0
+//     int idle = 30, intvl = 5, cnt = 3;
+//     setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
+//     setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+//     setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
+// #endif
     int flags = lwip_fcntl(sock, F_GETFL, 0);
     lwip_fcntl(sock, F_SETFL, flags | O_NONBLOCK);
 
     // Notify the RX task that the connection is established
     xTaskNotify(stream_task_handle, CONNECTION_ESTABLISHED_BIT, eSetBits);
-
-    SnapcastMessage *hello_msg = new HelloMessage();
-    hello_msg->set_send_time();
-    hello_msg->toBytes(tx_buffer);
-    int bytes_written = send(sock, (char *) tx_buffer, hello_msg->getMessageSize(), 0);
-    delete hello_msg;
 
     header_have = 0;
     rb_chunk = nullptr;
@@ -281,7 +275,6 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
       int sel = lwip_select(sock + 1, &read_fds, NULL, NULL, &timeout);
       if (sel < 0) {
         ESP_LOGE("transport", "select() error: errno %d", errno);
-        xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
         break;
       }
 
@@ -315,14 +308,12 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
             }
             if (r == 0) {
               ESP_LOGI("transport", "recv() EOF (peer closed)");
-              xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
               goto connection_done;
             }
             int e = errno;
             if (e == EAGAIN || e == EWOULDBLOCK)
               break;
             ESP_LOGE("transport", "recv(discard) error: errno=%d (%s)", e, strerror(e));
-            xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
             goto connection_done;
           }
 
@@ -335,14 +326,12 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
                 // keep looping; maybe more data available
               } else if (r == 0) {
                 ESP_LOGI("transport", "recv() EOF (peer closed)");
-                xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
                 goto connection_done;
               } else {
                 int e = errno;
                 if (e == EAGAIN || e == EWOULDBLOCK)
                   break;  // no more for now
                 ESP_LOGE("transport", "recv(header) error: errno=%d (%s)", e, strerror(e));
-                xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
                 goto connection_done;
               }
             }
@@ -418,7 +407,6 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
 
           if (r == 0) {
             ESP_LOGI("transport", "recv() EOF (peer closed)");
-            xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
             goto connection_done;
           }
 
@@ -428,8 +416,11 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
             break;
           }
 
-          ESP_LOGE("transport", "recv(body) error: errno=%d (%s)", e, strerror(e));
-          xTaskNotify(stream_task_handle, CONNECTION_DROPPED_BIT, eSetBits);
+          int so_err = 0;
+          socklen_t sl = sizeof(so_err);
+          getsockopt(sock, SOL_SOCKET, SO_ERROR, &so_err, &sl);
+          ESP_LOGE("transport", "recv(body) errno=%d (%s), SO_ERROR=%d (%s)", errno, strerror(errno), so_err,
+                   strerror(so_err));
           goto connection_done;
         }
         taskYIELD();
@@ -459,7 +450,7 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     if (stop_requested)
       break;
   }
-  free(tx_buffer);
+  psram_allocator.deallocate(tx_buffer, TX_BUFFER_SIZE);
   xTaskNotify(stream_task_handle, TASK_CLOSING_BIT, eSetBits);
 }
 
@@ -471,6 +462,7 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
     this->error_msg_ = "Read ring buffer is not available";
     return ESP_FAIL;
   }
+  
   while (millis() < timeout) {
     size_t len = 0;
     uint8_t *chunk = read_ring_buffer->get_next_chunk(len, timeout_ms);
@@ -494,38 +486,49 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
     uint8_t *payload = chunk + sizeof(MessageHeader);
     size_t payload_len = msg->typed_message_size;
     switch (msg->getMessageType()) {
-      case message_type::kCodecHeader: {
-        if (this->state_ != StreamState::STREAMING) {
-          read_ring_buffer->release_read_chunk(chunk);
-          continue;
-        }
+      case message_type::kCodecHeader: {        
         CodecHeaderPayloadView codec_header_payload;
         if (!codec_header_payload.bind(payload, payload_len)) {
           read_ring_buffer->release_read_chunk(chunk);
           return ESP_FAIL;
         }
-        timed_chunk_t *timed_chunk = nullptr;
-        size_t size = codec_header_payload.payload_size;
-        timed_ring_buffer->acquire_write_chunk(&timed_chunk, sizeof(timed_chunk_t) + size, pdMS_TO_TICKS(timeout_ms));
-        if (timed_chunk == nullptr) {
-          this->error_msg_ = "Error acquiring write chunk from ring buffer";
-          read_ring_buffer->release_read_chunk(chunk);
-          return ESP_FAIL;
+        if (this->codec_header_) {
+          free(this->codec_header_);
         }
-        timed_chunk->stamp = tv_t(0, 0);
-        if (!codec_header_payload.copyPayloadTo(timed_chunk->data, size)) {
-          timed_ring_buffer->release_write_chunk(timed_chunk, size);
+        size_t size = codec_header_payload.payload_size;
+        RAMAllocator<uint8_t> psram_allocator;
+        this->codec_header_ = psram_allocator.allocate(size);
+        this->codec_header_size_ = size;
+        if (!codec_header_payload.copyPayloadTo(this->codec_header_, size)) {
+          free(this->codec_header_);
+          this->codec_header_ = nullptr;
           this->error_msg_ = "Error copying codec header payload";
           read_ring_buffer->release_read_chunk(chunk);
           return ESP_FAIL;
         }
-        timed_ring_buffer->release_write_chunk(timed_chunk, size);
-        this->codec_header_sent_ = true;
         read_ring_buffer->release_read_chunk(chunk);
         return ESP_OK;
       } break;
       case message_type::kWireChunk: {
-        if (this->state_ != StreamState::STREAMING || !this->codec_header_sent_) {
+        if (this->state_ == StreamState::STREAMING && this->codec_header_ && !this->codec_header_sent_){
+          timed_chunk_t *timed_chunk = nullptr;
+          timed_ring_buffer->acquire_write_chunk(&timed_chunk, sizeof(timed_chunk_t) + this->codec_header_size_, pdMS_TO_TICKS(timeout_ms));
+          if (timed_chunk == nullptr) {
+            this->error_msg_ = "Error acquiring write chunk from ring buffer";
+            read_ring_buffer->release_read_chunk(chunk);
+            return ESP_FAIL;
+          }
+          timed_chunk->stamp = tv_t(0, 0);
+          if (!std::memcpy(timed_chunk->data, this->codec_header_, this->codec_header_size_)){
+            timed_ring_buffer->release_write_chunk(timed_chunk, this->codec_header_size_);
+            this->error_msg_ = "Error copying codec header payload";
+            read_ring_buffer->release_read_chunk(chunk);
+            return ESP_FAIL;
+          }
+          timed_ring_buffer->release_write_chunk(timed_chunk, this->codec_header_size_);
+          this->codec_header_sent_ = true;
+        }
+        if (this->state_ != StreamState::STREAMING || !this->codec_header_sent_ || !this->time_stats_.is_ready()) {
           read_ring_buffer->release_read_chunk(chunk);
           vTaskDelay(pdMS_TO_TICKS(5));
           continue;
@@ -588,15 +591,16 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
         this->on_time_msg_(*msg, stamp);
       }
         read_ring_buffer->release_read_chunk(chunk);
+        vTaskDelay(pdMS_TO_TICKS(1));
         continue;
       case message_type::kServerSettings: {
         ServerSettingsMessage server_settings_msg(*msg, payload, payload_len);
         this->on_server_settings_msg_(server_settings_msg);
-        // server_settings_msg.print();
-      }
         read_ring_buffer->release_read_chunk(chunk);
+        vTaskDelay(pdMS_TO_TICKS(1));
         continue;
-
+      }
+        
       default:
         this->error_msg_ = "Unknown message type: " + to_string(msg->type);
         read_ring_buffer->release_read_chunk(chunk);
@@ -657,25 +661,47 @@ void SnapcastStream::stream_task_() {
     ESP_LOGE(TAG, "Failed to create Snapcast RX/TX task!");
     return;
   }
+  
+  const uint32_t retry_window_ms = 30000;   // e.g. retry for 30 seconds then give up
+  const uint32_t max_backoff_ms  = 10000;
+
+  bool desired_connected = false;
+  bool destroy_requested = false;
+
+  uint32_t reconnect_start_ms = 0;  // 0 means not currently retrying
+  uint32_t backoff_ms = 250;
+
+  auto request_destroy = [&]() {
+    if (destroy_requested) return;
+    destroy_requested = true;
+    desired_connected = false;
+    this->start_after_connecting_ = false;
+    this->set_state_(StreamState::STOPPING);
+
+    // Tell transport to stop and exit
+    xTaskNotify(transport_task_handle, STOP_BIT, eSetBits);
+  };
 
   constexpr TickType_t STREAMING_WAIT = pdMS_TO_TICKS(5);
   constexpr TickType_t IDLE_WAIT = pdMS_TO_TICKS(100);
-
-  bool reconnect_pending = false;
   uint32_t notify_value;
   this->set_state_(StreamState::DISCONNECTED);
   while (true) {
     TickType_t wait_time = (this->state_ == StreamState::STREAMING) ? STREAMING_WAIT : IDLE_WAIT;
     if (xTaskNotifyWait(0, 0xFFFFFFFF, &notify_value, wait_time)) {
       if (notify_value & CONNECT_BIT) {
+        desired_connected = true;
+        destroy_requested = false;
+
+        reconnect_start_ms = 0;
+        backoff_ms = 250;
         // Tell transport to connect
         this->set_state_(StreamState::CONNECTING);
         xTaskNotify(transport_task_handle, CONNECT_BIT, eSetBits);
       }
 
       if (notify_value & STOP_BIT) {
-        this->set_state_(StreamState::STOPPING);
-        xTaskNotify(transport_task_handle, STOP_BIT, eSetBits);
+        request_destroy();
       }
 
       if (notify_value & START_STREAM_BIT) {
@@ -687,16 +713,16 @@ void SnapcastStream::stream_task_() {
       }
 
       if (notify_value & SEND_REPORT_BIT) {
-        if (this->state_ != StreamState::DISCONNECTED) {
+        if (this->state_ == StreamState::CONNECTED_IDLE || this->state_ == StreamState::STREAMING) {
           this->send_report_();
         }
       }
 
       if (notify_value & CONNECTION_ESTABLISHED_BIT) {
-        this->reconnect_counter_ = 0;
-        this->send_hello_();
-        this->time_stats_.reset();
-        set_state_(StreamState::CONNECTED_IDLE);
+        reconnect_start_ms = 0;
+        backoff_ms = 250; 
+        set_state_(StreamState::CONNECTED_IDLE);        
+        this->send_hello_();        
         if (this->start_after_connecting_) {
           this->start_streaming_();
         }
@@ -704,33 +730,29 @@ void SnapcastStream::stream_task_() {
 
       if (notify_value & TASK_CLOSING_BIT) {
         // tx_rx task is closing, we can exit the loop
-        this->set_state_(StreamState::DISCONNECTED);
         break;
       }
-      if (notify_value & CONNECTION_FAILED_BIT) {
-        if (this->reconnect_on_error_()) {
-          this->set_state_(StreamState::RECONNECTING);
-          vTaskDelay(pdMS_TO_TICKS(1000));
-          xTaskNotify(transport_task_handle, CONNECT_BIT, eSetBits);
-        }
-      }
-
-      if (notify_value & CONNECTION_DROPPED_BIT) {
-        if (this->reconnect_on_error_()) {
-          this->error_msg_ = "Failed to connect or connection dropped";
-          this->set_state_(StreamState::RECONNECTING);
-          reconnect_pending = true;
-        } else {
-          this->error_msg_ = "Failed to connect or connection dropped";
-          this->set_state_(StreamState::ERROR);
-        }
-      }
-
+      
       if (notify_value & CONNECTION_CLOSED_BIT) {
         this->set_state_(StreamState::DISCONNECTED);
-        if (reconnect_pending) {
-          reconnect_pending = false;
-          xTaskNotify(transport_task_handle, CONNECT_BIT, eSetBits);
+        this->codec_header_sent_ = false;
+        if (destroy_requested || !desired_connected) {
+          // no reconnect
+        } else {
+          uint32_t now = millis();
+          // start retry window if first failure
+          if (reconnect_start_ms == 0) reconnect_start_ms = now;
+          // budget check
+          if ((now - reconnect_start_ms) > retry_window_ms) {
+            this->error_msg_ = "Reconnect budget exceeded, stopping";
+            request_destroy();
+          } else {
+            // backoff and retry
+            vTaskDelay(pdMS_TO_TICKS(backoff_ms));
+            xTaskNotify(transport_task_handle, CONNECT_BIT, eSetBits);
+            backoff_ms = std::min(backoff_ms * 2u, max_backoff_ms);
+            this->set_state_(StreamState::RECONNECTING);
+          }
         }
       }
     }
@@ -739,10 +761,8 @@ void SnapcastStream::stream_task_() {
       this->send_time_sync_();
       const uint32_t timeout = this->time_stats_.is_ready() ? 500 : 10;
       if (this->read_and_process_messages_(stream_package_buffer.get(), timeout) == ESP_FAIL) {
-        this->error_msg_ = "Error reading or processing messages, initiating a new session";
         this->set_state_(StreamState::RECONNECTING);
         this->start_after_connecting_ = true;
-        reconnect_pending = true;
         xTaskNotify(transport_task_handle, DISCONNECT_BIT, eSetBits);
       }
     }
@@ -785,9 +805,8 @@ void SnapcastStream::start_streaming_() {
     this->set_state_(StreamState::ERROR);
     return;
   }
-  this->codec_header_sent_ = false;
-  this->send_hello_();
   rb->reset();
+  this->codec_header_sent_ = false;
   this->start_after_connecting_ = false;
   this->set_state_(StreamState::STREAMING);
   return;

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -230,12 +230,12 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     int one = 1;
     setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof(one));
-// #ifdef TCP_KEEPIDLE && 0
-//     int idle = 30, intvl = 5, cnt = 3;
-//     setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
-//     setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
-//     setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
-// #endif
+    // #ifdef TCP_KEEPIDLE && 0
+    //     int idle = 30, intvl = 5, cnt = 3;
+    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
+    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
+    // #endif
     int flags = lwip_fcntl(sock, F_GETFL, 0);
     lwip_fcntl(sock, F_SETFL, flags | O_NONBLOCK);
 
@@ -462,7 +462,7 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
     this->error_msg_ = "Read ring buffer is not available";
     return ESP_FAIL;
   }
-  
+
   while (millis() < timeout) {
     size_t len = 0;
     uint8_t *chunk = read_ring_buffer->get_next_chunk(len, timeout_ms);
@@ -486,7 +486,7 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
     uint8_t *payload = chunk + sizeof(MessageHeader);
     size_t payload_len = msg->typed_message_size;
     switch (msg->getMessageType()) {
-      case message_type::kCodecHeader: {        
+      case message_type::kCodecHeader: {
         CodecHeaderPayloadView codec_header_payload;
         if (!codec_header_payload.bind(payload, payload_len)) {
           read_ring_buffer->release_read_chunk(chunk);
@@ -510,16 +510,17 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
         return ESP_OK;
       } break;
       case message_type::kWireChunk: {
-        if (this->state_ == StreamState::STREAMING && this->codec_header_ && !this->codec_header_sent_){
+        if (this->state_ == StreamState::STREAMING && this->codec_header_ && !this->codec_header_sent_) {
           timed_chunk_t *timed_chunk = nullptr;
-          timed_ring_buffer->acquire_write_chunk(&timed_chunk, sizeof(timed_chunk_t) + this->codec_header_size_, pdMS_TO_TICKS(timeout_ms));
+          timed_ring_buffer->acquire_write_chunk(&timed_chunk, sizeof(timed_chunk_t) + this->codec_header_size_,
+                                                 pdMS_TO_TICKS(timeout_ms));
           if (timed_chunk == nullptr) {
             this->error_msg_ = "Error acquiring write chunk from ring buffer";
             read_ring_buffer->release_read_chunk(chunk);
             return ESP_FAIL;
           }
           timed_chunk->stamp = tv_t(0, 0);
-          if (!std::memcpy(timed_chunk->data, this->codec_header_, this->codec_header_size_)){
+          if (!std::memcpy(timed_chunk->data, this->codec_header_, this->codec_header_size_)) {
             timed_ring_buffer->release_write_chunk(timed_chunk, this->codec_header_size_);
             this->error_msg_ = "Error copying codec header payload";
             read_ring_buffer->release_read_chunk(chunk);
@@ -600,7 +601,7 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
         vTaskDelay(pdMS_TO_TICKS(1));
         continue;
       }
-        
+
       default:
         this->error_msg_ = "Unknown message type: " + to_string(msg->type);
         read_ring_buffer->release_read_chunk(chunk);
@@ -661,9 +662,9 @@ void SnapcastStream::stream_task_() {
     ESP_LOGE(TAG, "Failed to create Snapcast RX/TX task!");
     return;
   }
-  
-  const uint32_t retry_window_ms = 30000;   // e.g. retry for 30 seconds then give up
-  const uint32_t max_backoff_ms  = 10000;
+
+  const uint32_t retry_window_ms = 30000;  // e.g. retry for 30 seconds then give up
+  const uint32_t max_backoff_ms = 10000;
 
   bool desired_connected = false;
   bool destroy_requested = false;
@@ -672,7 +673,8 @@ void SnapcastStream::stream_task_() {
   uint32_t backoff_ms = 250;
 
   auto request_destroy = [&]() {
-    if (destroy_requested) return;
+    if (destroy_requested)
+      return;
     destroy_requested = true;
     desired_connected = false;
     this->start_after_connecting_ = false;
@@ -720,9 +722,9 @@ void SnapcastStream::stream_task_() {
 
       if (notify_value & CONNECTION_ESTABLISHED_BIT) {
         reconnect_start_ms = 0;
-        backoff_ms = 250; 
-        set_state_(StreamState::CONNECTED_IDLE);        
-        this->send_hello_();        
+        backoff_ms = 250;
+        set_state_(StreamState::CONNECTED_IDLE);
+        this->send_hello_();
         if (this->start_after_connecting_) {
           this->start_streaming_();
         }
@@ -732,7 +734,7 @@ void SnapcastStream::stream_task_() {
         // tx_rx task is closing, we can exit the loop
         break;
       }
-      
+
       if (notify_value & CONNECTION_CLOSED_BIT) {
         this->set_state_(StreamState::DISCONNECTED);
         this->codec_header_sent_ = false;
@@ -741,7 +743,8 @@ void SnapcastStream::stream_task_() {
         } else {
           uint32_t now = millis();
           // start retry window if first failure
-          if (reconnect_start_ms == 0) reconnect_start_ms = now;
+          if (reconnect_start_ms == 0)
+            reconnect_start_ms = now;
           // budget check
           if ((now - reconnect_start_ms) > retry_window_ms) {
             this->error_msg_ = "Reconnect budget exceeded, stopping";

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -133,9 +133,17 @@ esp_err_t SnapcastStream::connect(std::string server, uint32_t port) {
 
 esp_err_t SnapcastStream::disconnect() {
   // close connection and stop all running tasks
-  if (this->stream_task_handle_) {
+  ESP_LOGI(TAG, "disconnect() prev state=%d", this->state_);
+  if (this->stream_task_handle_) {    
+    this->set_state_(StreamState::STOPPING);
     xTaskNotify(this->stream_task_handle_, STOP_BIT, eSetBits);
+    auto st = eTaskGetState(this->stream_task_handle_);
+    ESP_LOGI(TAG, "stream task state=%d", (int)st);
+    ESP_LOGI(TAG, "transport stack watermark=%u",
+      uxTaskGetStackHighWaterMark(this->stream_task_handle_));
+                    
   } else {
+    ESP_LOGI(TAG, "stream_task_handle is null");
     this->set_state_(StreamState::DESTROYED);
   }
   return ESP_OK;
@@ -431,7 +439,27 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
       if (xQueueReceive(outgoing_queue, &msg, 0) == pdPASS) {
         msg->set_send_time();
         msg->toBytes(tx_buffer);
-        int bytes_written = send(sock, (char *) tx_buffer, msg->getMessageSize(), 0);
+        const size_t want = msg->getMessageSize();
+        int bytes_written = send(sock, (char *) tx_buffer, want, 0);
+        if (bytes_written < 0) {
+          int e = errno;
+          ESP_LOGE("transport", "send() failed: errno=%d (%s)", e, strerror(e));
+          if (msg->getMessageType() == message_type::kHello){
+            // todo resend hello
+          }
+          delete msg;
+          if (e == EAGAIN || e == EWOULDBLOCK) {
+            // couldn't send right now;         
+            goto connection_done;
+          }
+          goto connection_done;  // fatal send error
+        }
+        if ((size_t)bytes_written != want) {
+          ESP_LOGE("transport", "partial send: %d/%u -> reconnect", bytes_written, (unsigned)want);
+          delete msg;
+          goto connection_done;
+        }         
+        
         if (bytes_written > 0 && msg->getMessageType() == message_type::kTime) {
           time_stats->set_request_time(msg->id(), msg->send_time());
         }
@@ -704,10 +732,26 @@ void SnapcastStream::stream_task_() {
   };
 
   constexpr TickType_t STREAMING_WAIT = pdMS_TO_TICKS(5);
-  constexpr TickType_t IDLE_WAIT = pdMS_TO_TICKS(100);
+  constexpr TickType_t IDLE_WAIT = pdMS_TO_TICKS(10);
   uint32_t notify_value;
   this->set_state_(StreamState::DISCONNECTED);
   while (true) {
+    static uint32_t last_log = 0;
+    
+    if (millis() - last_log > 10000) {
+      ESP_LOGI(TAG, "state=%d destroy=%d desired_conn=%d",
+              this->state_, destroy_requested, desired_connected);
+      ESP_LOGI(TAG, "stream stack watermark=%u",
+         uxTaskGetStackHighWaterMark(NULL));
+      if(transport_task_handle){
+        auto st = eTaskGetState(transport_task_handle);
+        ESP_LOGI(TAG, "transport task state=%d", (int)st);
+        ESP_LOGI(TAG, "transport stack watermark=%u",
+         uxTaskGetStackHighWaterMark(transport_task_handle));
+      }              
+      last_log = millis();
+    }
+    
     TickType_t wait_time = (this->state_ == StreamState::STREAMING) ? STREAMING_WAIT : IDLE_WAIT;
     if (xTaskNotifyWait(0, 0xFFFFFFFF, &notify_value, wait_time)) {
       if (notify_value & CONNECT_BIT) {
@@ -765,7 +809,7 @@ void SnapcastStream::stream_task_() {
         this->set_state_(StreamState::DISCONNECTED);
         this->codec_header_sent_ = false;
         if (destroy_requested || !desired_connected) {
-          // no reconnect
+          request_destroy();
         } else {
           uint32_t now = millis();
           // start retry window if first failure
@@ -792,6 +836,8 @@ void SnapcastStream::stream_task_() {
       if (this->read_and_process_messages_(stream_package_buffer.get(), timeout) == ESP_FAIL) {
         this->set_state_(StreamState::RECONNECTING);
         xTaskNotify(transport_task_handle, DISCONNECT_BIT, eSetBits);
+        ESP_LOGW(TAG, "read_and_process_messages failed, curr_state: %d\n", this->state_ );
+        ESP_LOGW(TAG, "msg: %s\n", this->error_msg_.c_str());
       }
     }
   }

--- a/esphome/components/snapcast/snapcast_stream.cpp
+++ b/esphome/components/snapcast/snapcast_stream.cpp
@@ -151,6 +151,7 @@ esp_err_t SnapcastStream::start_with_notify(std::weak_ptr<esphome::TimedRingBuff
 }
 
 esp_err_t SnapcastStream::stop_streaming() {
+  ESP_LOGD(TAG, "Stop streaming called...");
   xTaskNotify(this->stream_task_handle_, STOP_STREAM_BIT, eSetBits);
   return ESP_OK;
 }
@@ -230,12 +231,12 @@ static void transport_task_(const std::string &server, uint32_t port, std::share
     int one = 1;
     setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof(one));
-    // #ifdef TCP_KEEPIDLE && 0
-    //     int idle = 30, intvl = 5, cnt = 3;
-    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
-    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
-    //     setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
-    // #endif
+#ifdef TCP_KEEPIDLE
+    int idle = 30, intvl = 5, cnt = 3;
+    setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
+    setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+    setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt));
+#endif
     int flags = lwip_fcntl(sock, F_GETFL, 0);
     lwip_fcntl(sock, F_SETFL, flags | O_NONBLOCK);
 
@@ -614,14 +615,29 @@ esp_err_t SnapcastStream::read_and_process_messages_(ChunkedRingBuffer *read_rin
 void SnapcastStream::stream_task_() {
   std::shared_ptr<ChunkedRingBuffer> stream_package_buffer = ChunkedRingBuffer::create(256 * 1024);
 
+  auto on_exit_task = [&]() {
+    if (this->outgoing_queue_) {
+      // Drain and delete any pending messages so they don't leak.
+      SnapcastMessage *m = nullptr;
+      while (xQueueReceive(this->outgoing_queue_, &m, 0) == pdPASS) {
+        delete m;
+      }
+      vQueueDelete(this->outgoing_queue_);
+      this->outgoing_queue_ = nullptr;
+    }
+    this->set_state_(StreamState::DESTROYED);
+  };
+
   if (stream_package_buffer == nullptr) {
     ESP_LOGE(TAG, "Failed to create stream package buffer!");
+    on_exit_task();
     return;
   }
 
   this->outgoing_queue_ = xQueueCreate(10, sizeof(SnapcastMessage *));
   if (this->outgoing_queue_ == NULL) {
     ESP_LOGE(TAG, "Failed to create outgoing queue!");
+    on_exit_task();
     return;
   }
 
@@ -659,14 +675,17 @@ void SnapcastStream::stream_task_() {
       1);
 
   if (result != pdPASS) {
+    delete args;
     ESP_LOGE(TAG, "Failed to create Snapcast RX/TX task!");
+    on_exit_task();
     return;
   }
 
-  const uint32_t retry_window_ms = 30000;  // e.g. retry for 30 seconds then give up
+  const uint32_t retry_window_ms = 5000;  // retry for 5 seconds then give up
   const uint32_t max_backoff_ms = 10000;
 
   bool desired_connected = false;
+  bool desired_streaming = false;
   bool destroy_requested = false;
 
   uint32_t reconnect_start_ms = 0;  // 0 means not currently retrying
@@ -677,7 +696,7 @@ void SnapcastStream::stream_task_() {
       return;
     destroy_requested = true;
     desired_connected = false;
-    this->start_after_connecting_ = false;
+    desired_streaming = false;
     this->set_state_(StreamState::STOPPING);
 
     // Tell transport to stop and exit
@@ -707,10 +726,12 @@ void SnapcastStream::stream_task_() {
       }
 
       if (notify_value & START_STREAM_BIT) {
+        desired_streaming = true;
         this->start_streaming_();
       }
 
       if (notify_value & STOP_STREAM_BIT) {
+        desired_streaming = false;
         this->stop_streaming_();
       }
 
@@ -723,15 +744,20 @@ void SnapcastStream::stream_task_() {
       if (notify_value & CONNECTION_ESTABLISHED_BIT) {
         reconnect_start_ms = 0;
         backoff_ms = 250;
-        set_state_(StreamState::CONNECTED_IDLE);
         this->send_hello_();
-        if (this->start_after_connecting_) {
+        this->time_stats_.reset();
+        if (desired_streaming) {
           this->start_streaming_();
+        } else {
+          set_state_(StreamState::CONNECTED_IDLE);
         }
       }
 
       if (notify_value & TASK_CLOSING_BIT) {
         // tx_rx task is closing, we can exit the loop
+        if (desired_streaming) {
+          this->set_state_(StreamState::ERROR);
+        }
         break;
       }
 
@@ -765,23 +791,12 @@ void SnapcastStream::stream_task_() {
       const uint32_t timeout = this->time_stats_.is_ready() ? 500 : 10;
       if (this->read_and_process_messages_(stream_package_buffer.get(), timeout) == ESP_FAIL) {
         this->set_state_(StreamState::RECONNECTING);
-        this->start_after_connecting_ = true;
         xTaskNotify(transport_task_handle, DISCONNECT_BIT, eSetBits);
       }
     }
   }
 
-  if (this->outgoing_queue_) {
-    // Drain and delete any pending messages so they don't leak.
-    SnapcastMessage *m = nullptr;
-    while (xQueueReceive(this->outgoing_queue_, &m, 0) == pdPASS) {
-      delete m;
-    }
-    vQueueDelete(this->outgoing_queue_);
-    this->outgoing_queue_ = nullptr;
-  }
-
-  this->set_state_(StreamState::DESTROYED);
+  on_exit_task();
 }
 
 void SnapcastStream::set_state_(StreamState new_state) {
@@ -796,30 +811,34 @@ void SnapcastStream::set_state_(StreamState new_state) {
 
 void SnapcastStream::start_streaming_() {
   if (this->state_ == StreamState::STREAMING) {
+    // notify listeners that already in streaming state
+    this->set_state_(StreamState::STREAMING);
     return;
   }
-  if (this->state_ != StreamState::CONNECTED_IDLE) {
-    this->start_after_connecting_ = true;
+  if (this->state_ == StreamState::CONNECTED_IDLE || this->state_ == StreamState::RECONNECTING) {
+    auto rb = this->write_ring_buffer_.lock();
+    if (!rb) {
+      this->error_msg_ = "Ring-buffer not set yet, but trying to start streaming...";
+      this->set_state_(StreamState::ERROR);
+      return;
+    }
+    rb->reset();
+    this->codec_header_sent_ = false;
+    this->send_hello_();
+    this->set_state_(StreamState::STREAMING);
     return;
   }
-  auto rb = this->write_ring_buffer_.lock();
-  if (!rb) {
-    this->error_msg_ = "Ring-buffer not set yet, but trying to start streaming...";
-    this->set_state_(StreamState::ERROR);
+  if (this->state_ == StreamState::RECONNECTING) {
+    this->send_hello_();
+    this->set_state_(StreamState::STREAMING);
     return;
   }
-  rb->reset();
-  this->codec_header_sent_ = false;
-  this->start_after_connecting_ = false;
-  this->set_state_(StreamState::STREAMING);
-  return;
 }
 
 void SnapcastStream::stop_streaming_() {
   if (this->state_ != StreamState::STREAMING) {
     return;
   }
-  this->start_after_connecting_ = false;
   this->set_state_(StreamState::CONNECTED_IDLE);
 }
 

--- a/esphome/components/snapcast/snapcast_stream.h
+++ b/esphome/components/snapcast/snapcast_stream.h
@@ -38,25 +38,30 @@ using namespace audio;
 namespace snapcast {
 
 enum class StreamState {
-  DESTROYED,     // stream_task and transport_task not running
+  DESTROYED,  // stream_task and transport_task not running
+  STARTING,
   DISCONNECTED,  // stream_task is running, not connected yet
   CONNECTING,
-  RECONNECTING,    // Requested to reconnect
   CONNECTED_IDLE,  // Connected but waiting
   STREAMING,       // Receiving data
+  RECONNECTING,
+  STOPPING,        // Requested shutdown
   ERROR,           // Fatal or recoverable error
-  STOPPING         // Requested shutdown
 };
 
 class SnapcastClient;
 
 class SnapcastStream {
  public:
+  esp_err_t init();
+  esp_err_t terminate();
+  bool finalize_termination();
+
   /// @brief Establish a connection to the Snapcast server.
   /// @param server The hostname or IP address of the Snapcast server.
   /// @param port The TCP port to connect to on the server.
   /// @return `ESP_OK` on success, or an appropriate error code.
-  esp_err_t connect(std::string server, uint32_t port);
+  esp_err_t connect(const std::string& server, uint32_t port);
 
   /// @brief Disconnect from the Snapcast server.
   /// @return `ESP_OK` on success, or an appropriate error code.
@@ -67,7 +72,8 @@ class SnapcastStream {
   /// @param notification_task A FreeRTOS task to be notified on status changes.
   /// @return `ESP_OK` on success, or an appropriate error code.
   esp_err_t start_with_notify(std::weak_ptr<esphome::TimedRingBuffer> ring_buffer, TaskHandle_t notification_task);
-
+  void clear_notification_target() { this->notification_target_ = nullptr; }
+  
   /// @brief Stop the audio/data stream and return to an idle state.
   /// @return `ESP_OK` on success, or an appropriate error code.
   esp_err_t stop_streaming();
@@ -78,17 +84,16 @@ class SnapcastStream {
   /// @return `ESP_OK` on success, or an appropriate error code.
   esp_err_t report_volume(uint8_t volume, bool muted);
 
-  /// @brief Check if the stream is connected (either idle or actively streaming).
-  /// @return `true` if connected, `false` otherwise.
   bool is_connected() const {
-    return this->state_ == StreamState::STREAMING || this->state_ == StreamState::CONNECTED_IDLE;
+    return this->state_ == StreamState::CONNECTED_IDLE || this->state_ == StreamState::STREAMING;
   }
-
-  /// @brief Check if the stream is actively receiving data.
-  /// @return `true` if streaming is in progress, `false` otherwise.
-  bool is_running() const { return this->state_ == StreamState::STREAMING; }
-
   bool is_destroyed() const { return this->state_ == StreamState::DESTROYED; }
+  bool is_terminating() const { return this->stream_task_exiting_; }
+
+  bool server_is_lost() const { return this->state_ == StreamState::DISCONNECTED && !this->want_connected_; }
+
+  bool error_enforces_termination() const { return this->state_ == StreamState::ERROR && this->stream_task_exiting_; }
+  bool is_streaming() const { return this->state_ == StreamState::STREAMING; }
 
   /// @brief Set a callback to be invoked on stream status updates.
   /// @param cb A function receiving state, volume, and mute information.
@@ -96,13 +101,16 @@ class SnapcastStream {
     this->on_status_update_ = std::move(cb);
   }
 
+  void get_target_snapshot_(std::string &server, uint32_t &port);
+
  protected:
   friend SnapcastClient;
   void on_server_settings_msg_(const ServerSettingsMessage &msg);
   void on_time_msg_(MessageHeader msg, tv_t time);
 
+  SemaphoreHandle_t config_mutex_{nullptr};
   std::string server_;
-  uint32_t port_;
+  uint32_t port_{0};
   uint32_t server_buffer_size_{0};
   int32_t latency_{0};
   std::atomic<uint8_t> volume_{0};
@@ -110,6 +118,7 @@ class SnapcastStream {
 
   StreamState state_{StreamState::DESTROYED};
   std::string error_msg_;
+  bool want_connected_{false};
 
   tv_t to_local_time_(tv_t server_time) const {
     return server_time - this->est_time_diff_.load(std::memory_order_relaxed) +
@@ -125,9 +134,15 @@ class SnapcastStream {
   std::function<void(StreamState state, uint8_t volume, bool muted)> on_status_update_;
 
  private:
-  TaskHandle_t stream_task_handle_{nullptr};
-  StaticTask_t task_stack_;
   StackType_t *task_stack_buffer_{nullptr};
+
+  TaskHandle_t stream_task_handle_{nullptr};
+  std::atomic<bool> stream_task_exiting_{false};
+  StaticTask_t task_stack_;
+
+  TaskHandle_t transport_task_handle_{nullptr};
+  std::atomic<bool> transport_task_exiting_{false};
+
   QueueHandle_t outgoing_queue_{nullptr};
 
   void stream_task_();

--- a/esphome/components/snapcast/snapcast_stream.h
+++ b/esphome/components/snapcast/snapcast_stream.h
@@ -48,7 +48,6 @@ enum class StreamState {
   STOPPING         // Requested shutdown
 };
 
-
 class SnapcastClient;
 
 class SnapcastStream {

--- a/esphome/components/snapcast/snapcast_stream.h
+++ b/esphome/components/snapcast/snapcast_stream.h
@@ -45,8 +45,8 @@ enum class StreamState {
   CONNECTED_IDLE,  // Connected but waiting
   STREAMING,       // Receiving data
   RECONNECTING,
-  STOPPING,        // Requested shutdown
-  ERROR,           // Fatal or recoverable error
+  STOPPING,  // Requested shutdown
+  ERROR,     // Fatal or recoverable error
 };
 
 class SnapcastClient;
@@ -61,7 +61,7 @@ class SnapcastStream {
   /// @param server The hostname or IP address of the Snapcast server.
   /// @param port The TCP port to connect to on the server.
   /// @return `ESP_OK` on success, or an appropriate error code.
-  esp_err_t connect(const std::string& server, uint32_t port);
+  esp_err_t connect(const std::string &server, uint32_t port);
 
   /// @brief Disconnect from the Snapcast server.
   /// @return `ESP_OK` on success, or an appropriate error code.
@@ -73,7 +73,7 @@ class SnapcastStream {
   /// @return `ESP_OK` on success, or an appropriate error code.
   esp_err_t start_with_notify(std::weak_ptr<esphome::TimedRingBuffer> ring_buffer, TaskHandle_t notification_task);
   void clear_notification_target() { this->notification_target_ = nullptr; }
-  
+
   /// @brief Stop the audio/data stream and return to an idle state.
   /// @return `ESP_OK` on success, or an appropriate error code.
   esp_err_t stop_streaming();

--- a/esphome/components/snapcast/snapcast_stream.h
+++ b/esphome/components/snapcast/snapcast_stream.h
@@ -143,7 +143,6 @@ class SnapcastStream {
 
   esp_err_t read_and_process_messages_(ChunkedRingBuffer *read_ring_buffer, uint32_t timeout_ms);
 
-  bool start_after_connecting_{false};
   bool codec_header_sent_{false};
   uint8_t *codec_header_{nullptr};
   size_t codec_header_size_{0};

--- a/esphome/components/snapcast/snapcast_stream.h
+++ b/esphome/components/snapcast/snapcast_stream.h
@@ -48,7 +48,6 @@ enum class StreamState {
   STOPPING         // Requested shutdown
 };
 
-constexpr uint8_t MAX_RECONNECTIONS = 3;
 
 class SnapcastClient;
 
@@ -102,7 +101,6 @@ class SnapcastStream {
   friend SnapcastClient;
   void on_server_settings_msg_(const ServerSettingsMessage &msg);
   void on_time_msg_(MessageHeader msg, tv_t time);
-  bool reconnect_on_error_() { return ++(this->reconnect_counter_) < MAX_RECONNECTIONS; }
 
   std::string server_;
   uint32_t port_;
@@ -110,7 +108,6 @@ class SnapcastStream {
   int32_t latency_{0};
   std::atomic<uint8_t> volume_{0};
   std::atomic<bool> muted_{false};
-  uint32_t reconnect_counter_{0};
 
   StreamState state_{StreamState::DESTROYED};
   std::string error_msg_;
@@ -149,6 +146,8 @@ class SnapcastStream {
 
   bool start_after_connecting_{false};
   bool codec_header_sent_{false};
+  uint8_t *codec_header_{nullptr};
+  size_t codec_header_size_{0};
 };
 
 }  // namespace snapcast

--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -73,11 +73,11 @@ void AudioPipeline::start_file(audio::AudioFile *audio_file) {
 }
 
 #if USE_SNAPCAST
-void AudioPipeline::start_snapcast(snapcast::SnapcastStream *stream) {
+void AudioPipeline::start_snapcast(snapcast::SnapcastClient *client) {
   if (this->is_playing_) {
     xEventGroupSetBits(this->event_group_, PIPELINE_COMMAND_STOP);
   }
-  this->snapcast_stream_ = stream;
+  this->snapcast_client_ = client;
   this->pending_snapcast_ = true;
 }
 #endif
@@ -389,7 +389,7 @@ void AudioPipeline::read_task(void *params) {
       }
 #if USE_SNAPCAST
       else if (event_bits & EventGroupBits::READER_COMMAND_INIT_SNAPCAST) {
-        err = reader->start(this_pipeline->snapcast_stream_, this_pipeline->current_audio_file_type_);
+        err = reader->start(this_pipeline->snapcast_client_, this_pipeline->current_audio_file_type_);
       }
 #endif
 

--- a/esphome/components/speaker/media_player/audio_pipeline.h
+++ b/esphome/components/speaker/media_player/audio_pipeline.h
@@ -17,7 +17,7 @@
 namespace esphome {
 #if USE_SNAPCAST
 namespace snapcast {
-class SnapcastStream;
+class SnapcastClient;
 }
 #endif
 namespace speaker {
@@ -83,9 +83,9 @@ class AudioPipeline {
 
 #if USE_SNAPCAST
   /// @brief Starts an audio pipeline given a pointer to a snapcast stream
-  /// @param stream Pointer to a snapcast stream
+  /// @param client Pointer to the snapcast client
   /// @return ESP_OK if successful or an appropriate error if not
-  void start_snapcast(snapcast::SnapcastStream *stream);
+  void start_snapcast(snapcast::SnapcastClient *client);
 #endif
 
   /// @brief Stops the pipeline. Sends a stop signal to each task (if running) and clears the ring buffers.
@@ -139,7 +139,7 @@ class AudioPipeline {
   std::string current_uri_{};
   audio::AudioFile *current_audio_file_{nullptr};
 #if USE_SNAPCAST
-  snapcast::SnapcastStream *snapcast_stream_{nullptr};
+  snapcast::SnapcastClient *snapcast_client_{nullptr};
 #endif
   audio::AudioFileType current_audio_file_type_;
   audio::AudioStreamInfo current_audio_stream_info_;

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -392,7 +392,7 @@ void SpeakerMediaPlayer::loop() {
 #if USE_SNAPCAST
           if (this->snapcast_client_ && this->snapcast_client_->is_snapcast_url(next_item.value().url.value())) {
             this->snapcast_client_->connect_to_url(next_item.value().url.value());
-            this->media_pipeline_->start_snapcast(this->snapcast_client_->get_stream());
+            this->media_pipeline_->start_snapcast(this->snapcast_client_);
           } else
 #endif
           {

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -555,6 +555,11 @@ void SpeakerMediaPlayer::set_mute_state_(bool mute_state, bool restore_only) {
       this->defer([this]() { this->unmute_trigger_->trigger(); });
     }
   }
+#if USE_SNAPCAST
+  if (this->snapcast_client_) {
+    this->snapcast_client_->report_volume(this->volume, this->is_muted_);
+  }
+#endif
 }
 
 void SpeakerMediaPlayer::set_volume_(float volume, bool publish, bool restore_only) {


### PR DESCRIPTION
## Snapcast
- refactoring lifecycle management of streaming task
- several bug fixes
- HA media player "stop/pause" now sends rpc-message to let snapcast server stop the stream
- HA media player "mute" is now sent correctly
