### PR TITLE
SPI - DeviceControl changes for enabling 4 mic tests

### DIFF
--- a/config/manufacturer_testing.yaml
+++ b/config/manufacturer_testing.yaml
@@ -205,6 +205,18 @@ improv_serial:
 
       - if:
           condition:
+            lambda: return x.get_action() == std::string("LOG_NETWORK_STATE");
+          then:
+            - if:
+                condition:
+                  wifi.connected:
+                then:
+                  - logger.log: "WiFi is connected"
+                else:
+                  - logger.log: "WiFi is NOT connected"
+
+      - if:
+          condition:
             lambda: return x.get_action() == std::string("MEASURE_MIC_ENERGY");
           then:
             - lambda: |-
@@ -243,6 +255,159 @@ improv_serial:
             - lambda: |-
                 id(mic_tester).set_udp_stream_enabled(false);
                 ESP_LOGI("udp_audio", "UDP audio streaming disabled");
+
+      - if:
+          condition:
+            lambda: return x.get_action() == std::string("SET_MIC_GAIN");
+          then:
+            - lambda: |-
+                if (!x.get_url().has_value()) {
+                  ESP_LOGW("mic_gain", "SET_MIC_GAIN missing url");
+                  return;
+                }
+                const std::string query = *x.get_url();
+                auto get_param = [](const std::string &src, const std::string &key, std::string *out) -> bool {
+                  const std::string needle = key + "=";
+                  size_t start = src.find(needle);
+                  if (start == std::string::npos)
+                    return false;
+                  start += needle.size();
+                  size_t end = src.find('&', start);
+                  if (end == std::string::npos)
+                    end = src.size();
+                  *out = src.substr(start, end - start);
+                  return true;
+                };
+                std::string value;
+                if (!get_param(query, "mic_gain", &value)) {
+                  ESP_LOGW("mic_gain", "SET_MIC_GAIN missing mic_gain");
+                  return;
+                }
+                char *end = nullptr;
+                long gain_long = std::strtol(value.c_str(), &end, 10);
+                if (end == value.c_str() || *end != '\0') {
+                  ESP_LOGW("mic_gain", "SET_MIC_GAIN invalid mic_gain: %s", value.c_str());
+                  return;
+                }
+                int gain = static_cast<int>(gain_long);
+                if (!id(satellite1_id).set_mic_gain(gain)) {
+                  ESP_LOGW("mic_gain", "SET_MIC_GAIN failed");
+                  return;
+                }
+                ESP_LOGI("mic_gain", "Mic gain set to %d", gain);
+
+      - if:
+          condition:
+            lambda: return x.get_action() == std::string("GET_MIC_GAIN");
+          then:
+            - lambda: |-
+                int gain = 0;
+                if (!id(satellite1_id).get_mic_gain(&gain)) {
+                  ESP_LOGW("mic_gain", "GET_MIC_GAIN failed");
+                  return;
+                }
+                ESP_LOGI("mic_gain", "Mic gain is %d", gain);
+
+      - if:
+          condition:
+            lambda: return x.get_action() == std::string("SET_I2S_CHANNEL_MAP");
+          then:
+            - lambda: |-
+                if (!x.get_url().has_value()) {
+                  ESP_LOGW("mic_i2s_map", "SET_I2S_CHANNEL_MAP missing url");
+                  return;
+                }
+                const std::string query = *x.get_url();
+                auto get_param = [](const std::string &src, const std::string &key, std::string *out) -> bool {
+                  const std::string needle = key + "=";
+                  size_t start = src.find(needle);
+                  if (start == std::string::npos)
+                    return false;
+                  start += needle.size();
+                  size_t end = src.find('&', start);
+                  if (end == std::string::npos)
+                    end = src.size();
+                  *out = src.substr(start, end - start);
+                  return true;
+                };
+                std::string left_value;
+                std::string right_value;
+                if (!get_param(query, "left", &left_value) || !get_param(query, "right", &right_value)) {
+                  ESP_LOGW("mic_i2s_map", "SET_I2S_CHANNEL_MAP missing left/right");
+                  return;
+                }
+                char *end_left = nullptr;
+                char *end_right = nullptr;
+                long left_long = std::strtol(left_value.c_str(), &end_left, 10);
+                long right_long = std::strtol(right_value.c_str(), &end_right, 10);
+                if (end_left == left_value.c_str() || *end_left != '\0' || end_right == right_value.c_str() || *end_right != '\0') {
+                  ESP_LOGW("mic_i2s_map", "SET_I2S_CHANNEL_MAP invalid values: %s/%s", left_value.c_str(), right_value.c_str());
+                  return;
+                }
+                int left = static_cast<int>(left_long);
+                int right = static_cast<int>(right_long);
+                if (left < 0 || left > 7 || right < 0 || right > 7) {
+                  ESP_LOGW("mic_i2s_map", "SET_I2S_CHANNEL_MAP out of range: %d/%d", left, right);
+                  return;
+                }
+                if (!id(satellite1_id).set_mic_output_i2s_channel_map(static_cast<uint8_t>(left), static_cast<uint8_t>(right))) {
+                  ESP_LOGW("mic_i2s_map", "SET_I2S_CHANNEL_MAP failed");
+                  return;
+                }
+                ESP_LOGI("mic_i2s_map", "I2S channel map set to left=%d right=%d", left, right);
+
+      - if:
+          condition:
+            lambda: return x.get_action() == std::string("GET_I2S_CHANNEL_MAP");
+          then:
+            - lambda: |-
+                uint8_t left = 0;
+                uint8_t right = 0;
+                if (!id(satellite1_id).get_mic_output_i2s_channel_map(&left, &right)) {
+                  ESP_LOGW("mic_i2s_map", "GET_I2S_CHANNEL_MAP failed");
+                  return;
+                }
+                ESP_LOGI("mic_i2s_map", "I2S channel map is left=%u right=%u", left, right);
+
+      - if:
+          condition:
+            lambda: return x.get_action() == std::string("SET_PACK_EXTRA_UPSAMPLE_CHANNELS");
+          then:
+            - lambda: |-
+                if (!x.get_url().has_value()) {
+                  ESP_LOGW("mic_i2s_map", "SET_PACK_EXTRA_UPSAMPLE_CHANNELS missing url");
+                  return;
+                }
+                const std::string query = *x.get_url();
+                auto get_param = [](const std::string &src, const std::string &key, std::string *out) -> bool {
+                  const std::string needle = key + "=";
+                  size_t start = src.find(needle);
+                  if (start == std::string::npos)
+                    return false;
+                  start += needle.size();
+                  size_t end = src.find('&', start);
+                  if (end == std::string::npos)
+                    end = src.size();
+                  *out = src.substr(start, end - start);
+                  return true;
+                };
+                std::string value;
+                if (!get_param(query, "enabled", &value)) {
+                  ESP_LOGW("mic_i2s_map", "SET_PACK_EXTRA_UPSAMPLE_CHANNELS missing enabled");
+                  return;
+                }
+                char *end = nullptr;
+                long enabled_long = std::strtol(value.c_str(), &end, 10);
+                if (end == value.c_str() || *end != '\0') {
+                  ESP_LOGW("mic_i2s_map", "SET_PACK_EXTRA_UPSAMPLE_CHANNELS invalid enabled: %s", value.c_str());
+                  return;
+                }
+                bool enabled = enabled_long != 0;
+                if (!id(satellite1_id).set_mic_output_pack_extra_upsample_channels(enabled)) {
+                  ESP_LOGW("mic_i2s_map", "SET_PACK_EXTRA_UPSAMPLE_CHANNELS failed");
+                  return;
+                }
+                ESP_LOGI("mic_i2s_map", "Pack extra upsample channels set to %s", enabled ? "true" : "false");
 
       - if:
           condition:
