### PR TITLE
Migrate to ESPHome 2026.3.X

### DIFF
--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -18,7 +18,7 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2026.2.4
+      esphome-version: 2026.3.3
       release-summary: develop-branch
       release-url:
       release-version:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -80,7 +80,7 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2026.2.4
+      esphome-version: 2026.3.3
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
   push-tag:

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -36,7 +36,7 @@ esphome:
   name: ${node_name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2026.2.0
+  min_version: 2026.3.0
 
   project:
     name: ${company_name}.${project_name}

--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -1,4 +1,5 @@
 import esphome.codegen as cg
+from esphome.components.esp32 import add_idf_component
 import esphome.config_validation as cv
 from esphome.const import CONF_BITS_PER_SAMPLE, CONF_NUM_CHANNELS, CONF_SAMPLE_RATE
 import esphome.final_validate as fv
@@ -165,4 +166,8 @@ def final_validate_audio_schema(
 
 
 async def to_code(config):
-    cg.add_library("esphome/esp-audio-libs", "1.1.4")
+    add_idf_component(
+        name="esphome/esp-audio-libs",
+        ref="2.0.3",
+    )
+    

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -65,6 +65,11 @@ esp_err_t AudioDecoder::start(AudioFileType audio_file_type) {
 #ifdef USE_AUDIO_FLAC_SUPPORT
     case AudioFileType::FLAC:
       this->flac_decoder_ = make_unique<esp_audio_libs::flac::FLACDecoder>();
+      //xCRC check slows down decoding by 15-20% on an ESP32-S3. FLAC sources in ESPHome are either from an http source
+      // or built into the firmware, so the data integrity is already verified by the time it gets to the decoder,
+      // making the CRC check unnecessary.
+      this->flac_decoder_->set_crc_check_enabled(false);
+
       this->free_buffer_required_ =
           this->output_transfer_buffer_->capacity();  // Adjusted and reallocated after reading the header
       break;

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -65,9 +65,9 @@ esp_err_t AudioDecoder::start(AudioFileType audio_file_type) {
 #ifdef USE_AUDIO_FLAC_SUPPORT
     case AudioFileType::FLAC:
       this->flac_decoder_ = make_unique<esp_audio_libs::flac::FLACDecoder>();
-      //xCRC check slows down decoding by 15-20% on an ESP32-S3. FLAC sources in ESPHome are either from an http source
-      // or built into the firmware, so the data integrity is already verified by the time it gets to the decoder,
-      // making the CRC check unnecessary.
+      // xCRC check slows down decoding by 15-20% on an ESP32-S3. FLAC sources in ESPHome are either from an http source
+      //  or built into the firmware, so the data integrity is already verified by the time it gets to the decoder,
+      //  making the CRC check unnecessary.
       this->flac_decoder_->set_crc_check_enabled(false);
 
       this->free_buffer_required_ =
@@ -287,9 +287,9 @@ FileDecoderState AudioDecoder::decode_flac_() {
   static uint32_t counter = 0;
 #endif
 
-  auto result = this->flac_decoder_->decode_frame(
-      this->input_transfer_buffer_->get_buffer_start(), this->input_transfer_buffer_->available(),
-      this->output_transfer_buffer_->get_buffer_end(), &output_samples);
+  auto result = this->flac_decoder_->decode_frame(this->input_transfer_buffer_->get_buffer_start(),
+                                                  this->input_transfer_buffer_->available(),
+                                                  this->output_transfer_buffer_->get_buffer_end(), &output_samples);
 
 #if SNAPCAST_DEBUG
   time_acc += micros() - start_time_stamp;

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -284,7 +284,7 @@ FileDecoderState AudioDecoder::decode_flac_() {
 
   auto result = this->flac_decoder_->decode_frame(
       this->input_transfer_buffer_->get_buffer_start(), this->input_transfer_buffer_->available(),
-      reinterpret_cast<int16_t *>(this->output_transfer_buffer_->get_buffer_end()), &output_samples);
+      this->output_transfer_buffer_->get_buffer_end(), &output_samples);
 
 #if SNAPCAST_DEBUG
   time_acc += micros() - start_time_stamp;
@@ -337,7 +337,7 @@ FileDecoderState AudioDecoder::decode_mp3_() {
 
   // Advance read pointer to match the offset for the syncword
   this->input_transfer_buffer_->decrease_buffer_length(offset);
-  uint8_t *buffer_start = this->input_transfer_buffer_->get_buffer_start();
+  const uint8_t *buffer_start = this->input_transfer_buffer_->get_buffer_start();
 
   buffer_length = (int) this->input_transfer_buffer_->available();
   int err = esp_audio_libs::helix_decoder::MP3Decode(this->mp3_decoder_, &buffer_start, &buffer_length,

--- a/esphome/components/audio/audio_transfer_buffer.cpp
+++ b/esphome/components/audio/audio_transfer_buffer.cpp
@@ -2,6 +2,8 @@
 
 #ifdef USE_ESP32
 
+#include <cstring>
+
 #include "esphome/core/helpers.h"
 
 namespace esphome {
@@ -75,12 +77,32 @@ bool AudioTransferBuffer::has_buffered_data() const {
 }
 
 bool AudioTransferBuffer::reallocate(size_t new_buffer_size) {
-  if (this->buffer_length_ > 0) {
-    // Buffer currently has data, so reallocation is impossible
+  if (this->buffer_ == nullptr) {
+    return this->allocate_buffer_(new_buffer_size);
+  }
+
+  if (new_buffer_size < this->buffer_length_) {
+    // New size is too small to hold existing data
     return false;
   }
-  this->deallocate_buffer_();
-  return this->allocate_buffer_(new_buffer_size);
+
+  // Shift existing data to the start of the buffer so realloc preserves it
+  if ((this->buffer_length_ > 0) && (this->data_start_ != this->buffer_)) {
+    std::memmove(this->buffer_, this->data_start_, this->buffer_length_);
+    this->data_start_ = this->buffer_;
+  }
+
+  RAMAllocator<uint8_t> allocator;
+  uint8_t *new_buffer = allocator.reallocate(this->buffer_, new_buffer_size);
+  if (new_buffer == nullptr) {
+    // Reallocation failed, but the original buffer is still valid
+    return false;
+  }
+
+  this->buffer_ = new_buffer;
+  this->data_start_ = this->buffer_;
+  this->buffer_size_ = new_buffer_size;
+  return true;
 }
 
 bool AudioTransferBuffer::allocate_buffer_(size_t buffer_size) {
@@ -115,7 +137,7 @@ size_t AudioSourceTransferBuffer::transfer_data_from_source(TickType_t ticks_to_
   if (pre_shift) {
     // Shift data in buffer to start
     if (this->buffer_length_ > 0) {
-      memmove(this->buffer_, this->data_start_, this->buffer_length_);
+      std::memmove(this->buffer_, this->data_start_, this->buffer_length_);
     }
     this->data_start_ = this->buffer_;
   }
@@ -150,7 +172,7 @@ size_t AudioSinkTransferBuffer::transfer_data_to_sink(TickType_t ticks_to_wait, 
 
   if (post_shift) {
     // Shift unwritten data to the start of the buffer
-    memmove(this->buffer_, this->data_start_, this->buffer_length_);
+    std::memmove(this->buffer_, this->data_start_, this->buffer_length_);
     this->data_start_ = this->buffer_;
   }
 

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -57,7 +57,10 @@ class AudioTransferBuffer {
   /// @brief Tests if there is any data in the transfer buffer or the source/sink.
   /// @return True if there is data, false otherwise.
   virtual bool has_buffered_data() const;
-
+  
+  /// @brief Reallocates the transfer buffer, preserving any existing data.
+  /// @param new_buffer_size The new size in bytes. Must be at least as large as available().
+  /// @return True if successful, false otherwise. On failure, the original buffer remains valid.
   bool reallocate(size_t new_buffer_size);
 
  protected:
@@ -110,6 +113,7 @@ class AudioSinkTransferBuffer : public AudioTransferBuffer {
   void clear_buffered_data() override;
 
   bool has_buffered_data() const override;
+
 
  protected:
 #ifdef USE_SPEAKER

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -57,7 +57,7 @@ class AudioTransferBuffer {
   /// @brief Tests if there is any data in the transfer buffer or the source/sink.
   /// @return True if there is data, false otherwise.
   virtual bool has_buffered_data() const;
-  
+
   /// @brief Reallocates the transfer buffer, preserving any existing data.
   /// @param new_buffer_size The new size in bytes. Must be at least as large as available().
   /// @return True if successful, false otherwise. On failure, the original buffer remains valid.
@@ -113,7 +113,6 @@ class AudioSinkTransferBuffer : public AudioTransferBuffer {
   void clear_buffered_data() override;
 
   bool has_buffered_data() const override;
-
 
  protected:
 #ifdef USE_SPEAKER

--- a/esphome/components/fusb302b/__init__.py
+++ b/esphome/components/fusb302b/__init__.py
@@ -77,6 +77,7 @@ PD_ACTION_SCHEMA = automation.maybe_simple_id({cv.GenerateID(): cv.use_id(PowerD
         },
         key=CONF_REQUEST_VOLTAGE,
     ),
+    synchronous=True,
 )
 async def power_delivery_request_voltage_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -99,11 +99,16 @@ def _set_stream_limits(config):
     return config
 
 def _validate_esp32_variant(config):
-    if config[CONF_DAC_TYPE] != "internal":
-        return config
     variant = esp32.get_esp32_variant()
-    if variant not in INTERNAL_DAC_VARIANTS:
-        raise cv.Invalid(f"{variant} does not have an internal DAC")
+    if config[CONF_DAC_TYPE] == "internal":
+        if variant not in INTERNAL_DAC_VARIANTS:
+            raise cv.Invalid(f"{variant} does not have an internal DAC")
+    elif (
+        variant == esp32.const.VARIANT_ESP32
+        and config.get(CONF_BITS_PER_SAMPLE) == 8
+        and config.get(CONF_CHANNEL) in (CONF_MONO, CONF_LEFT, CONF_RIGHT)
+    ):
+        raise cv.Invalid("8-bit mono mode is not supported on ESP32")
     return config
 
 

--- a/esphome/components/memory_flasher/__init__.py
+++ b/esphome/components/memory_flasher/__init__.py
@@ -341,6 +341,7 @@ FLASH_ACTION_SCHEMA = cv.All(
     "memory_flasher.write_image",
     FlashAction,
     FLASH_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def flash_image_action_to_code(config, action_id, template_arg, args):
     flasher = await cg.get_variable(config[CONF_FLASHER_ID])
@@ -369,7 +370,9 @@ FlASH_EMBEDDED_ACTION_SCHEMA = automation.maybe_simple_id(
 @automation.register_action(
     "memory_flasher.write_embedded_image", 
     FlashEmbeddedAction, 
-    FlASH_EMBEDDED_ACTION_SCHEMA)
+    FlASH_EMBEDDED_ACTION_SCHEMA,
+    synchronous=True,
+)
 async def flash_embedded_image_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_FLASHER_ID])
@@ -384,7 +387,9 @@ ERASE_MEMORY_ACTION_SCHEMA = automation.maybe_simple_id(
 @automation.register_action(
     "memory_flasher.erase", 
     EraseAction, 
-    ERASE_MEMORY_ACTION_SCHEMA)
+    ERASE_MEMORY_ACTION_SCHEMA,
+    synchronous=True,
+)
 async def erase_memory_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_FLASHER_ID])

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -529,8 +529,8 @@ async def to_code(config):
 MICRO_WAKE_WORD_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(MicroWakeWord)})
 
 
-@register_action("micro_wake_word.start", StartAction, MICRO_WAKE_WORD_ACTION_SCHEMA)
-@register_action("micro_wake_word.stop", StopAction, MICRO_WAKE_WORD_ACTION_SCHEMA)
+@register_action("micro_wake_word.start", StartAction, MICRO_WAKE_WORD_ACTION_SCHEMA, synchronous=True)
+@register_action("micro_wake_word.stop", StopAction, MICRO_WAKE_WORD_ACTION_SCHEMA, synchronous=True)
 @register_condition(
     "micro_wake_word.is_running", IsRunningCondition, MICRO_WAKE_WORD_ACTION_SCHEMA
 )
@@ -551,16 +551,18 @@ MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA = automation.maybe_simple_id(
     "micro_wake_word.enable_model",
     EnableModelAction,
     MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 @register_action(
     "micro_wake_word.disable_model",
     DisableModelAction,
     MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 @register_condition(
     "micro_wake_word.model_is_enabled",
     ModelIsEnabledCondition,
-    MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA,
+    MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA    
 )
 async def model_action(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -80,6 +80,7 @@ bool StreamingModel::load_model_() {
     TfLiteTensor *output = this->interpreter_->output(0);
     if ((output->dims->size != 2) || (output->dims->data[0] != 1) || (output->dims->data[1] != 1)) {
       ESP_LOGE(TAG, "Streaming model tensor output dimension is not 1x1.");
+      return false;
     }
 
     if (output->type != kTfLiteUInt8) {

--- a/esphome/components/mixer/speaker/__init__.py
+++ b/esphome/components/mixer/speaker/__init__.py
@@ -156,6 +156,7 @@ async def to_code(config):
             ),
         }
     ),
+    synchronous=True,
 )
 async def ducking_set_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/satellite1/audio_dac/__init__.py
+++ b/esphome/components/satellite1/audio_dac/__init__.py
@@ -91,9 +91,9 @@ async def to_code(config):
 
 DAC_ACTION_SCHEMA = automation.maybe_simple_id({cv.GenerateID(): cv.use_id(DACProxy)})
 
-@automation.register_action("dac_proxy.activate", ActivateAction, DAC_ACTION_SCHEMA)
-@automation.register_action("dac_proxy.activate_line_out", ActivateLineOutAction, DAC_ACTION_SCHEMA)
-@automation.register_action("dac_proxy.activate_speaker", ActivateSpeakerAction, DAC_ACTION_SCHEMA)
+@automation.register_action("dac_proxy.activate", ActivateAction, DAC_ACTION_SCHEMA, synchronous=True)
+@automation.register_action("dac_proxy.activate_line_out", ActivateLineOutAction, DAC_ACTION_SCHEMA, synchronous=True)
+@automation.register_action("dac_proxy.activate_speaker", ActivateSpeakerAction, DAC_ACTION_SCHEMA, synchronous=True)
 async def tas2780_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])

--- a/esphome/components/satellite1/satellite1.py
+++ b/esphome/components/satellite1/satellite1.py
@@ -85,7 +85,9 @@ RESET_XMOS_ACTION_SCHEMA = automation.maybe_simple_id(
 @automation.register_action(
     "satellite1.xmos_hardware_reset", 
     XMOSHardwareResetAction, 
-    RESET_XMOS_ACTION_SCHEMA)
+    RESET_XMOS_ACTION_SCHEMA,
+    synchronous=True,
+)
 async def erase_memory_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_SATELLITE1])

--- a/esphome/components/snapcast/__init__.py
+++ b/esphome/components/snapcast/__init__.py
@@ -67,8 +67,8 @@ SNAPCAST_ACTION_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("snapcast.enable", EnableAction, SNAPCAST_ACTION_SCHEMA)
-@automation.register_action("snapcast.disable", DisableAction, SNAPCAST_ACTION_SCHEMA)
+@automation.register_action("snapcast.enable", EnableAction, SNAPCAST_ACTION_SCHEMA, synchronous=True)
+@automation.register_action("snapcast.disable", DisableAction, SNAPCAST_ACTION_SCHEMA, synchronous=True)
 async def tas2780_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -78,6 +78,7 @@ async def speaker_action(config, action_id, template_arg, args):
         },
         key=CONF_DATA,
     ),
+    synchronous=True,
 )
 async def speaker_play_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -92,10 +93,10 @@ async def speaker_play_action(config, action_id, template_arg, args):
     return var
 
 
-automation.register_action("speaker.stop", StopAction, SPEAKER_AUTOMATION_SCHEMA)(
+automation.register_action("speaker.stop", StopAction, SPEAKER_AUTOMATION_SCHEMA, synchronous=True)(
     speaker_action
 )
-automation.register_action("speaker.finish", FinishAction, SPEAKER_AUTOMATION_SCHEMA)(
+automation.register_action("speaker.finish", FinishAction, SPEAKER_AUTOMATION_SCHEMA, synchronous=True)(
     speaker_action
 )
 
@@ -118,6 +119,7 @@ automation.register_condition(
         },
         key=CONF_VOLUME,
     ),
+    synchronous=True,
 )
 async def speaker_volume_set_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -128,9 +130,9 @@ async def speaker_volume_set_action(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "speaker.mute_off", MuteOffAction, SPEAKER_AUTOMATION_SCHEMA
+    "speaker.mute_off", MuteOffAction, SPEAKER_AUTOMATION_SCHEMA, synchronous=True,
 )
-@automation.register_action("speaker.mute_on", MuteOnAction, SPEAKER_AUTOMATION_SCHEMA)
+@automation.register_action("speaker.mute_on", MuteOnAction, SPEAKER_AUTOMATION_SCHEMA, synchronous=True)
 async def speaker_mute_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/speaker/media_player/__init__.py
+++ b/esphome/components/speaker/media_player/__init__.py
@@ -456,6 +456,7 @@ async def to_code(config):
         },
         key=CONF_MEDIA_FILE,
     ),
+    synchronous=True,
 )
 async def play_on_device_media_media_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -480,6 +481,7 @@ async def play_on_device_media_media_action(config, action_id, template_arg, arg
         },
         key=CONF_VOLUME,
     ),
+    synchronous=True,
 )
 async def restore_volume_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/speaker/media_player/__init__.py
