### PR TITLE
Add UDP mic streaming support

### DIFF
--- a/config/manufacturer_testing.yaml
+++ b/config/manufacturer_testing.yaml
@@ -84,6 +84,9 @@ online_testing:
   id: mic_tester
   microphone: sat1_mics
   media_file: audio_test_sweep
+  udp_stream_enabled: false
+  udp_stream_port: 5005
+  udp_stream_packet_samples: 960
   on_detected:
     then:
       - logger.log: "Sweep detected"
@@ -207,6 +210,39 @@ improv_serial:
             - lambda: |-
                 float energy = id(mic_tester).get_mic_energy();
                 ESP_LOGI("mic_energy", "Mic energy (ch=%d): %.6f", id(mic_tester).get_channel(), energy);
+
+      - if:
+          condition:
+            lambda: return x.get_action() == std::string("SET_UDP_AUDIO_TARGET");
+          then:
+            - lambda: |-
+                if (!x.get_url().has_value()) {
+                  ESP_LOGW("udp_audio", "SET_UDP_AUDIO_TARGET missing url");
+                  return;
+                }
+                std::string target = *x.get_url();
+                size_t colon = target.find(':');
+                if (colon == std::string::npos) {
+                  ESP_LOGW("udp_audio", "Invalid UDP target: %s", target.c_str());
+                  return;
+                }
+                std::string host = target.substr(0, colon);
+                int port = std::stoi(target.substr(colon + 1));
+                if (port <= 0 || port > 65535) {
+                  ESP_LOGW("udp_audio", "Invalid UDP port: %d", port);
+                  return;
+                }
+                id(mic_tester).set_udp_stream_target(host, static_cast<uint16_t>(port));
+                id(mic_tester).set_udp_stream_enabled(true);
+                ESP_LOGI("udp_audio", "UDP audio target set to %s:%d", host.c_str(), port);
+
+      - if:
+          condition:
+            lambda: return x.get_action() == std::string("STOP_UDP_STREAMING");
+          then:
+            - lambda: |-
+                id(mic_tester).set_udp_stream_enabled(false);
+                ESP_LOGI("udp_audio", "UDP audio streaming disabled");
 
       - if:
           condition:

--- a/esphome/components/online_testing/__init__.py
+++ b/esphome/components/online_testing/__init__.py
@@ -12,12 +12,16 @@ from esphome.components import audio, esp32, microphone
 
 
 AUTO_LOAD = ["audio"]
-DEPENDENCIES = ["microphone","media_player"]
+DEPENDENCIES = ["microphone", "media_player"]
 
 CODEOWNERS = ["@gnumpi"]
 
 CONF_MEDIA_FILE = "media_file"
 CONF_ON_DETECTED = "on_detected"
+CONF_UDP_STREAM_ENABLED = "udp_stream_enabled"
+CONF_UDP_STREAM_HOST = "udp_stream_host"
+CONF_UDP_STREAM_PORT = "udp_stream_port"
+CONF_UDP_STREAM_PACKET_SAMPLES = "udp_stream_packet_samples"
 
 udp_stream_ns = cg.esphome_ns.namespace("online_testing")
 MicTester = udp_stream_ns.class_("MicTester", cg.Component)
@@ -36,7 +40,6 @@ IsRunningCondition = udp_stream_ns.class_(
 )
 
 
-
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -45,9 +48,14 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MEDIA_FILE): cv.use_id(audio.AudioFile),
             cv.Optional(CONF_ON_DETECTED): automation.validate_automation(single=True),
             cv.Optional(CONF_ON_TIMEOUT): automation.validate_automation(single=True),
+            cv.Optional(CONF_UDP_STREAM_ENABLED, default=False): cv.boolean,
+            cv.Optional(CONF_UDP_STREAM_HOST): cv.string,
+            cv.Optional(CONF_UDP_STREAM_PORT, default=5005): cv.port,
+            cv.Optional(CONF_UDP_STREAM_PACKET_SAMPLES, default=960): cv.positive_int,
         }
     ).extend(cv.COMPONENT_SCHEMA)
 )