@@ -321,11 +486,13 @@ improv_serial:
             - delay: 500ms
             - lambda: |-
                 id(mic_tester).set_channel(1);
+                id(mic_tester).set_microphone(id(sat1_mics));
                 if (!id(mic_tester).is_running()) {
-                  id(mic_tester).set_microphone(id(sat1_mics));
                   id(mic_tester).request_start(true);
                 } else {
+                  id(mic_tester).pause_detection();
                   id(mic_tester).reset_detection();
+                  id(mic_tester).request_start(true);
                 }
 
       - if:

--- a/esphome/components/satellite1/runtime_testing/spi_error_rate.h
+++ b/esphome/components/satellite1/runtime_testing/spi_error_rate.h
@@ -8,7 +8,7 @@
 namespace esphome {
 namespace satellite1 {
 
-const uint8_t ECHO_RES_ID = 230;
+const uint8_t ECHO_RES_ID = 37;
 
 const uint8_t ECHO_SERVICER_CMD_ECHO_1 = 0;
 const uint8_t ECHO_SERVICER_CMD_ECHO_64 = 1;

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -2,10 +2,29 @@
 #include "esp_rom_gpio.h"
 #include "esphome/core/log.h"
 
+#include <cstdint>
+
+
 namespace esphome {
 namespace satellite1 {
 
 static const char *TAG = "Satellite1";
+
+static inline void write_u32_le(uint8_t *dst, uint32_t value) {
+  dst[0] = value & 0xFF;
+  dst[1] = (value >> 8) & 0xFF;
+  dst[2] = (value >> 16) & 0xFF;
+  dst[3] = (value >> 24) & 0xFF;
+}
+
+static inline void write_i32_le(uint8_t *dst, int32_t value) {
+  write_u32_le(dst, static_cast<uint32_t>(value));
+}
+
+static inline int32_t read_i32_le(const uint8_t *src) {
+  return static_cast<int32_t>(static_cast<uint32_t>(src[0]) | (static_cast<uint32_t>(src[1]) << 8) |
+                              (static_cast<uint32_t>(src[2]) << 16) | (static_cast<uint32_t>(src[3]) << 24));
+}
 
 void Satellite1::setup() {
   this->spi_setup();
@@ -208,6 +227,56 @@ void Satellite1::xmos_hardware_reset() {
   delay(100);
   this->xmos_rst_pin_->digital_write(0);
   delay(100);
+}
+
+bool Satellite1::set_mic_gain(int mic_gain) {
+  uint8_t payload[20] = {0};
+  write_u32_le(payload, DC_AUDIO_PIPELINE::MIC_INPUT_FIELD_MIC_GAIN);
+  write_i32_le(payload + 4, static_cast<int32_t>(mic_gain));
+  return this->transfer(DC_AUDIO_PIPELINE::MIC_INPUT_SETTINGS_RES_ID, DC_AUDIO_PIPELINE::CMD_SET_SETTINGS_PARTIAL,
+                        payload, sizeof(payload));
+}
+
+bool Satellite1::get_mic_gain(int *mic_gain_out) {
+  if (mic_gain_out == nullptr)
+    return false;
+  uint8_t payload[16] = {0};
+  if (!this->transfer(DC_AUDIO_PIPELINE::MIC_INPUT_SETTINGS_RES_ID, DC_AUDIO_PIPELINE::CMD_GET_SETTINGS, payload,
+                      sizeof(payload))) {
+    return false;
+  }
+  *mic_gain_out = read_i32_le(payload);
+  return true;
+}
+
+bool Satellite1::set_mic_output_i2s_channel_map(uint8_t left, uint8_t right) {
+  uint8_t payload[16] = {0};
+  write_u32_le(payload, DC_AUDIO_PIPELINE::MIC_OUTPUT_FIELD_I2S_CHANNEL_MAP);
+  payload[5] = left;
+  payload[6] = right;
+  return this->transfer(DC_AUDIO_PIPELINE::MIC_OUTPUT_SETTINGS_RES_ID, DC_AUDIO_PIPELINE::CMD_SET_SETTINGS_PARTIAL,
+                        payload, sizeof(payload));
+}
+
+bool Satellite1::get_mic_output_i2s_channel_map(uint8_t *left, uint8_t *right) {
+  if (left == nullptr || right == nullptr)
+    return false;
+  uint8_t payload[9] = {0};
+  if (!this->transfer(DC_AUDIO_PIPELINE::MIC_OUTPUT_SETTINGS_RES_ID, DC_AUDIO_PIPELINE::CMD_GET_SETTINGS, payload,
+                      sizeof(payload))) {
+    return false;
+  }
+  *left = payload[1];
+  *right = payload[2];
+  return true;
+}
+
+bool Satellite1::set_mic_output_pack_extra_upsample_channels(bool enabled) {
+  uint8_t payload[16] = {0};
+  write_u32_le(payload, DC_AUDIO_PIPELINE::MIC_OUTPUT_FIELD_PACK_EXTRA_UPSAMPLE_CHANNELS);
+  payload[4] = enabled ? 1 : 0;
+  return this->transfer(DC_AUDIO_PIPELINE::MIC_OUTPUT_SETTINGS_RES_ID, DC_AUDIO_PIPELINE::CMD_SET_SETTINGS_PARTIAL,
+                        payload, sizeof(payload));
 }
 
 }  // namespace satellite1

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -94,14 +94,18 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
   }
 
   uint8_t send_recv_buf[256 + 3] = {0};
-  int status_report_dummies = std::max<int>(0, DC_STATUS_REGISTER::REGISTER_LEN - payload_len - 1);
+  const bool is_read = (command & CONTROL_CMD_READ_BIT) != 0;
+  const uint8_t read_request_len = payload_len + (is_read ? 1 : 0);
+  int status_report_dummies = std::max<int>(0, DC_STATUS_REGISTER::REGISTER_LEN - read_request_len - 1);
 
   int attempts = 3;
   do {
     send_recv_buf[0] = resource_id;
     send_recv_buf[1] = command;
-    send_recv_buf[2] = payload_len + !!(command & CONTROL_CMD_READ_BIT);
-    memcpy(&send_recv_buf[3], payload, payload_len);
+    send_recv_buf[2] = read_request_len;
+    if (payload_len > 0 && payload != nullptr) {
+      memcpy(&send_recv_buf[3], payload, payload_len);
+    }
     this->enable();
     this->transfer_array(&send_recv_buf[0], payload_len + 3 + status_report_dummies);
     this->disable();
@@ -123,21 +127,44 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
     uint8_t *arr = this->dc_status_register_;
   }
 
-  if (command & CONTROL_CMD_READ_BIT) {
-    attempts = 3;
+  if (is_read) {
+    attempts = 10;
     do {
-      memset(send_recv_buf, 0, payload_len + 3);
+      const uint8_t read_len = std::max<uint8_t>(3, read_request_len);
+      memset(send_recv_buf, 0, read_len);
       this->enable();
-      this->transfer_array(&send_recv_buf[0], payload_len + 3);
+      this->transfer_array(&send_recv_buf[0], read_len);
       this->disable();
-      vTaskDelay(1);
-    } while (send_recv_buf[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE && attempts-- > 0);
 
-    if (send_recv_buf[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE) {
-      return false;
-    }
+      if (send_recv_buf[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE) {
+        vTaskDelay(1);
+        continue;
+      }
 
-    memcpy(payload, &send_recv_buf[1], payload_len);
+      const bool payload_available = (send_recv_buf[0] == DC_RET_STATUS::PAYLOAD_AVAILABLE);
+      const bool legacy_dfu_payload = (resource_id == DC_RESOURCE::DFU_CONTROLLER && command == DC_DFU_CMD::GET_VERSION &&
+                                       send_recv_buf[0] == 0);
+      const bool legacy_audio_payload = (send_recv_buf[0] == 0 &&
+                                         (resource_id == DC_AUDIO_PIPELINE::MIC_OUTPUT_SETTINGS_RES_ID ||
+                                          resource_id == DC_AUDIO_PIPELINE::SPEAKER_SETTINGS_RES_ID ||
+                                          resource_id == DC_AUDIO_PIPELINE::MIC_INPUT_SETTINGS_RES_ID));
+      if (!(payload_available || legacy_dfu_payload || legacy_audio_payload)) {
+        vTaskDelay(1);
+        continue;
+      }
+
+      if (read_len < (payload_len + 1)) {
+        vTaskDelay(1);
+        continue;
+      }
+
+      if (payload_len > 0 && payload != nullptr) {
+        memcpy(payload, &send_recv_buf[1], payload_len);
+      }
+      return true;
+    } while (attempts-- > 0);
+
+    return false;
   }
 
   return true;

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -53,6 +53,21 @@ enum dc_dfu_cmd_id {
 };
 }
 
+namespace DC_AUDIO_PIPELINE {
+static const uint8_t MIC_OUTPUT_SETTINGS_RES_ID = 230;
+static const uint8_t SPEAKER_SETTINGS_RES_ID = 231;
+static const uint8_t MIC_INPUT_SETTINGS_RES_ID = 232;
+
+static const uint8_t CMD_GET_SETTINGS = (0 | CONTROL_CMD_READ_BIT);
+static const uint8_t CMD_SET_SETTINGS_PARTIAL = 1;
+
+static const uint32_t MIC_OUTPUT_FIELD_PACK_EXTRA_UPSAMPLE_CHANNELS = 1 << 2;
+static const uint32_t MIC_OUTPUT_FIELD_I2S_CHANNEL_MAP = 1 << 3;
+static const uint32_t MIC_OUTPUT_FIELD_UPSAMPLE_CHANNEL_MAP = 1 << 4;
+static const uint32_t MIC_OUTPUT_FIELD_OVERWRITE_REF_WITH_IC_NS_OUTPUT = 1 << 9;
+static const uint32_t MIC_INPUT_FIELD_MIC_GAIN = 1 << 0;
+}
+
 enum Satellite1State : uint8_t {
   SAT_DETACHED_STATE,
   SAT_XMOS_CONNECTED_STATE,
@@ -153,6 +168,12 @@ class Satellite1 : public Component,
 
   void xmos_hardware_reset();
   void read_xmos_firmware() { this->dfu_get_fw_version_(); }
+
+  bool set_mic_gain(int mic_gain);
+  bool get_mic_gain(int *mic_gain_out);
+  bool set_mic_output_i2s_channel_map(uint8_t left, uint8_t right);
+  bool get_mic_output_i2s_channel_map(uint8_t *left, uint8_t *right);
+  bool set_mic_output_pack_extra_upsample_channels(bool enabled);
 
  protected:
   bool dfu_get_fw_version_();


### PR DESCRIPTION
## Summary
- Fix SPI read handling for audio pipeline payloads
- Expose audio pipeline controls for mic gain and I2S mapping
- Enable Improv actions for network and mic diagnostics
- Align SPI error rate echo resource id