+++ b/esphome/components/speaker/media_player/__init__.py
@@ -15,6 +15,8 @@ from esphome.const import (
     CONF_FORMAT,
     CONF_ID,
     CONF_NUM_CHANNELS,
+    CONF_ON_TURN_OFF,
+    CONF_ON_TURN_ON,
     CONF_PATH,
     CONF_RAW_DATA_ID,
     CONF_SAMPLE_RATE,
@@ -345,6 +347,9 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    if CONF_ON_TURN_OFF in config or CONF_ON_TURN_ON in config:
+        cg.add_define("USE_SPEAKER_MEDIA_PLAYER_ON_OFF", True)
+    
     if CORE.data[DOMAIN][config[CONF_ID].id][CONF_CODEC_SUPPORT_ENABLED]:
         # Compile all supported audio codecs
         cg.add_define("USE_AUDIO_FLAC_SUPPORT", True)

--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -566,8 +566,8 @@ void AudioPipeline::decode_task(void *params) {
 
         if (!started_playback && has_stream_info) {
           // Verify enough data is available before starting playback
-          size_t curr_bytes = this_pipeline->reader_output_rb_->bytes_available();
-          if (curr_bytes >= initial_bytes_to_buffer) {
+          if (this_pipeline->reader_output_rb_ != nullptr &&
+              this_pipeline->reader_output_rb_->bytes_available() >= initial_bytes_to_buffer) {
             started_playback = true;
           }
         }

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -147,7 +147,7 @@ void SpeakerMediaPlayer::watch_media_commands_() {
         this->state = media_player::MEDIA_PLAYER_STATE_ON;
         publish_state();
       }
-#endif      
+#endif
       PlaylistItem playlist_item;
       if (media_command.url.has_value()) {
         playlist_item.url = *media_command.url.value();
@@ -197,7 +197,7 @@ void SpeakerMediaPlayer::watch_media_commands_() {
             this->state = media_player::MEDIA_PLAYER_STATE_ON;
             publish_state();
           }
-#endif        
+#endif
           if ((this->media_pipeline_ != nullptr) && (this->is_paused_)) {
             this->media_pipeline_->set_pause_state(false);
           }
@@ -213,7 +213,7 @@ void SpeakerMediaPlayer::watch_media_commands_() {
         case media_player::MEDIA_PLAYER_COMMAND_TURN_OFF:
           this->is_turn_off_ = true;
           // Intentional Fall-through
-#endif          
+#endif
         case media_player::MEDIA_PLAYER_COMMAND_PAUSE:
         case media_player::MEDIA_PLAYER_COMMAND_STOP:
           // Pipelines do not stop immediately after calling the stop command, so confirm its stopped before unpausing.
@@ -221,9 +221,9 @@ void SpeakerMediaPlayer::watch_media_commands_() {
 #ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
           if (this->single_pipeline_() || (media_command.announce.has_value() && media_command.announce.value()) ||
               (this->is_turn_off_ && this->announcement_pipeline_state_ != AudioPipelineState::STOPPED)) {
-#else          
+#else
           if (this->single_pipeline_() || (media_command.announce.has_value() && media_command.announce.value())) {
-#endif            
+#endif
             if (this->announcement_pipeline_ != nullptr) {
               this->cancel_timeout("next_ann");
               this->announcement_playlist_.clear();
@@ -444,12 +444,12 @@ void SpeakerMediaPlayer::loop() {
       } else {
         this->curr_media_item_.reset();
 #ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
-          if (this->state != media_player::MEDIA_PLAYER_STATE_OFF) {
-            this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
-          }
-#else        
+        if (this->state != media_player::MEDIA_PLAYER_STATE_OFF) {
+          this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
+        }
+#else
         this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
-#endif        
+#endif
       }
     }
 

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -417,7 +417,7 @@ void SpeakerMediaPlayer::loop() {
         uint32_t timeout_ms = 0;
         if (this->curr_media_item_.has_value()) {
           // Only delay starting playback if moving on the next playlist item or repeating the current item
-          timeout_ms = this->announcement_playlist_delay_ms_;
+          timeout_ms = this->media_playlist_delay_ms_;
         }
         this->curr_media_item_ = next_item.value();
         if (next_item.value().url.has_value()) {

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -57,7 +57,11 @@ static const float FIRST_BOOT_DEFAULT_VOLUME = 0.5f;
 static const char *const TAG = "speaker_media_player";
 
 void SpeakerMediaPlayer::setup() {
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+  state = media_player::MEDIA_PLAYER_STATE_OFF;
+#else
   state = media_player::MEDIA_PLAYER_STATE_IDLE;
+#endif
 
   this->media_control_command_queue_ = xQueueCreate(MEDIA_CONTROLS_QUEUE_LENGTH, sizeof(MediaCallCommand));
 
@@ -138,6 +142,12 @@ void SpeakerMediaPlayer::watch_media_commands_() {
     bool enqueue = media_command.enqueue.has_value() && media_command.enqueue.value();
 
     if (media_command.url.has_value() || media_command.file.has_value()) {
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+      if (this->state == media_player::MEDIA_PLAYER_STATE_OFF) {
+        this->state = media_player::MEDIA_PLAYER_STATE_ON;
+        publish_state();
+      }
+#endif      
       PlaylistItem playlist_item;
       if (media_command.url.has_value()) {
         playlist_item.url = *media_command.url.value();
@@ -182,16 +192,38 @@ void SpeakerMediaPlayer::watch_media_commands_() {
     if (media_command.command.has_value()) {
       switch (media_command.command.value()) {
         case media_player::MEDIA_PLAYER_COMMAND_PLAY:
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+          if (this->state == media_player::MEDIA_PLAYER_STATE_OFF) {
+            this->state = media_player::MEDIA_PLAYER_STATE_ON;
+            publish_state();
+          }
+#endif        
           if ((this->media_pipeline_ != nullptr) && (this->is_paused_)) {
             this->media_pipeline_->set_pause_state(false);
           }
           this->is_paused_ = false;
           break;
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+        case media_player::MEDIA_PLAYER_COMMAND_TURN_ON:
+          if (this->state == media_player::MEDIA_PLAYER_STATE_OFF) {
+            this->state = media_player::MEDIA_PLAYER_STATE_ON;
+            this->publish_state();
+          }
+          break;
+        case media_player::MEDIA_PLAYER_COMMAND_TURN_OFF:
+          this->is_turn_off_ = true;
+          // Intentional Fall-through
+#endif          
         case media_player::MEDIA_PLAYER_COMMAND_PAUSE:
         case media_player::MEDIA_PLAYER_COMMAND_STOP:
           // Pipelines do not stop immediately after calling the stop command, so confirm its stopped before unpausing.
           // This avoids an audible short segment playing after receiving the stop command in a paused state.
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+          if (this->single_pipeline_() || (media_command.announce.has_value() && media_command.announce.value()) ||
+              (this->is_turn_off_ && this->announcement_pipeline_state_ != AudioPipelineState::STOPPED)) {
+#else          
           if (this->single_pipeline_() || (media_command.announce.has_value() && media_command.announce.value())) {
+#endif            
             if (this->announcement_pipeline_ != nullptr) {
               this->cancel_timeout("next_ann");
               this->announcement_playlist_.clear();
@@ -411,7 +443,13 @@ void SpeakerMediaPlayer::loop() {
         }
       } else {
         this->curr_media_item_.reset();
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+          if (this->state != media_player::MEDIA_PLAYER_STATE_OFF) {
+            this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
+          }
+#else        
         this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
+#endif        
       }
     }
 
@@ -423,6 +461,20 @@ void SpeakerMediaPlayer::loop() {
     this->publish_state();
     ESP_LOGD(TAG, "State changed to %s", media_player::media_player_state_to_string(this->state));
   }
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+  if (this->is_turn_off_ && (this->state == media_player::MEDIA_PLAYER_STATE_PAUSED ||
+                             this->state == media_player::MEDIA_PLAYER_STATE_IDLE)) {
+    this->is_turn_off_ = false;
+    if (this->state == media_player::MEDIA_PLAYER_STATE_PAUSED) {
+      this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
+      this->publish_state();
+      ESP_LOGD(TAG, "State changed to %s", media_player::media_player_state_to_string(this->state));
+    }
+    this->state = media_player::MEDIA_PLAYER_STATE_OFF;
+    this->publish_state();
+    ESP_LOGD(TAG, "State changed to %s", media_player::media_player_state_to_string(this->state));
+  }
+#endif
 }
 
 void SpeakerMediaPlayer::play_file(audio::AudioFile *media_file, bool announcement, bool enqueue) {
@@ -513,6 +565,9 @@ media_player::MediaPlayerTraits SpeakerMediaPlayer::get_traits() {
   if (!this->single_pipeline_()) {
     traits.set_supports_pause(true);
   }
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+  traits.set_supports_turn_off_on(true);
+#endif
 
   if (this->announcement_format_.has_value()) {
     traits.get_supported_formats().push_back(this->announcement_format_.value());

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -159,6 +159,9 @@ class SpeakerMediaPlayer : public Component,
 
   bool is_paused_{false};
   bool is_muted_{false};
+#ifdef USE_SPEAKER_MEDIA_PLAYER_ON_OFF
+  bool is_turn_off_{false};
+#endif
   uint8_t unpause_media_remaining_{0};
   uint8_t unpause_announcement_remaining_{0};
 

--- a/esphome/components/tas2780/audio_dac.py
+++ b/esphome/components/tas2780/audio_dac.py
@@ -50,14 +50,14 @@ TAS2780_ACTION_SCHEMA = cv.Schema(
     }
 )
 
-@automation.register_action("tas2780.deactivate", DeactivateAction, TAS2780_ACTION_SCHEMA)
-@automation.register_action("tas2780.reset", RestAction, TAS2780_ACTION_SCHEMA)
+@automation.register_action("tas2780.deactivate", DeactivateAction, TAS2780_ACTION_SCHEMA, synchronous=True)
+@automation.register_action("tas2780.reset", RestAction, TAS2780_ACTION_SCHEMA, synchronous=True)
 async def tas2780_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
 
-@automation.register_action("tas2780.activate", ActivateAction, TAS2780_ACTION_SCHEMA)
+@automation.register_action("tas2780.activate", ActivateAction, TAS2780_ACTION_SCHEMA, synchronous=True)
 async def tas2780_action(config, action_id, template_arg, args):
     tas2780 = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, tas2780)
@@ -79,7 +79,7 @@ TAS2780_UPDATE_CONFIG_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("tas2780.update_config", UpdateConfigAction, TAS2780_UPDATE_CONFIG_SCHEMA)
+@automation.register_action("tas2780.update_config", UpdateConfigAction, TAS2780_UPDATE_CONFIG_SCHEMA, synchronous=True)
 async def tas2780_action(config, action_id, template_arg, args):
     tas2780 = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, tas2780)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-esphome==2026.2.4
+esphome==2026.3.3
 setuptools
 yamllint
 pre-commit


### PR DESCRIPTION
- Bump firmware to ESPHome 2026.3.3 
- Update local component overrides to match ESPHome 2026.3 API/behavior changes across audio, speaker/media player, i2s audio, micro wake word, and related custom components.
- Pull in key stability fixes from upstream/custom patches (audio buffer reallocation, FLAC CRC handling, media queue/decode startup guards, unsupported 8-bit mono rejection, and wake-word tensor shape validation).