### PR TITLE
pin esp-nn==1.1.2 [skip ci] (#479)

### DIFF
--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -9,6 +9,9 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
+    
+    components:
+      - espressif/esp-nn==1.1.2
 
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"


### PR DESCRIPTION
Espressif released a new version of espressif/esp-nn.
As the version was not pinned before the latest version got pulled which is not compatible with the current micro-wake-word implementation. 

Pinning to the previously used version 1.1.2 doesn't change the firmware itself, hence we don't want to create a patch release for this.