### PR TITLE
media_player: Fix stuck in muted issue

### DIFF
--- a/esphome/components/snapcast/snapcast_client.cpp
+++ b/esphome/components/snapcast/snapcast_client.cpp
@@ -182,8 +182,8 @@ void SnapcastClient::on_stream_state_update(StreamState stream_state, uint8_t vo
       this->media_player_ != nullptr && volume >= 0 && volume <= 100) {
     this->media_player_->make_call()
         .set_volume(volume / 100.)
-        .set_command(muted ? media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_MUTE
-                           : media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_UNMUTE)
+        .set_command(muted || volume == 0 ? media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_MUTE
+                                          : media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_UNMUTE)
         .perform();
     return;
   }

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -228,7 +228,6 @@ void SpeakerMediaPlayer::watch_media_commands_() {
           break;
         case media_player::MEDIA_PLAYER_COMMAND_MUTE: {
           this->set_mute_state_(true);
-
           this->publish_state();
           break;
         }
@@ -489,6 +488,9 @@ void SpeakerMediaPlayer::control(const media_player::MediaPlayerCall &call) {
 
   if (call.get_volume().has_value()) {
     media_command.volume = call.get_volume().value();
+    if (call.get_command().has_value()) {
+      media_command.command = call.get_command().value();
+    }
     // Wait 0 ticks for queue to be free, volume sets aren't that important!
     xQueueSend(this->media_control_command_queue_, &media_command, 0);
     return;
@@ -555,16 +557,21 @@ void SpeakerMediaPlayer::set_mute_state_(bool mute_state, bool restore_only) {
     } else {
       this->defer([this]() { this->unmute_trigger_.trigger(); });
     }
-  }
 #if USE_SNAPCAST
-  if (this->snapcast_client_) {
-    this->snapcast_client_->report_volume(this->volume, this->is_muted_);
-  }
+    if (this->snapcast_client_) {
+      float report_volume = this->volume;
+      if (this->is_muted_ && this->volume < 0.01) {
+        report_volume = 0.01;
+      }
+      this->snapcast_client_->report_volume(report_volume, this->is_muted_);
+    }
 #endif
+  }
 }
 
 void SpeakerMediaPlayer::set_volume_(float volume, bool publish, bool restore_only) {
   // Remap the volume to fit with in the configured limits
+  volume = clamp<float>(volume, 0.0, 1.0);
   float bounded_volume = remap<float, float>(volume, 0.0f, 1.0f, this->volume_min_, this->volume_max_);
 
   if (!restore_only) {
@@ -576,20 +583,32 @@ void SpeakerMediaPlayer::set_volume_(float volume, bool publish, bool restore_on
     }
   }
 
-  if (publish) {
+  if (volume < 0.001) {
+    this->volume = 0.001;
+  } else {
     this->volume = volume;
+  }
+
+  bool muted_changed = false;
+  // Turn on the mute state if the volume is effectively zero, off otherwise
+  if (volume < 0.001 && !this->is_muted_) {
+    this->set_mute_state_(true);
+    muted_changed = true;
+  } else if (this->is_muted_) {
+    this->set_mute_state_(false);
+    muted_changed = true;
+  }
+  if (publish) {
     this->save_volume_restore_state_();
   }
 
-  // Turn on the mute state if the volume is effectively zero, off otherwise
-  if (volume < 0.001) {
-    this->set_mute_state_(true);
-  } else {
-    this->set_mute_state_(false);
-  }
 #if USE_SNAPCAST
-  if (this->snapcast_client_) {
-    this->snapcast_client_->report_volume(volume, this->is_muted_);
+  if (this->snapcast_client_ && !muted_changed) {
+    float report_volume = this->volume;
+    if (this->is_muted_ && this->volume < 0.01) {
+      report_volume = 0.01;
+    }
+    this->snapcast_client_->report_volume(report_volume, this->is_muted_);
   }
 #endif
   this->defer([this, volume]() { this->volume_trigger_.trigger(volume); });


### PR DESCRIPTION
The media_player interprets volume==0 as muted, but also a bug lets media_player to ignore MUTED and UNMUTED commands. This could result in a state where the media_player kept stuck in muted state.