+
 
 async def to_code(config):
     esp32.add_idf_component(
@@ -55,7 +63,7 @@ async def to_code(config):
         repo="https://github.com/kahrendt/esp-dsp",
         ref="no-round-dot-product",
     )
-    
+
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
@@ -63,6 +71,17 @@ async def to_code(config):
     cg.add(var.set_microphone(mic))
     media_file = await cg.get_variable(config[CONF_MEDIA_FILE])
     cg.add(var.set_media_file(media_file))
+
+    if CONF_UDP_STREAM_ENABLED in config:
+        cg.add(var.set_udp_stream_enabled(config[CONF_UDP_STREAM_ENABLED]))
+    if CONF_UDP_STREAM_HOST in config:
+        cg.add(var.set_udp_stream_host(config[CONF_UDP_STREAM_HOST]))
+    if CONF_UDP_STREAM_PORT in config:
+        cg.add(var.set_udp_stream_port(config[CONF_UDP_STREAM_PORT]))
+    if CONF_UDP_STREAM_PACKET_SAMPLES in config:
+        cg.add(
+            var.set_udp_stream_packet_samples(config[CONF_UDP_STREAM_PACKET_SAMPLES])
+        )
 
     if CONF_ON_DETECTED in config:
         await automation.build_automation(
@@ -74,18 +93,16 @@ async def to_code(config):
             var.get_end_trigger(), [], config[CONF_ON_TIMEOUT]
         )
 
+
 MIC_TESTER_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(MicTester)})
+
 
 @register_action(
     "mic_tester.start_continuous",
     StartContinuousAction,
     MIC_TESTER_ACTION_SCHEMA,
 )
-@register_action(
-    "mic_tester.start",
-    StartAction,
-    MIC_TESTER_ACTION_SCHEMA
-)
+@register_action("mic_tester.start", StartAction, MIC_TESTER_ACTION_SCHEMA)
 async def voice_assistant_listen_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
@@ -97,4 +114,3 @@ async def voice_assistant_stop_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
-

--- a/esphome/components/online_testing/mic_tests.cpp
+++ b/esphome/components/online_testing/mic_tests.cpp
@@ -3,9 +3,25 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include "esp_dsp.h"
+#ifdef USE_WIFI
+#include "esphome/components/wifi/wifi_component.h"
+#endif
 
 #include <cinttypes>
 #include <cstdio>
