### PR TITLE
Add sweep gating for mic tests

### DIFF
--- a/esphome/components/online_testing/mic_tests.cpp
+++ b/esphome/components/online_testing/mic_tests.cpp
@@ -131,6 +131,8 @@ void MicTester::clear_buffers_() {
   this->read_pos_ = 0;
   this->energy_accumulator_ = 0.0f;
   this->energy_sample_count_ = 0;
+  this->sweep_armed_ = true;
+  this->last_sweep_ms_ = 0;
 }
 
 void MicTester::deallocate_buffers_() {
@@ -263,7 +265,14 @@ void MicTester::loop() {
       float corr = detect_sweep_streaming(temp, chunk, this->sweep_norm_, 1.0e6f, true);
       ESP_LOGD("sweep", "Sweep-Detect corr=%.2f (ch=%d)", corr, this->channel_);
 
-      if (corr > DETECTION_THRESHOLD) {
+      if (corr < DETECTION_RESET_THRESHOLD) {
+        this->sweep_armed_ = true;
+      }
+
+      const uint32_t now = millis();
+      if (this->sweep_armed_ && corr > DETECTION_THRESHOLD && (now - this->last_sweep_ms_ > DETECTION_COOLDOWN_MS)) {
+        this->last_sweep_ms_ = now;
+        this->sweep_armed_ = false;
         ESP_LOGI("sweep", "Sweep detected: corr=%.2f", corr);
         this->sweep_detected_trigger_->trigger();
       }

--- a/esphome/components/online_testing/mic_tests.h
+++ b/esphome/components/online_testing/mic_tests.h
@@ -94,6 +94,9 @@ class MicTester : public Component {
   float energy_accumulator_{0.0f};
   size_t energy_sample_count_{0};
 
+  bool sweep_armed_{true};
+  uint32_t last_sweep_ms_{0};
+
   State state_{State::IDLE};
   State desired_state_{State::IDLE};
 };


### PR DESCRIPTION
## Summary
- Add reset and cooldown thresholds to gate sweep detection
- Prevent duplicate sweep triggers from close‑together correlations