### PR TITLE
Dashboard config: Make firmware repo url configurable as well

### DIFF
--- a/config/common/components.external.yaml
+++ b/config/common/components.external.yaml
@@ -1,10 +1,11 @@
 substitutions:
-  ext_comp_repo_ref: develop
+  ext_comp_repo_url: https://github.com/FutureProofHomes/Satellite1-ESPHome
+  ext_comp_repo_ref: staging
 
 external_components:
   - source:
       type: git
-      url: https://github.com/FutureProofHomes/Satellite1-ESPHome
+      url: ${ext_comp_repo_url}
       ref: ${ext_comp_repo_ref}
     components:
       - audio

--- a/config/satellite1.dashboard.yaml
+++ b/config/satellite1.dashboard.yaml
@@ -13,8 +13,8 @@ esphome:
 
 packages:
   FutureProofHomes.Satellite1:
-    url: https://github.com/futureproofhomes/satellite1-esphome
-    ref: staging  # Make sure to also change the ext_comp_repo_ref below
+    url: &repo_url "https://github.com/futureproofhomes/satellite1-esphome"
+    ref: &repo_ref "staging"
     refresh: 1s
     files:
       # Main config files, don't remove
@@ -22,7 +22,8 @@ packages:
       - config/common/dashboard_build.yaml
       - path: config/common/components.external.yaml
         vars:
-          ext_comp_repo_ref: staging  # Make sure to set this to the same as the ref above
+          ext_comp_repo_url: *repo_url
+          ext_comp_repo_ref: *repo_ref
 
       # yamllint disable rule:comments-indentation
       # OPTIONALLY, uncomment if you have the smaller LD2410 mmWave sensor connected to your HAT.


### PR DESCRIPTION
- let the user specify the firmware repo in the dashboard config file
- use anchor/aliases for repo_url and repo_ref, so users don't have to manually align the components.external.yaml parameter.