+#include <cstring>
+
+#ifdef USE_ESP32
+extern "C" {
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <lwip/sockets.h>
+#include <lwip/inet.h>
+}
+#endif
+
+#include <cerrno>
 
 
 namespace esphome {
@@ -111,6 +127,9 @@ float MicTester::get_setup_priority() const { return setup_priority::AFTER_CONNE
 void MicTester::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MicTester...");
   this->read_sweep_();
+  if (this->udp_packet_buffer_.empty() && this->udp_stream_packet_samples_ > 0) {
+    this->udp_packet_buffer_.resize(this->udp_stream_packet_samples_);
+  }
 }
 
 bool MicTester::allocate_buffers_() {
@@ -133,6 +152,7 @@ void MicTester::clear_buffers_() {
   this->energy_sample_count_ = 0;
   this->sweep_armed_ = true;
   this->last_sweep_ms_ = 0;
+  this->reset_udp_packet_();
 }
 
 void MicTester::deallocate_buffers_() {
@@ -188,8 +208,9 @@ void MicTester::on_audio_data_(const std::vector<uint8_t> &data) {
 
   for (size_t i = 0; i < num_frames; i++) {
     size_t idx = wp % limit;
-    int16_t sample = static_cast<int16_t>(samples_32[i * 2 + this->channel_] >> 16);
+    int16_t sample = static_cast<int16_t>(samples_32[i * 2 + this->channel_] >> 13);
     this->input_buffer_[idx] = sample;
+    this->append_udp_sample_(sample);
     this->energy_accumulator_ += static_cast<float>(sample) * static_cast<float>(sample);
     this->energy_sample_count_++;
     wp++;
@@ -395,6 +416,126 @@ float MicTester::get_mic_energy() {
   this->energy_accumulator_ = 0.0f;
   this->energy_sample_count_ = 0;
   return rms;
+}
+
+void MicTester::set_udp_stream_enabled(bool enabled) {
+  if (this->udp_stream_enabled_ == enabled)
+    return;
+  this->udp_stream_enabled_ = enabled;
+  if (!enabled) {
+    this->close_udp_socket_();
+    this->reset_udp_packet_();
+  }
+}
+
+void MicTester::set_udp_stream_host(const std::string &host) {
+  this->udp_stream_host_ = host;
+  this->udp_target_valid_ = false;
+  this->close_udp_socket_();
+}
+
+void MicTester::set_udp_stream_port(uint16_t port) {
+  this->udp_stream_port_ = port;
+  this->udp_target_valid_ = false;
+  this->close_udp_socket_();
+}
+
+void MicTester::set_udp_stream_packet_samples(size_t samples) {
+  if (samples == 0)
+    return;
+  this->udp_stream_packet_samples_ = samples;
+  this->udp_packet_buffer_.assign(samples, 0);
+  this->udp_packet_fill_ = 0;
+}
+
+void MicTester::set_udp_stream_target(const std::string &host, uint16_t port) {
+  this->udp_stream_host_ = host;
+  this->udp_stream_port_ = port;
+  this->udp_target_valid_ = false;
+  this->close_udp_socket_();
+}
+
+bool MicTester::ensure_udp_socket_ready_() {
+  if (!this->udp_stream_enabled_)
+    return false;
+  if (this->udp_stream_host_.empty() || this->udp_stream_port_ == 0)
+    return false;
+#ifdef USE_WIFI
+  if (wifi::global_wifi_component == nullptr || !wifi::global_wifi_component->is_connected())
+    return false;
+#endif
+
+  if (!this->udp_target_valid_) {
+    struct in_addr addr {};
+    if (inet_aton(this->udp_stream_host_.c_str(), &addr) == 0) {
+      uint32_t now = millis();
+      if (now - this->last_udp_error_log_ > 5000) {
+        ESP_LOGW(TAG, "UDP target invalid: %s", this->udp_stream_host_.c_str());
+        this->last_udp_error_log_ = now;
+      }
+      return false;
+    }
+    std::memset(&this->udp_dest_addr_, 0, sizeof(this->udp_dest_addr_));
+    this->udp_dest_addr_.sin_family = AF_INET;
+    this->udp_dest_addr_.sin_port = htons(this->udp_stream_port_);
+    this->udp_dest_addr_.sin_addr = addr;
+    this->udp_target_valid_ = true;
+  }
+
+  if (this->udp_socket_ < 0) {
+    this->udp_socket_ = lwip_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (this->udp_socket_ < 0) {
+      uint32_t now = millis();
+      if (now - this->last_udp_error_log_ > 5000) {
+        ESP_LOGW(TAG, "UDP socket open failed: errno %d", errno);
+        this->last_udp_error_log_ = now;
+      }
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void MicTester::close_udp_socket_() {
+  if (this->udp_socket_ >= 0) {
+    close(this->udp_socket_);
+    this->udp_socket_ = -1;
+  }
+  this->udp_target_valid_ = false;
+}
+
+void MicTester::append_udp_sample_(int16_t sample) {
+  if (!this->ensure_udp_socket_ready_())
+    return;
+
+  if (this->udp_stream_packet_samples_ == 0)
+    return;
+
+  if (this->udp_packet_buffer_.size() != this->udp_stream_packet_samples_) {
+    this->udp_packet_buffer_.assign(this->udp_stream_packet_samples_, 0);
+    this->udp_packet_fill_ = 0;
+  }
+
+  this->udp_packet_buffer_[this->udp_packet_fill_++] = sample;
+  if (this->udp_packet_fill_ < this->udp_stream_packet_samples_)
+    return;
+
+  const size_t byte_count = this->udp_stream_packet_samples_ * sizeof(int16_t);
+  int sent = lwip_sendto(this->udp_socket_, this->udp_packet_buffer_.data(), byte_count, 0,
+                         reinterpret_cast<struct sockaddr *>(&this->udp_dest_addr_), sizeof(this->udp_dest_addr_));
+  if (sent < 0) {
+    uint32_t now = millis();
+    if (now - this->last_udp_error_log_ > 5000) {
+      ESP_LOGW(TAG, "UDP send failed: errno %d", errno);
+      this->last_udp_error_log_ = now;
+    }
+  }
+  this->udp_packet_fill_ = 0;
+}
+
+void MicTester::reset_udp_packet_() {
+  this->udp_packet_fill_ = 0;
 }
 
 void MicTester::signal_stop_() {

--- a/esphome/components/online_testing/mic_tests.h
+++ b/esphome/components/online_testing/mic_tests.h
@@ -11,6 +11,13 @@
 
 #include <unordered_map>
 #include <vector>
+#include <string>
+
+#ifdef USE_ESP32
+extern "C" {
+#include <lwip/sockets.h>
+}
+#endif
 
 namespace esphome {
 namespace online_testing {
@@ -45,6 +52,12 @@ class MicTester : public Component {
 
   float get_mic_energy();
 
+  void set_udp_stream_enabled(bool enabled);
+  void set_udp_stream_host(const std::string &host);
+  void set_udp_stream_port(uint16_t port);
+  void set_udp_stream_packet_samples(size_t samples);
+  void set_udp_stream_target(const std::string &host, uint16_t port);
+
   bool is_running() const { return this->state_ != State::IDLE; }
   bool is_mic_active() const { return this->state_ != State::IDLE && this->state_ != State::STOP_MICROPHONE && this->state_ != State::STOPPING_MICROPHONE; }
   void set_continuous(bool continuous) { this->continuous_ = continuous; }
@@ -65,6 +78,11 @@ class MicTester : public Component {
   void set_state_(State state);
   void set_state_(State state, State desired_state);
   void signal_stop_();
+
+  bool ensure_udp_socket_ready_();
+  void close_udp_socket_();
+  void append_udp_sample_(int16_t sample);
+  void reset_udp_packet_();
 
   void on_audio_data_(const std::vector<uint8_t> &data);
 
@@ -96,6 +114,16 @@ class MicTester : public Component {
 
   bool sweep_armed_{true};
   uint32_t last_sweep_ms_{0};
+  bool udp_stream_enabled_{false};
+  std::string udp_stream_host_{};
+  uint16_t udp_stream_port_{0};
+  size_t udp_stream_packet_samples_{960};
+  std::vector<int16_t> udp_packet_buffer_{};
+  size_t udp_packet_fill_{0};
+  int udp_socket_{-1};
+  bool udp_target_valid_{false};
+  struct sockaddr_in udp_dest_addr_ {};
+  uint32_t last_udp_error_log_{0};
 
   State state_{State::IDLE};
   State desired_state_{State::IDLE};

--- a/esphome/components/online_testing/udp_wav_receiver.py
+++ b/esphome/components/online_testing/udp_wav_receiver.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import socket
+import wave
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Receive UDP PCM and write a WAV file")
+    parser.add_argument(
+        "--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=5005, help="UDP port (default: 5005)"
+    )
+    parser.add_argument(
+        "--rate", type=int, default=16000, help="Sample rate (default: 16000)"
+    )
+    parser.add_argument("--channels", type=int, default=1, help="Channels (default: 1)")
+    parser.add_argument("--outfile", default="mic_capture.wav", help="Output WAV file")
+    args = parser.parse_args()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((args.host, args.port))
+
+    with wave.open(args.outfile, "wb") as wf:
+        wf.setnchannels(args.channels)
+        wf.setsampwidth(2)
+        wf.setframerate(args.rate)
+
+        print(f"Listening on {args.host}:{args.port}, writing to {args.outfile}")
+        try:
+            while True:
+                data, _addr = sock.recvfrom(65535)
+                if not data:
+                    continue
+                wf.writeframes(data)
+        except KeyboardInterrupt:
+            print("Stopping recorder")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add UDP streaming of mic samples for live capture during testing
- Expose UDP stream configuration (enable/host/port/packet size) in online_testing
- Include a simple UDP WAV receiver script for capturing audio