### PR TITLE
Introduce Satellite1-Radar (Hub for LD2410 & LD2450)

### DIFF
--- a/config/common/components.external.yaml
+++ b/config/common/components.external.yaml
@@ -13,6 +13,7 @@ external_components:
       - memory_flasher
       - pcm5122
       - satellite1
+      - satellite1_radar
       - tas2780
 
   - source:

--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -44,6 +44,14 @@ spi:
     miso_pin: GPIO13
     interface: SPI2
 
+uart:
+  - id: uart_mmwave
+    tx_pin: GPIO43
+    rx_pin: GPIO44
+    baud_rate: 256000
+    parity: NONE
+    stop_bits: 1
+
 i2s_audio:
   - id: i2s_shared
     i2s_lrclk_pin: GPIO07

--- a/config/common/mmwave.yaml
+++ b/config/common/mmwave.yaml
@@ -1,0 +1,9 @@
+satellite1_radar:
+  id: sat1_radar
+  uart_id: uart_mmwave
+
+text_sensor:
+  - platform: satellite1_radar
+    id: radar_detected_text
+    satellite1_radar_id: sat1_radar
+    name: Radar Detected

--- a/config/common/mmwave_ld2410.yaml
+++ b/config/common/mmwave_ld2410.yaml
@@ -1,11 +1,6 @@
 ld2410:
-
-uart:
-  tx_pin: GPIO43
-  rx_pin: GPIO44
-  baud_rate: 256000
-  parity: NONE
-  stop_bits: 1
+  id: ld2410_radar
+  uart_id: uart_mmwave
 
 button:
   - platform: ld2410

--- a/config/common/mmwave_ld2450.yaml
+++ b/config/common/mmwave_ld2450.yaml
@@ -4,17 +4,9 @@
 # # https://deploy-preview-3327--esphome.netlify.app/components/sensor/ld2450.html?highlight=ld2450
 # ===========================================================================================
 
-uart:
-  id: uart_ld2450
-  tx_pin: GPIO43
-  rx_pin: GPIO44
-  baud_rate: 256000
-  parity: NONE
-  stop_bits: 1
-
 ld2450:
   id: ld2450_radar
-  uart_id: uart_ld2450
+  uart_id: uart_mmwave
 
 binary_sensor:
   - platform: ld2450

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -89,10 +89,9 @@ packages:
   va: !include common/voice_assistant.yaml
   timer: !include common/timer.yaml
   led_ring: !include common/led_ring.yaml
+  mmwave: !include common/mmwave.yaml
 
   ## OPTIONAL COMPONENTS
-  # mmwave_ld2410: !include common/mmwave_ld2410.yaml
-  # mmwave_ld2450: !include common/mmwave_ld2450.yaml
   # debug: !include common/debug.yaml
   # developer: !include common/developer.yaml
 

--- a/config/satellite1.ld2410.yaml
+++ b/config/satellite1.ld2410.yaml
@@ -1,6 +1,11 @@
 packages:
   base_image: !include satellite1.yaml
-  mmwave_ld2450: !include common/mmwave_ld2410.yaml
+  mmwave_ld2410: !include common/mmwave_ld2410.yaml
+
+satellite1_radar: !remove
+
+text_sensor:
+  - id: !remove radar_detected_text
 
 esphome:
   name: ${node_name}

--- a/config/satellite1.ld2450.yaml
+++ b/config/satellite1.ld2450.yaml
@@ -2,6 +2,11 @@ packages:
   base_image: !include satellite1.yaml
   mmwave_ld2450: !include common/mmwave_ld2450.yaml
 
+satellite1_radar: !remove
+
+text_sensor:
+  - id: !remove radar_detected_text
+
 esphome:
   name: ${node_name}
   project:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -106,6 +106,7 @@ external_components:
       - memory_flasher
       - pcm5122
       - satellite1
+      - satellite1_radar
       - tas2780
 
   - source:

--- a/esphome/components/satellite1_radar/__init__.py
+++ b/esphome/components/satellite1_radar/__init__.py
@@ -92,6 +92,11 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
+    # Expose lightweight tuner HTTP endpoint to Home Assistant device info
+    # so HA can show the Web UI link without enabling full web_server component.
+    cg.add_define("USE_WEBSERVER")
+    cg.add_define("USE_WEBSERVER_PORT", 80)
+
     cg.add(
         var.set_device_class_indices(
             device_class_indices["distance"],

--- a/esphome/components/satellite1_radar/__init__.py
+++ b/esphome/components/satellite1_radar/__init__.py
@@ -21,9 +21,9 @@ MULTI_CONF = False
 # These values reserve StaticVector capacity in App for post-detection
 # registration of radar entities.
 RUNTIME_ENTITY_HEADROOM = {
-    "binary_sensor": 3,
+    "binary_sensor": 1,
     "sensor": 6,
-    "text_sensor": 4,
+    "text_sensor": 5,
     "switch": 1,
     "button": 3,
 }

--- a/esphome/components/satellite1_radar/__init__.py
+++ b/esphome/components/satellite1_radar/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import uart
+from esphome.components import mdns, uart
 from esphome.const import CONF_ID, Framework
 from esphome.core.entity_helpers import (
     register_device_class,
@@ -15,6 +15,15 @@ from esphome.core import CORE, HexInt
 CODEOWNERS = ["@FutureProofHomes"]
 DEPENDENCIES = ["uart"]
 MULTI_CONF = False
+
+# The radar tuner exposes a lightweight HTTP endpoint, but it does not use
+# ESPHome's full web_server component. Reserve the matching mDNS service slot
+# so the generated _http record cannot overwrite Sendspin's _sendspin record.
+if "satellite1_radar" not in mdns.COMPONENTS_WITH_MDNS_SERVICES:
+    mdns.COMPONENTS_WITH_MDNS_SERVICES = (
+        *mdns.COMPONENTS_WITH_MDNS_SERVICES,
+        "satellite1_radar",
+    )
 
 # Headroom for entities that may be registered dynamically at runtime.
 #

--- a/esphome/components/satellite1_radar/__init__.py
+++ b/esphome/components/satellite1_radar/__init__.py
@@ -3,27 +3,27 @@ from pathlib import Path
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import mdns, uart
-from esphome.const import CONF_ID, Framework
+from esphome.components import mdns, socket, uart
+from esphome.const import CONF_ESPHOME, CONF_ID, Framework
 from esphome.core.entity_helpers import (
     register_device_class,
     register_icon,
     register_unit_of_measurement,
 )
 from esphome.core import CORE, HexInt
+import esphome.final_validate as fv
 
 CODEOWNERS = ["@FutureProofHomes"]
-DEPENDENCIES = ["uart"]
+DEPENDENCIES = ["network","uart"]
 MULTI_CONF = False
 
-# The radar tuner exposes a lightweight HTTP endpoint, but it does not use
-# ESPHome's full web_server component. Reserve the matching mDNS service slot
-# so the generated _http record cannot overwrite Sendspin's _sendspin record.
-if "satellite1_radar" not in mdns.COMPONENTS_WITH_MDNS_SERVICES:
-    mdns.COMPONENTS_WITH_MDNS_SERVICES = (
-        *mdns.COMPONENTS_WITH_MDNS_SERVICES,
-        "satellite1_radar",
-    )
+
+def _consume_sockets(config):
+    """Register socket needs for this component."""
+    # Example: 1 web-server
+    socket.consume_sockets(1, "satellite1_radar")(config)
+    return config
+
 
 # Headroom for entities that may be registered dynamically at runtime.
 #
@@ -57,8 +57,19 @@ CONFIG_SCHEMA = cv.All(
     .extend(cv.COMPONENT_SCHEMA)
     .extend(uart.UART_DEVICE_SCHEMA),
     cv.only_with_framework(Framework.ESP_IDF),
+    _consume_sockets,
 )
 
+def _final_validate(config):
+    full_config = fv.full_config.get()[CONF_ESPHOME]
+    if "web_server" not in full_config:
+        mdns.COMPONENTS_WITH_MDNS_SERVICES = (
+            *mdns.COMPONENTS_WITH_MDNS_SERVICES,
+            "satellite1_radar",
+        )
+    return config
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 async def to_code(config):
     device_class_indices = {

--- a/esphome/components/satellite1_radar/__init__.py
+++ b/esphome/components/satellite1_radar/__init__.py
@@ -1,0 +1,138 @@
+import gzip
+from pathlib import Path
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import CONF_ID, Framework
+from esphome.core.entity_helpers import (
+    register_device_class,
+    register_icon,
+    register_unit_of_measurement,
+)
+from esphome.core import CORE, HexInt
+
+CODEOWNERS = ["@FutureProofHomes"]
+DEPENDENCIES = ["uart"]
+MULTI_CONF = False
+
+# Headroom for entities that may be registered dynamically at runtime.
+#
+# These values reserve StaticVector capacity in App for post-detection
+# registration of radar entities.
+RUNTIME_ENTITY_HEADROOM = {
+    "binary_sensor": 3,
+    "sensor": 6,
+    "text_sensor": 4,
+    "switch": 1,
+    "button": 3,
+}
+
+CONF_LD2410_HTML_ID = "ld2410_html_id"
+CONF_LD2450_HTML_ID = "ld2450_html_id"
+CONF_SATELLITE1_RADAR_ID = "satellite1_radar_id"
+
+satellite1_radar_ns = cg.esphome_ns.namespace("satellite1_radar")
+Satellite1Radar = satellite1_radar_ns.class_(
+    "Satellite1Radar", cg.Component, uart.UARTDevice
+)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Satellite1Radar),
+            cv.GenerateID(CONF_LD2410_HTML_ID): cv.declare_id(cg.uint8),
+            cv.GenerateID(CONF_LD2450_HTML_ID): cv.declare_id(cg.uint8),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
+    cv.only_with_framework(Framework.ESP_IDF),
+)
+
+
+async def to_code(config):
+    device_class_indices = {
+        "distance": register_device_class("distance"),
+        "illuminance": register_device_class("illuminance"),
+        "occupancy": register_device_class("occupancy"),
+        "motion": register_device_class("motion"),
+    }
+    unit_indices = {
+        "centimeter": register_unit_of_measurement("cm"),
+        "percent": register_unit_of_measurement("%"),
+    }
+    icon_indices = {
+        "radar": register_icon("mdi:radar"),
+        "chip": register_icon("mdi:chip"),
+        "signal": register_icon("mdi:signal"),
+        "motion_sensor": register_icon("mdi:motion-sensor"),
+        "account_multiple": register_icon("mdi:account-multiple"),
+        "account": register_icon("mdi:account"),
+        "account_arrow_right": register_icon("mdi:account-arrow-right"),
+        "tune_vertical": register_icon("mdi:tune-vertical"),
+        "factory": register_icon("mdi:factory"),
+        "restart": register_icon("mdi:restart"),
+        "database_refresh": register_icon("mdi:database-refresh"),
+    }
+
+    if any(device_class_indices.values()):
+        cg.add_define("USE_ENTITY_DEVICE_CLASS")
+    if any(unit_indices.values()):
+        cg.add_define("USE_ENTITY_UNIT_OF_MEASUREMENT")
+    if any(icon_indices.values()):
+        cg.add_define("USE_ENTITY_ICON")
+
+    for platform_name, extra in RUNTIME_ENTITY_HEADROOM.items():
+        CORE.platform_counts[platform_name] = (
+            CORE.platform_counts.get(platform_name, 0) + extra
+        )
+
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    cg.add(
+        var.set_device_class_indices(
+            device_class_indices["distance"],
+            device_class_indices["illuminance"],
+            device_class_indices["occupancy"],
+            device_class_indices["motion"],
+        )
+    )
+    cg.add(var.set_unit_indices(unit_indices["centimeter"], unit_indices["percent"]))
+    cg.add(
+        var.set_icon_indices(
+            icon_indices["radar"],
+            icon_indices["chip"],
+            icon_indices["signal"],
+            icon_indices["motion_sensor"],
+            icon_indices["account_multiple"],
+            icon_indices["account"],
+            icon_indices["account_arrow_right"],
+            icon_indices["tune_vertical"],
+            icon_indices["factory"],
+            icon_indices["restart"],
+            icon_indices["database_refresh"],
+        )
+    )
+
+    base_dir = Path(__file__).parent
+    ld2410_path = base_dir / "tuner_ui" / "radar_tuner_ld2410.html"
+    ld2450_path = base_dir / "tuner_ui" / "radar_tuner_ld2450.html"
+
+    ld2410_gz = gzip.compress(ld2410_path.read_bytes(), compresslevel=9)
+    ld2450_gz = gzip.compress(ld2450_path.read_bytes(), compresslevel=9)
+
+    ld2410_progmem = cg.progmem_array(
+        config[CONF_LD2410_HTML_ID],
+        tuple(map(HexInt, ld2410_gz)),
+    )
+    ld2450_progmem = cg.progmem_array(
+        config[CONF_LD2450_HTML_ID],
+        tuple(map(HexInt, ld2450_gz)),
+    )
+
+    cg.add(var.set_ld2410_html(ld2410_progmem, len(ld2410_gz)))
+    cg.add(var.set_ld2450_html(ld2450_progmem, len(ld2450_gz)))
+    return var

--- a/esphome/components/satellite1_radar/ld2410_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2410_handler.cpp
@@ -24,7 +24,7 @@ void LD2410Handler::setup(uart::UARTDevice *uart) {
   if (config_pref_.load(&loaded)) {
     this->set_backend_config(loaded);
   }
-  query_params(uart);
+  query_params();
 }
 
 void LD2410Handler::create_and_register_entities() {
@@ -205,24 +205,21 @@ void LD2410Handler::loop(uart::UARTDevice *uart) {
   process_queue_();
 }
 
-void LD2410Handler::factory_reset(uart::UARTDevice *uart) {
-  uart_ = uart;
+void LD2410Handler::factory_reset() {
   queue_enter_config_();
   queue_config_command_(0x00A2, nullptr, 0);
   queue_exit_config_();
   ESP_LOGI(TAG_LD2410, "Factory reset queued");
 }
 
-void LD2410Handler::restart(uart::UARTDevice *uart) {
-  uart_ = uart;
+void LD2410Handler::restart() {
   queue_enter_config_();
   queue_config_command_(0x00A3, nullptr, 0);
   queue_exit_config_();
   ESP_LOGI(TAG_LD2410, "Restart queued");
 }
 
-void LD2410Handler::query_params(uart::UARTDevice *uart) {
-  uart_ = uart;
+void LD2410Handler::query_params() {
   queue_enter_config_();
   queue_config_command_(0x00A0, nullptr, 0);
   queue_config_command_(0x0061, nullptr, 0);
@@ -231,8 +228,7 @@ void LD2410Handler::query_params(uart::UARTDevice *uart) {
   ESP_LOGI(TAG_LD2410, "Parameter query queued");
 }
 
-void LD2410Handler::write_gate_config(uart::UARTDevice *uart) {
-  uart_ = uart;
+void LD2410Handler::write_gate_config() {
   queue_enter_config_();
 
   uint32_t max_move = static_cast<uint32_t>(config_.max_move_gate);
@@ -265,8 +261,7 @@ void LD2410Handler::write_gate_config(uart::UARTDevice *uart) {
   ESP_LOGI(TAG_LD2410, "Gate configuration queued");
 }
 
-void LD2410Handler::set_distance_resolution(uart::UARTDevice *uart, bool fine) {
-  uart_ = uart;
+void LD2410Handler::set_distance_resolution(bool fine) {
   queue_enter_config_();
   uint8_t data[2];
   put_uint16_le_(data, fine ? 0x0001 : 0x0000);
@@ -300,21 +295,19 @@ bool LD2410Handler::set_backend_config(const LD2410BackendConfig &cfg) {
   return true;
 }
 
-void LD2410Handler::apply_backend_config(uart::UARTDevice *uart) {
-  this->write_gate_config(uart);
-  this->set_distance_resolution(uart, config_.distance_resolution == 1);
+void LD2410Handler::apply_backend_config() {
+  this->write_gate_config();
+  this->set_distance_resolution(config_.distance_resolution == 1);
 }
 
-void LD2410Handler::enable_engineering_mode(uart::UARTDevice *uart) {
-  uart_ = uart;
+void LD2410Handler::enable_engineering_mode() {
   queue_enter_config_();
   queue_config_command_(0x0062, nullptr, 0);
   queue_exit_config_();
   ESP_LOGI(TAG_LD2410, "Engineering mode enable queued");
 }
 
-void LD2410Handler::disable_engineering_mode(uart::UARTDevice *uart) {
-  uart_ = uart;
+void LD2410Handler::disable_engineering_mode() {
   queue_enter_config_();
   queue_config_command_(0x0063, nullptr, 0);
   queue_exit_config_();

--- a/esphome/components/satellite1_radar/ld2410_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2410_handler.cpp
@@ -13,9 +13,8 @@ namespace satellite1_radar {
 static const char *const TAG_LD2410 = "satellite1_radar.ld2410";
 static constexpr size_t MAX_UART_BYTES_PER_LOOP = 128;
 
-void LD2410Handler::setup(uart::UARTDevice *uart) {
+void LD2410Handler::setup() {
   ESP_LOGI(TAG_LD2410, "Initializing LD2410 handler");
-  uart_ = uart;
   if (!buf_) {
     buf_ = std::unique_ptr<uint8_t[]>(new uint8_t[MAX_BUF]());
   }
@@ -139,16 +138,14 @@ void LD2410Handler::create_and_register_entities() {
   }
 }
 
-void LD2410Handler::loop(uart::UARTDevice *uart) {
-  uart_ = uart;
-
+void LD2410Handler::loop() {
   if (!buf_)
     return;
 
   size_t bytes_processed = 0;
-  while (uart_->available() && bytes_processed < MAX_UART_BYTES_PER_LOOP) {
+  while (uart_.available() && bytes_processed < MAX_UART_BYTES_PER_LOOP) {
     uint8_t byte;
-    if (!uart_->read_byte(&byte))
+    if (!uart_.read_byte(&byte))
       break;
     bytes_processed++;
 
@@ -317,9 +314,6 @@ void LD2410Handler::disable_engineering_mode() {
 uint16_t LD2410Handler::to_uint16_(uint8_t lo, uint8_t hi) { return (static_cast<uint16_t>(hi) << 8) | lo; }
 
 void LD2410Handler::process_queue_() {
-  if (uart_ == nullptr)
-    return;
-
   if (waiting_for_ack_) {
     if (millis() - ack_wait_start_ > ACK_TIMEOUT_MS) {
       ESP_LOGW(TAG_LD2410, "Command ACK timeout, skipping");
@@ -332,7 +326,7 @@ void LD2410Handler::process_queue_() {
   if (!dequeue_frame_(cmd))
     return;
 
-  uart_->write_array(cmd.frame, cmd.len);
+  uart_.write_array(cmd.frame, cmd.len);
   waiting_for_ack_ = true;
   ack_wait_start_ = millis();
 }

--- a/esphome/components/satellite1_radar/ld2410_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2410_handler.cpp
@@ -36,28 +36,20 @@ void LD2410Handler::create_and_register_entities() {
     this->presence_sensor = this->runtime_presence_binary_sensor_.get();
   }
 
-  if (this->moving_target_sensor == nullptr) {
-    this->runtime_moving_target_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
-    this->runtime_moving_target_binary_sensor_->configure_dynamic("Radar Target Moving", ENTITY_CATEGORY_NONE, false,
-                                                                  this->device_class_meta_.motion);
-    App.register_binary_sensor(this->runtime_moving_target_binary_sensor_.get());
-    this->moving_target_sensor = this->runtime_moving_target_binary_sensor_.get();
-  }
-
-  if (this->still_target_sensor == nullptr) {
-    this->runtime_still_target_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
-    this->runtime_still_target_binary_sensor_->configure_dynamic("Radar Target Still", ENTITY_CATEGORY_NONE, false,
-                                                                 this->device_class_meta_.occupancy);
-    App.register_binary_sensor(this->runtime_still_target_binary_sensor_.get());
-    this->still_target_sensor = this->runtime_still_target_binary_sensor_.get();
-  }
-
   if (this->version_text_sensor == nullptr) {
     this->runtime_radar_firmware_text_sensor_.reset(new Satellite1RadarDynamicTextSensor());
     this->runtime_radar_firmware_text_sensor_->configure_dynamic("Radar Firmware", ENTITY_CATEGORY_DIAGNOSTIC, false,
                                                                  this->icon_meta_.chip);
     App.register_text_sensor(this->runtime_radar_firmware_text_sensor_.get());
     this->version_text_sensor = this->runtime_radar_firmware_text_sensor_.get();
+  }
+
+  if (this->target_state_text_sensor == nullptr) {
+    this->runtime_target_state_text_sensor_.reset(new Satellite1RadarDynamicTextSensor());
+    this->runtime_target_state_text_sensor_->configure_dynamic("Radar Target", ENTITY_CATEGORY_NONE, false,
+                                                               this->icon_meta_.motion_sensor);
+    App.register_text_sensor(this->runtime_target_state_text_sensor_.get());
+    this->target_state_text_sensor = this->runtime_target_state_text_sensor_.get();
   }
 
   if (this->moving_distance == nullptr) {
@@ -451,7 +443,6 @@ void LD2410Handler::parse_data_frame_(const uint8_t *buf, size_t len) {
   uint8_t target_state = buf[8];
 
   bool has_moving = (target_state == 0x01 || target_state == 0x03);
-  bool has_still = (target_state == 0x02 || target_state == 0x03);
   bool has_target = (target_state != 0x00);
 
   uint16_t move_dist = to_uint16_(buf[9], buf[10]);
@@ -464,10 +455,9 @@ void LD2410Handler::parse_data_frame_(const uint8_t *buf, size_t len) {
 
   if (presence_sensor != nullptr)
     presence_sensor->publish_state(has_target);
-  if (moving_target_sensor != nullptr)
-    moving_target_sensor->publish_state(has_moving);
-  if (still_target_sensor != nullptr)
-    still_target_sensor->publish_state(has_still);
+
+  const char *target_activity = !has_target ? "Clear" : has_moving ? "Moving" : "Still";
+  debounce_target_state_(target_activity, TARGET_STATE_STREAK_THRESHOLD);
 
   publish_sensor_(moving_distance, static_cast<float>(move_dist));
   publish_sensor_(still_distance, static_cast<float>(still_dist));
@@ -580,6 +570,31 @@ void LD2410Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
 void LD2410Handler::publish_sensor_(sensor::Sensor *s, float val) {
   if (s != nullptr)
     s->publish_state(val);
+}
+
+void LD2410Handler::debounce_target_state_(const std::string &raw, int threshold) {
+  if (target_state_text_sensor == nullptr)
+    return;
+  if (threshold <= 0 || pub_target_state_.empty()) {
+    pub_target_state_ = raw;
+    target_state_text_sensor->publish_state(raw);
+    return;
+  }
+  if (raw == pub_target_state_) {
+    streak_target_state_ = 0;
+    return;
+  }
+  if (raw == cand_target_state_) {
+    streak_target_state_++;
+  } else {
+    cand_target_state_ = raw;
+    streak_target_state_ = 1;
+  }
+  if (streak_target_state_ >= threshold) {
+    pub_target_state_ = raw;
+    target_state_text_sensor->publish_state(raw);
+    streak_target_state_ = 0;
+  }
 }
 
 void LD2410Handler::put_uint16_le_(uint8_t *buf, uint16_t val) {

--- a/esphome/components/satellite1_radar/ld2410_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2410_handler.cpp
@@ -12,6 +12,7 @@ namespace satellite1_radar {
 
 static const char *const TAG_LD2410 = "satellite1_radar.ld2410";
 static constexpr size_t MAX_UART_BYTES_PER_LOOP = 128;
+static constexpr uint8_t LD2410_NO_BT_MAC[6] = {0x08, 0x05, 0x04, 0x03, 0x02, 0x01};
 
 void LD2410Handler::setup() {
   ESP_LOGI(TAG_LD2410, "Initializing LD2410 handler");
@@ -200,6 +201,12 @@ void LD2410Handler::loop() {
   }
 
   process_queue_();
+
+  if (bt_readback_pending_ && static_cast<int32_t>(millis() - bt_readback_due_ms_) >= 0) {
+    bt_readback_pending_ = false;
+    this->query_params();
+    ESP_LOGI(TAG_LD2410, "Queued parameter readback after Bluetooth restart");
+  }
 }
 
 void LD2410Handler::factory_reset() {
@@ -219,10 +226,20 @@ void LD2410Handler::restart() {
 void LD2410Handler::query_params() {
   queue_enter_config_();
   queue_config_command_(0x00A0, nullptr, 0);
+  uint8_t mac_query_data[2] = {0x01, 0x00};
+  queue_config_command_(0x00A5, mac_query_data, 2);
   queue_config_command_(0x0061, nullptr, 0);
   queue_config_command_(0x00AB, nullptr, 0);
   queue_exit_config_();
   ESP_LOGI(TAG_LD2410, "Parameter query queued");
+}
+
+void LD2410Handler::query_mac_address() {
+  queue_enter_config_();
+  uint8_t data[2] = {0x01, 0x00};
+  queue_config_command_(0x00A5, data, 2);
+  queue_exit_config_();
+  ESP_LOGI(TAG_LD2410, "MAC query queued");
 }
 
 void LD2410Handler::write_gate_config() {
@@ -269,6 +286,16 @@ void LD2410Handler::set_distance_resolution(bool fine) {
   ESP_LOGI(TAG_LD2410, "Distance resolution change queued (%s)", fine ? "0.2m" : "0.75m");
 }
 
+void LD2410Handler::set_bluetooth_enabled(bool enabled) {
+  queue_enter_config_();
+  uint8_t data[2];
+  put_uint16_le_(data, enabled ? 0x0001 : 0x0000);
+  queue_config_command_(0x00A4, data, 2);
+  queue_config_command_(0x00A3, nullptr, 0);
+  queue_exit_config_();
+  ESP_LOGI(TAG_LD2410, "Bluetooth %s queued with restart", enabled ? "enable" : "disable");
+}
+
 bool LD2410Handler::validate_backend_config_(LD2410BackendConfig &cfg) const {
   if (cfg.max_move_gate > 8 || cfg.max_still_gate > 8)
     return false;
@@ -295,6 +322,7 @@ bool LD2410Handler::set_backend_config(const LD2410BackendConfig &cfg) {
 void LD2410Handler::apply_backend_config() {
   this->write_gate_config();
   this->set_distance_resolution(config_.distance_resolution == 1);
+  this->set_bluetooth_enabled(config_.bluetooth_enabled);
 }
 
 void LD2410Handler::enable_engineering_mode() {
@@ -528,6 +556,19 @@ void LD2410Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
     config_.distance_resolution = fine ? 1 : 0;
     save_backend_config_();
     ESP_LOGI(TAG_LD2410, "Distance resolution: %s", fine ? "0.2m" : "0.75m");
+  }
+
+  if (cmd_word == 0x01A5 && status == 0 && len >= 16) {
+    const bool has_bt_mac = memcmp(&buf[10], LD2410_NO_BT_MAC, sizeof(LD2410_NO_BT_MAC)) != 0;
+    config_.bluetooth_enabled = has_bt_mac;
+    save_backend_config_();
+    ESP_LOGI(TAG_LD2410, "Bluetooth state from MAC query: %s", has_bt_mac ? "enabled" : "disabled");
+  }
+
+  if (cmd_word == 0x01A4 && status == 0) {
+    bt_readback_pending_ = true;
+    bt_readback_due_ms_ = millis() + BT_READBACK_DELAY_MS;
+    ESP_LOGI(TAG_LD2410, "Bluetooth command acknowledged, scheduling readback");
   }
 
   on_ack_received_();

--- a/esphome/components/satellite1_radar/ld2410_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2410_handler.cpp
@@ -1,0 +1,568 @@
+#include "ld2410_handler.h"
+
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include <cmath>
+#include <cstring>
+
+namespace esphome {
+namespace satellite1_radar {
+
+static const char *const TAG_LD2410 = "satellite1_radar.ld2410";
+static constexpr size_t MAX_UART_BYTES_PER_LOOP = 128;
+
+void LD2410Handler::setup(uart::UARTDevice *uart) {
+  ESP_LOGI(TAG_LD2410, "Initializing LD2410 handler");
+  uart_ = uart;
+  if (!buf_) {
+    buf_ = std::unique_ptr<uint8_t[]>(new uint8_t[MAX_BUF]());
+  }
+  config_pref_ = global_preferences->make_preference<LD2410BackendConfig>(fnv1_hash("sat1.ld2410.config"));
+  LD2410BackendConfig loaded;
+  if (config_pref_.load(&loaded)) {
+    this->set_backend_config(loaded);
+  }
+  query_params(uart);
+}
+
+void LD2410Handler::create_and_register_entities() {
+  if (this->presence_sensor == nullptr) {
+    this->runtime_presence_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
+    this->runtime_presence_binary_sensor_->configure_dynamic("Room Presence", ENTITY_CATEGORY_NONE, false,
+                                                             this->device_class_meta_.occupancy);
+    App.register_binary_sensor(this->runtime_presence_binary_sensor_.get());
+    this->presence_sensor = this->runtime_presence_binary_sensor_.get();
+  }
+
+  if (this->moving_target_sensor == nullptr) {
+    this->runtime_moving_target_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
+    this->runtime_moving_target_binary_sensor_->configure_dynamic("Radar Target Moving", ENTITY_CATEGORY_NONE, false,
+                                                                  this->device_class_meta_.motion);
+    App.register_binary_sensor(this->runtime_moving_target_binary_sensor_.get());
+    this->moving_target_sensor = this->runtime_moving_target_binary_sensor_.get();
+  }
+
+  if (this->still_target_sensor == nullptr) {
+    this->runtime_still_target_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
+    this->runtime_still_target_binary_sensor_->configure_dynamic("Radar Target Still", ENTITY_CATEGORY_NONE, false,
+                                                                 this->device_class_meta_.occupancy);
+    App.register_binary_sensor(this->runtime_still_target_binary_sensor_.get());
+    this->still_target_sensor = this->runtime_still_target_binary_sensor_.get();
+  }
+
+  if (this->version_text_sensor == nullptr) {
+    this->runtime_radar_firmware_text_sensor_.reset(new Satellite1RadarDynamicTextSensor());
+    this->runtime_radar_firmware_text_sensor_->configure_dynamic("Radar Firmware", ENTITY_CATEGORY_DIAGNOSTIC, false,
+                                                                 this->icon_meta_.chip);
+    App.register_text_sensor(this->runtime_radar_firmware_text_sensor_.get());
+    this->version_text_sensor = this->runtime_radar_firmware_text_sensor_.get();
+  }
+
+  if (this->moving_distance == nullptr) {
+    this->runtime_moving_distance_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_moving_distance_sensor_->configure_dynamic(
+        "Radar Moving Distance", ENTITY_CATEGORY_NONE, false, this->device_class_meta_.distance,
+        this->unit_meta_.centimeter, 0, true, sensor::STATE_CLASS_MEASUREMENT, 0);
+    App.register_sensor(this->runtime_moving_distance_sensor_.get());
+    this->moving_distance = this->runtime_moving_distance_sensor_.get();
+  }
+
+  if (this->still_distance == nullptr) {
+    this->runtime_still_distance_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_still_distance_sensor_->configure_dynamic(
+        "Radar Still Distance", ENTITY_CATEGORY_NONE, false, this->device_class_meta_.distance,
+        this->unit_meta_.centimeter, 0, true, sensor::STATE_CLASS_MEASUREMENT, 0);
+    App.register_sensor(this->runtime_still_distance_sensor_.get());
+    this->still_distance = this->runtime_still_distance_sensor_.get();
+  }
+
+  if (this->moving_energy == nullptr) {
+    this->runtime_moving_energy_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_moving_energy_sensor_->configure_dynamic("Radar Moving Energy", ENTITY_CATEGORY_DIAGNOSTIC, true, 0,
+                                                           this->unit_meta_.percent, this->icon_meta_.signal, true,
+                                                           sensor::STATE_CLASS_MEASUREMENT, 0);
+    App.register_sensor(this->runtime_moving_energy_sensor_.get());
+    this->moving_energy = this->runtime_moving_energy_sensor_.get();
+  }
+
+  if (this->still_energy == nullptr) {
+    this->runtime_still_energy_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_still_energy_sensor_->configure_dynamic("Radar Still Energy", ENTITY_CATEGORY_DIAGNOSTIC, true, 0,
+                                                          this->unit_meta_.percent, this->icon_meta_.signal, true,
+                                                          sensor::STATE_CLASS_MEASUREMENT, 0);
+    App.register_sensor(this->runtime_still_energy_sensor_.get());
+    this->still_energy = this->runtime_still_energy_sensor_.get();
+  }
+
+  if (this->detection_distance == nullptr) {
+    this->runtime_detection_distance_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_detection_distance_sensor_->configure_dynamic("Radar Detection Distance", ENTITY_CATEGORY_DIAGNOSTIC,
+                                                                true, this->device_class_meta_.distance,
+                                                                this->unit_meta_.centimeter, 0, true,
+                                                                sensor::STATE_CLASS_MEASUREMENT, 0);
+    App.register_sensor(this->runtime_detection_distance_sensor_.get());
+    this->detection_distance = this->runtime_detection_distance_sensor_.get();
+  }
+
+  if (this->light_sensor == nullptr) {
+    this->runtime_light_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_light_sensor_->configure_dynamic("Radar Illuminance", ENTITY_CATEGORY_DIAGNOSTIC, true,
+                                                   this->device_class_meta_.illuminance, 0, 0, true,
+                                                   sensor::STATE_CLASS_MEASUREMENT);
+    App.register_sensor(this->runtime_light_sensor_.get());
+    this->light_sensor = this->runtime_light_sensor_.get();
+  }
+
+  if (this->runtime_factory_reset_button_ == nullptr) {
+    this->runtime_factory_reset_button_.reset(new Satellite1RadarButton());
+    this->runtime_factory_reset_button_->configure_dynamic("Radar Factory Reset", ENTITY_CATEGORY_DIAGNOSTIC, false,
+                                                           this->icon_meta_.factory);
+    this->runtime_factory_reset_button_->add_on_press_callback([this]() { this->factory_reset(); });
+    App.register_button(this->runtime_factory_reset_button_.get());
+  }
+
+  if (this->runtime_restart_button_ == nullptr) {
+    this->runtime_restart_button_.reset(new Satellite1RadarButton());
+    this->runtime_restart_button_->configure_dynamic("Radar Restart", ENTITY_CATEGORY_DIAGNOSTIC, false,
+                                                     this->icon_meta_.restart);
+    this->runtime_restart_button_->add_on_press_callback([this]() { this->restart(); });
+    App.register_button(this->runtime_restart_button_.get());
+  }
+
+  if (this->runtime_query_params_button_ == nullptr) {
+    this->runtime_query_params_button_.reset(new Satellite1RadarButton());
+    this->runtime_query_params_button_->configure_dynamic("Radar Update Sensors", ENTITY_CATEGORY_DIAGNOSTIC, false,
+                                                          this->icon_meta_.database_refresh);
+    this->runtime_query_params_button_->add_on_press_callback([this]() { this->query_params(); });
+    App.register_button(this->runtime_query_params_button_.get());
+  }
+}
+
+void LD2410Handler::loop(uart::UARTDevice *uart) {
+  uart_ = uart;
+
+  if (!buf_)
+    return;
+
+  size_t bytes_processed = 0;
+  while (uart_->available() && bytes_processed < MAX_UART_BYTES_PER_LOOP) {
+    uint8_t byte;
+    if (!uart_->read_byte(&byte))
+      break;
+    bytes_processed++;
+
+    if (buf_pos_ < MAX_BUF)
+      buf_[buf_pos_++] = byte;
+    else
+      buf_pos_ = 0;
+
+    if (buf_pos_ < 4)
+      continue;
+
+    bool is_data = (buf_[0] == 0xF4 && buf_[1] == 0xF3 && buf_[2] == 0xF2 && buf_[3] == 0xF1);
+    bool is_cmd = (buf_[0] == 0xFD && buf_[1] == 0xFC && buf_[2] == 0xFB && buf_[3] == 0xFA);
+
+    if (!is_data && !is_cmd) {
+      memmove(buf_.get(), buf_.get() + 1, buf_pos_ - 1);
+      buf_pos_--;
+      continue;
+    }
+
+    if (is_data && buf_pos_ >= 8) {
+      uint16_t data_len = to_uint16_(buf_[4], buf_[5]);
+      size_t frame_len = 4u + 2u + data_len + 4u;
+
+      if (buf_pos_ >= frame_len) {
+        if (buf_[frame_len - 4] == 0xF8 && buf_[frame_len - 3] == 0xF7 && buf_[frame_len - 2] == 0xF6 &&
+            buf_[frame_len - 1] == 0xF5) {
+          parse_data_frame_(buf_.get(), frame_len);
+        }
+        buf_pos_ = 0;
+        continue;
+      }
+    }
+
+    if (is_cmd && buf_pos_ >= 8) {
+      uint16_t data_len = to_uint16_(buf_[4], buf_[5]);
+      size_t frame_len = 4u + 2u + data_len + 4u;
+
+      if (buf_pos_ >= frame_len) {
+        if (buf_[frame_len - 4] == 0x04 && buf_[frame_len - 3] == 0x03 && buf_[frame_len - 2] == 0x02 &&
+            buf_[frame_len - 1] == 0x01) {
+          handle_ack_frame_(buf_.get(), frame_len);
+        }
+        buf_pos_ = 0;
+        continue;
+      }
+    }
+
+    if (buf_pos_ >= MAX_BUF - 1) {
+      buf_pos_ = 0;
+    }
+  }
+
+  process_queue_();
+}
+
+void LD2410Handler::factory_reset(uart::UARTDevice *uart) {
+  uart_ = uart;
+  queue_enter_config_();
+  queue_config_command_(0x00A2, nullptr, 0);
+  queue_exit_config_();
+  ESP_LOGI(TAG_LD2410, "Factory reset queued");
+}
+
+void LD2410Handler::restart(uart::UARTDevice *uart) {
+  uart_ = uart;
+  queue_enter_config_();
+  queue_config_command_(0x00A3, nullptr, 0);
+  queue_exit_config_();
+  ESP_LOGI(TAG_LD2410, "Restart queued");
+}
+
+void LD2410Handler::query_params(uart::UARTDevice *uart) {
+  uart_ = uart;
+  queue_enter_config_();
+  queue_config_command_(0x00A0, nullptr, 0);
+  queue_config_command_(0x0061, nullptr, 0);
+  queue_config_command_(0x00AB, nullptr, 0);
+  queue_exit_config_();
+  ESP_LOGI(TAG_LD2410, "Parameter query queued");
+}
+
+void LD2410Handler::write_gate_config(uart::UARTDevice *uart) {
+  uart_ = uart;
+  queue_enter_config_();
+
+  uint32_t max_move = static_cast<uint32_t>(config_.max_move_gate);
+  uint32_t max_still = static_cast<uint32_t>(config_.max_still_gate);
+  uint32_t tout = static_cast<uint32_t>(config_.timeout_seconds);
+
+  uint8_t d60[18];
+  d60[0] = 0x00;
+  d60[1] = 0x00;
+  put_uint32_le_(d60 + 2, max_move);
+  d60[6] = 0x01;
+  d60[7] = 0x00;
+  put_uint32_le_(d60 + 8, max_still);
+  d60[12] = 0x02;
+  d60[13] = 0x00;
+  put_uint32_le_(d60 + 14, tout);
+  queue_config_command_(0x0060, d60, 18);
+
+  for (size_t g = 0; g < NUM_GATES; g++) {
+    uint32_t mv = static_cast<uint32_t>(config_.gate_move_threshold[g]);
+    uint32_t sv = static_cast<uint32_t>(config_.gate_still_threshold[g]);
+    uint8_t d64[10];
+    put_uint16_le_(d64, static_cast<uint16_t>(g));
+    put_uint32_le_(d64 + 2, mv);
+    put_uint32_le_(d64 + 6, sv);
+    queue_config_command_(0x0064, d64, 10);
+  }
+
+  queue_exit_config_();
+  ESP_LOGI(TAG_LD2410, "Gate configuration queued");
+}
+
+void LD2410Handler::set_distance_resolution(uart::UARTDevice *uart, bool fine) {
+  uart_ = uart;
+  queue_enter_config_();
+  uint8_t data[2];
+  put_uint16_le_(data, fine ? 0x0001 : 0x0000);
+  queue_config_command_(0x00AA, data, 2);
+  queue_exit_config_();
+  config_.distance_resolution = fine ? 1 : 0;
+  save_backend_config_();
+  ESP_LOGI(TAG_LD2410, "Distance resolution change queued (%s)", fine ? "0.2m" : "0.75m");
+}
+
+bool LD2410Handler::validate_backend_config_(LD2410BackendConfig &cfg) const {
+  if (cfg.max_move_gate > 8 || cfg.max_still_gate > 8)
+    return false;
+  for (size_t g = 0; g < NUM_GATES; g++) {
+    if (cfg.gate_move_threshold[g] > 100 || cfg.gate_still_threshold[g] > 100)
+      return false;
+  }
+  if (cfg.distance_resolution > 1)
+    return false;
+  return true;
+}
+
+void LD2410Handler::save_backend_config_() { config_pref_.save(&config_); }
+
+bool LD2410Handler::set_backend_config(const LD2410BackendConfig &cfg) {
+  LD2410BackendConfig candidate = cfg;
+  if (!validate_backend_config_(candidate))
+    return false;
+  config_ = candidate;
+  save_backend_config_();
+  return true;
+}
+
+void LD2410Handler::apply_backend_config(uart::UARTDevice *uart) {
+  this->write_gate_config(uart);
+  this->set_distance_resolution(uart, config_.distance_resolution == 1);
+}
+
+void LD2410Handler::enable_engineering_mode(uart::UARTDevice *uart) {
+  uart_ = uart;
+  queue_enter_config_();
+  queue_config_command_(0x0062, nullptr, 0);
+  queue_exit_config_();
+  ESP_LOGI(TAG_LD2410, "Engineering mode enable queued");
+}
+
+void LD2410Handler::disable_engineering_mode(uart::UARTDevice *uart) {
+  uart_ = uart;
+  queue_enter_config_();
+  queue_config_command_(0x0063, nullptr, 0);
+  queue_exit_config_();
+  ESP_LOGI(TAG_LD2410, "Engineering mode disable queued");
+}
+
+uint16_t LD2410Handler::to_uint16_(uint8_t lo, uint8_t hi) { return (static_cast<uint16_t>(hi) << 8) | lo; }
+
+void LD2410Handler::process_queue_() {
+  if (uart_ == nullptr)
+    return;
+
+  if (waiting_for_ack_) {
+    if (millis() - ack_wait_start_ > ACK_TIMEOUT_MS) {
+      ESP_LOGW(TAG_LD2410, "Command ACK timeout, skipping");
+      waiting_for_ack_ = false;
+    }
+    return;
+  }
+
+  QueuedCmd cmd;
+  if (!dequeue_frame_(cmd))
+    return;
+
+  uart_->write_array(cmd.frame, cmd.len);
+  waiting_for_ack_ = true;
+  ack_wait_start_ = millis();
+}
+
+void LD2410Handler::on_ack_received_() {
+  if (!waiting_for_ack_)
+    return;
+  waiting_for_ack_ = false;
+}
+
+void LD2410Handler::enqueue_frame_(const QueuedCmd &cmd) {
+  if (cmd_queue_count_ == MAX_CMD_QUEUE_DEPTH) {
+    cmd_queue_head_ = (cmd_queue_head_ + 1) % MAX_CMD_QUEUE_DEPTH;
+    cmd_queue_count_--;
+    ESP_LOGW(TAG_LD2410, "Command queue full, dropping oldest");
+  }
+
+  const size_t tail = (cmd_queue_head_ + cmd_queue_count_) % MAX_CMD_QUEUE_DEPTH;
+  cmd_queue_[tail] = cmd;
+  cmd_queue_count_++;
+}
+
+bool LD2410Handler::dequeue_frame_(QueuedCmd &cmd) {
+  if (cmd_queue_count_ == 0)
+    return false;
+
+  cmd = cmd_queue_[cmd_queue_head_];
+  cmd_queue_head_ = (cmd_queue_head_ + 1) % MAX_CMD_QUEUE_DEPTH;
+  cmd_queue_count_--;
+  return true;
+}
+
+void LD2410Handler::queue_enter_config_() {
+  QueuedCmd cmd{};
+  static const uint8_t frame[] = {0xFD, 0xFC, 0xFB, 0xFA, 0x04, 0x00, 0xFF, 0x00, 0x01, 0x00, 0x04, 0x03, 0x02, 0x01};
+  memcpy(cmd.frame, frame, sizeof(frame));
+  cmd.len = sizeof(frame);
+  enqueue_frame_(cmd);
+}
+
+void LD2410Handler::queue_exit_config_() {
+  QueuedCmd cmd{};
+  static const uint8_t frame[] = {0xFD, 0xFC, 0xFB, 0xFA, 0x02, 0x00, 0xFE, 0x00, 0x04, 0x03, 0x02, 0x01};
+  memcpy(cmd.frame, frame, sizeof(frame));
+  cmd.len = sizeof(frame);
+  enqueue_frame_(cmd);
+}
+
+void LD2410Handler::queue_config_command_(uint16_t command, const uint8_t *data, size_t data_len) {
+  QueuedCmd cmd{};
+  size_t pos = 0;
+
+  cmd.frame[pos++] = 0xFD;
+  cmd.frame[pos++] = 0xFC;
+  cmd.frame[pos++] = 0xFB;
+  cmd.frame[pos++] = 0xFA;
+
+  uint16_t payload_len = static_cast<uint16_t>(2 + data_len);
+  cmd.frame[pos++] = payload_len & 0xFF;
+  cmd.frame[pos++] = (payload_len >> 8) & 0xFF;
+
+  cmd.frame[pos++] = command & 0xFF;
+  cmd.frame[pos++] = (command >> 8) & 0xFF;
+
+  if (data != nullptr && data_len > 0 && (pos + data_len) < (MAX_CMD_FRAME - 4)) {
+    memcpy(cmd.frame + pos, data, data_len);
+    pos += data_len;
+  }
+
+  cmd.frame[pos++] = 0x04;
+  cmd.frame[pos++] = 0x03;
+  cmd.frame[pos++] = 0x02;
+  cmd.frame[pos++] = 0x01;
+
+  cmd.len = pos;
+  enqueue_frame_(cmd);
+}
+
+void LD2410Handler::parse_data_frame_(const uint8_t *buf, size_t len) {
+  // Frame layout: 4(header) + 2(length) + payload_len + 4(footer)
+  // payload_len_min = 11 -> len >= 21
+  if (buf == nullptr || len < 21)
+    return;
+
+  uint8_t data_type = buf[6];
+  uint8_t head_byte = buf[7];
+
+  if (head_byte != 0xAA)
+    return;
+
+  uint8_t target_state = buf[8];
+
+  bool has_moving = (target_state == 0x01 || target_state == 0x03);
+  bool has_still = (target_state == 0x02 || target_state == 0x03);
+  bool has_target = (target_state != 0x00);
+
+  uint16_t move_dist = to_uint16_(buf[9], buf[10]);
+  uint8_t move_energy_val = buf[11];
+
+  uint16_t still_dist = to_uint16_(buf[12], buf[13]);
+  uint8_t still_energy_val = buf[14];
+
+  uint16_t detect_dist = to_uint16_(buf[15], buf[16]);
+
+  if (presence_sensor != nullptr)
+    presence_sensor->publish_state(has_target);
+  if (moving_target_sensor != nullptr)
+    moving_target_sensor->publish_state(has_moving);
+  if (still_target_sensor != nullptr)
+    still_target_sensor->publish_state(has_still);
+
+  publish_sensor_(moving_distance, static_cast<float>(move_dist));
+  publish_sensor_(still_distance, static_cast<float>(still_dist));
+  publish_sensor_(moving_energy, static_cast<float>(move_energy_val));
+  publish_sensor_(still_energy, static_cast<float>(still_energy_val));
+  publish_sensor_(detection_distance, static_cast<float>(detect_dist));
+
+  if (data_type == 0x01 && len >= (19 + 2 * NUM_GATES + 4)) {
+    size_t offset = 19;
+
+    for (size_t g = 0; g < NUM_GATES && (offset + g) < (len - 4); g++) {
+      gate_move_energy_values_[g] = static_cast<float>(buf[offset + g]);
+    }
+    offset += NUM_GATES;
+
+    for (size_t g = 0; g < NUM_GATES && (offset + g) < (len - 4); g++) {
+      gate_still_energy_values_[g] = static_cast<float>(buf[offset + g]);
+    }
+    offset += NUM_GATES;
+
+    if (offset < len - 4) {
+      publish_sensor_(light_sensor, static_cast<float>(buf[offset]));
+    }
+  }
+}
+
+void LD2410Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
+  if (len < 10)
+    return;
+
+  uint16_t cmd_word = to_uint16_(buf[6], buf[7]);
+  uint8_t status = buf[8];
+
+  if (status != 0) {
+    ESP_LOGW(TAG_LD2410, "Command 0x%04X failed (status=%u)", cmd_word, status);
+  }
+
+  if (cmd_word == 0x01A0 && status == 0 && len >= 18) {
+    char ver[32];
+    snprintf(ver, sizeof(ver), "V%u.%02X.%02X%02X%02X%02X", buf[13], buf[12], buf[17], buf[16], buf[15], buf[14]);
+    if (version_text_sensor != nullptr)
+      version_text_sensor->publish_state(ver);
+    ESP_LOGI(TAG_LD2410, "Firmware version: %s", ver);
+  }
+
+  if (cmd_word == 0x0161 && status == 0 && len >= 32) {
+    uint8_t max_move = buf[10];
+    uint8_t max_still = buf[11];
+
+    config_.max_move_gate = (max_move > 8) ? 8 : max_move;
+    config_.max_still_gate = (max_still > 8) ? 8 : max_still;
+
+    for (size_t g = 0; g < NUM_GATES && (12 + g) < (len - 4); g++) {
+      uint8_t gate_val = (buf[12 + g] > 100) ? 100 : buf[12 + g];
+      config_.gate_move_threshold[g] = gate_val;
+    }
+    for (size_t g = 0; g < NUM_GATES && (21 + g) < (len - 4); g++) {
+      uint8_t gate_val = (buf[21 + g] > 100) ? 100 : buf[21 + g];
+      config_.gate_still_threshold[g] = gate_val;
+    }
+
+    if (len > 31) {
+      uint16_t timeout = to_uint16_(buf[30], buf[31]);
+      config_.timeout_seconds = timeout;
+    }
+
+    save_backend_config_();
+
+    ESP_LOGI(TAG_LD2410, "Parameters: max_move=%u max_still=%u", max_move, max_still);
+  }
+
+  if (cmd_word == 0x0162) {
+    if (status == 0) {
+      ESP_LOGI(TAG_LD2410, "Engineering mode enabled");
+    } else {
+      ESP_LOGW(TAG_LD2410, "Failed to enable engineering mode");
+    }
+  }
+
+  if (cmd_word == 0x0163) {
+    if (status == 0) {
+      ESP_LOGI(TAG_LD2410, "Engineering mode disabled");
+    }
+  }
+
+  if (cmd_word == 0x01AB && status == 0 && len >= 12) {
+    uint16_t res = to_uint16_(buf[10], buf[11]);
+    bool fine = (res == 0x0001);
+    config_.distance_resolution = fine ? 1 : 0;
+    save_backend_config_();
+    ESP_LOGI(TAG_LD2410, "Distance resolution: %s", fine ? "0.2m" : "0.75m");
+  }
+
+  on_ack_received_();
+}
+
+void LD2410Handler::publish_sensor_(sensor::Sensor *s, float val) {
+  if (s != nullptr)
+    s->publish_state(val);
+}
+
+void LD2410Handler::put_uint16_le_(uint8_t *buf, uint16_t val) {
+  buf[0] = val & 0xFF;
+  buf[1] = (val >> 8) & 0xFF;
+}
+
+void LD2410Handler::put_uint32_le_(uint8_t *buf, uint32_t val) {
+  buf[0] = val & 0xFF;
+  buf[1] = (val >> 8) & 0xFF;
+  buf[2] = (val >> 16) & 0xFF;
+  buf[3] = (val >> 24) & 0xFF;
+}
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/ld2410_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2410_handler.cpp
@@ -98,10 +98,9 @@ void LD2410Handler::create_and_register_entities() {
 
   if (this->detection_distance == nullptr) {
     this->runtime_detection_distance_sensor_.reset(new Satellite1RadarDynamicSensor());
-    this->runtime_detection_distance_sensor_->configure_dynamic("Radar Detection Distance", ENTITY_CATEGORY_DIAGNOSTIC,
-                                                                true, this->device_class_meta_.distance,
-                                                                this->unit_meta_.centimeter, 0, true,
-                                                                sensor::STATE_CLASS_MEASUREMENT, 0);
+    this->runtime_detection_distance_sensor_->configure_dynamic(
+        "Radar Detection Distance", ENTITY_CATEGORY_DIAGNOSTIC, true, this->device_class_meta_.distance,
+        this->unit_meta_.centimeter, 0, true, sensor::STATE_CLASS_MEASUREMENT, 0);
     App.register_sensor(this->runtime_detection_distance_sensor_.get());
     this->detection_distance = this->runtime_detection_distance_sensor_.get();
   }

--- a/esphome/components/satellite1_radar/ld2410_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2410_handler.cpp
@@ -308,7 +308,10 @@ bool LD2410Handler::validate_backend_config_(LD2410BackendConfig &cfg) const {
   return true;
 }
 
-void LD2410Handler::save_backend_config_() { config_pref_.save(&config_); }
+void LD2410Handler::save_backend_config_() {
+  config_pref_.save(&config_);
+  global_preferences->sync();
+}
 
 bool LD2410Handler::set_backend_config(const LD2410BackendConfig &cfg) {
   LD2410BackendConfig candidate = cfg;

--- a/esphome/components/satellite1_radar/ld2410_handler.h
+++ b/esphome/components/satellite1_radar/ld2410_handler.h
@@ -65,12 +65,8 @@ class LD2410Handler {
   const LD2410BackendConfig &get_backend_config() const { return config_; }
   bool set_backend_config(const LD2410BackendConfig &cfg);
   void apply_backend_config(uart::UARTDevice *uart);
-  float get_gate_move_energy(size_t gate) const {
-    return (gate < NUM_GATES) ? gate_move_energy_values_[gate] : 0.0f;
-  }
-  float get_gate_still_energy(size_t gate) const {
-    return (gate < NUM_GATES) ? gate_still_energy_values_[gate] : 0.0f;
-  }
+  float get_gate_move_energy(size_t gate) const { return (gate < NUM_GATES) ? gate_move_energy_values_[gate] : 0.0f; }
+  float get_gate_still_energy(size_t gate) const { return (gate < NUM_GATES) ? gate_still_energy_values_[gate] : 0.0f; }
 
  protected:
   static constexpr size_t MAX_BUF = 256;

--- a/esphome/components/satellite1_radar/ld2410_handler.h
+++ b/esphome/components/satellite1_radar/ld2410_handler.h
@@ -51,20 +51,17 @@ class LD2410Handler {
   void setup(uart::UARTDevice *uart);
   void loop(uart::UARTDevice *uart);
 
-  void factory_reset(uart::UARTDevice *uart);
-  void restart(uart::UARTDevice *uart);
-  void query_params(uart::UARTDevice *uart);
-  void factory_reset() { this->factory_reset(this->uart_); }
-  void restart() { this->restart(this->uart_); }
-  void query_params() { this->query_params(this->uart_); }
-  void write_gate_config(uart::UARTDevice *uart);
-  void set_distance_resolution(uart::UARTDevice *uart, bool fine);
-  void enable_engineering_mode(uart::UARTDevice *uart);
-  void disable_engineering_mode(uart::UARTDevice *uart);
+  void factory_reset();
+  void restart();
+  void query_params();
+  void write_gate_config();
+  void set_distance_resolution(bool fine);
+  void enable_engineering_mode();
+  void disable_engineering_mode();
 
   const LD2410BackendConfig &get_backend_config() const { return config_; }
   bool set_backend_config(const LD2410BackendConfig &cfg);
-  void apply_backend_config(uart::UARTDevice *uart);
+  void apply_backend_config();
   float get_gate_move_energy(size_t gate) const { return (gate < NUM_GATES) ? gate_move_energy_values_[gate] : 0.0f; }
   float get_gate_still_energy(size_t gate) const { return (gate < NUM_GATES) ? gate_still_energy_values_[gate] : 0.0f; }
 

--- a/esphome/components/satellite1_radar/ld2410_handler.h
+++ b/esphome/components/satellite1_radar/ld2410_handler.h
@@ -15,6 +15,7 @@ namespace satellite1_radar {
 
 class LD2410Handler {
  public:
+  explicit LD2410Handler(uart::UARTDevice &uart) : uart_(uart) {}
   static constexpr size_t NUM_GATES = 9;  // g0 through g8
 
   struct LD2410BackendConfig {
@@ -48,8 +49,8 @@ class LD2410Handler {
   void set_icon_indices(const IconMeta &meta) { this->icon_meta_ = meta; }
   void create_and_register_entities();
 
-  void setup(uart::UARTDevice *uart);
-  void loop(uart::UARTDevice *uart);
+  void setup();
+  void loop();
 
   void factory_reset();
   void restart();
@@ -69,7 +70,7 @@ class LD2410Handler {
   static constexpr size_t MAX_BUF = 256;
   std::unique_ptr<uint8_t[]> buf_{};
   size_t buf_pos_{0};
-  uart::UARTDevice *uart_{nullptr};
+  uart::UARTDevice &uart_;
 
   static constexpr size_t MAX_CMD_FRAME = 64;
   static constexpr size_t MAX_CMD_QUEUE_DEPTH = 32;

--- a/esphome/components/satellite1_radar/ld2410_handler.h
+++ b/esphome/components/satellite1_radar/ld2410_handler.h
@@ -55,8 +55,10 @@ class LD2410Handler {
   void factory_reset();
   void restart();
   void query_params();
+  void query_mac_address();
   void write_gate_config();
   void set_distance_resolution(bool fine);
+  void set_bluetooth_enabled(bool enabled);
   void enable_engineering_mode();
   void disable_engineering_mode();
 
@@ -83,6 +85,9 @@ class LD2410Handler {
   size_t cmd_queue_count_{0};
   bool waiting_for_ack_{false};
   uint32_t ack_wait_start_{0};
+  bool bt_readback_pending_{false};
+  uint32_t bt_readback_due_ms_{0};
+  static const uint32_t BT_READBACK_DELAY_MS = 1500;
   static const uint32_t ACK_TIMEOUT_MS = 1000;
 
   static uint16_t to_uint16_(uint8_t lo, uint8_t hi);

--- a/esphome/components/satellite1_radar/ld2410_handler.h
+++ b/esphome/components/satellite1_radar/ld2410_handler.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 
 namespace esphome {
 namespace satellite1_radar {
@@ -38,11 +39,10 @@ class LD2410Handler {
 
   // Text sensors
   text_sensor::TextSensor *version_text_sensor{nullptr};
+  text_sensor::TextSensor *target_state_text_sensor{nullptr};
 
   // Common entities (references from parent)
   binary_sensor::BinarySensor *presence_sensor{nullptr};
-  binary_sensor::BinarySensor *moving_target_sensor{nullptr};
-  binary_sensor::BinarySensor *still_target_sensor{nullptr};
 
   void set_device_class_indices(const DeviceClassMeta &meta) { this->device_class_meta_ = meta; }
   void set_unit_indices(const UnitMeta &meta) { this->unit_meta_ = meta; }
@@ -89,6 +89,10 @@ class LD2410Handler {
   uint32_t bt_readback_due_ms_{0};
   static const uint32_t BT_READBACK_DELAY_MS = 1500;
   static const uint32_t ACK_TIMEOUT_MS = 1000;
+  static const int TARGET_STATE_STREAK_THRESHOLD = 3;
+  std::string pub_target_state_;
+  std::string cand_target_state_;
+  int streak_target_state_{0};
 
   static uint16_t to_uint16_(uint8_t lo, uint8_t hi);
 
@@ -101,6 +105,7 @@ class LD2410Handler {
   bool dequeue_frame_(QueuedCmd &cmd);
   void parse_data_frame_(const uint8_t *buf, size_t len);
   void handle_ack_frame_(const uint8_t *buf, size_t len);
+  void debounce_target_state_(const std::string &raw, int threshold);
 
   static void publish_sensor_(sensor::Sensor *s, float val);
   static void put_uint16_le_(uint8_t *buf, uint16_t val);
@@ -118,9 +123,8 @@ class LD2410Handler {
   IconMeta icon_meta_{};
 
   std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_presence_binary_sensor_{};
-  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_moving_target_binary_sensor_{};
-  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_still_target_binary_sensor_{};
   std::unique_ptr<Satellite1RadarDynamicTextSensor> runtime_radar_firmware_text_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicTextSensor> runtime_target_state_text_sensor_{};
   std::unique_ptr<Satellite1RadarDynamicSensor> runtime_moving_distance_sensor_{};
   std::unique_ptr<Satellite1RadarDynamicSensor> runtime_still_distance_sensor_{};
   std::unique_ptr<Satellite1RadarDynamicSensor> runtime_moving_energy_sensor_{};

--- a/esphome/components/satellite1_radar/ld2410_handler.h
+++ b/esphome/components/satellite1_radar/ld2410_handler.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/preferences.h"
+#include "radar_entities.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace esphome {
+namespace satellite1_radar {
+
+class LD2410Handler {
+ public:
+  static constexpr size_t NUM_GATES = 9;  // g0 through g8
+
+  struct LD2410BackendConfig {
+    uint16_t timeout_seconds{0};
+    uint8_t max_move_gate{8};
+    uint8_t max_still_gate{8};
+    uint8_t gate_move_threshold[NUM_GATES]{50, 50, 50, 50, 50, 50, 50, 50, 50};
+    uint8_t gate_still_threshold[NUM_GATES]{50, 50, 50, 50, 50, 50, 50, 50, 50};
+    uint8_t distance_resolution{0};  // 0=0.75m, 1=0.2m
+    bool bluetooth_enabled{false};
+  };
+
+  // Sensors
+  sensor::Sensor *moving_distance{nullptr};
+  sensor::Sensor *still_distance{nullptr};
+  sensor::Sensor *moving_energy{nullptr};
+  sensor::Sensor *still_energy{nullptr};
+  sensor::Sensor *detection_distance{nullptr};
+  sensor::Sensor *light_sensor{nullptr};
+
+  // Text sensors
+  text_sensor::TextSensor *version_text_sensor{nullptr};
+
+  // Common entities (references from parent)
+  binary_sensor::BinarySensor *presence_sensor{nullptr};
+  binary_sensor::BinarySensor *moving_target_sensor{nullptr};
+  binary_sensor::BinarySensor *still_target_sensor{nullptr};
+
+  void set_device_class_indices(const DeviceClassMeta &meta) { this->device_class_meta_ = meta; }
+  void set_unit_indices(const UnitMeta &meta) { this->unit_meta_ = meta; }
+  void set_icon_indices(const IconMeta &meta) { this->icon_meta_ = meta; }
+  void create_and_register_entities();
+
+  void setup(uart::UARTDevice *uart);
+  void loop(uart::UARTDevice *uart);
+
+  void factory_reset(uart::UARTDevice *uart);
+  void restart(uart::UARTDevice *uart);
+  void query_params(uart::UARTDevice *uart);
+  void factory_reset() { this->factory_reset(this->uart_); }
+  void restart() { this->restart(this->uart_); }
+  void query_params() { this->query_params(this->uart_); }
+  void write_gate_config(uart::UARTDevice *uart);
+  void set_distance_resolution(uart::UARTDevice *uart, bool fine);
+  void enable_engineering_mode(uart::UARTDevice *uart);
+  void disable_engineering_mode(uart::UARTDevice *uart);
+
+  const LD2410BackendConfig &get_backend_config() const { return config_; }
+  bool set_backend_config(const LD2410BackendConfig &cfg);
+  void apply_backend_config(uart::UARTDevice *uart);
+  float get_gate_move_energy(size_t gate) const {
+    return (gate < NUM_GATES) ? gate_move_energy_values_[gate] : 0.0f;
+  }
+  float get_gate_still_energy(size_t gate) const {
+    return (gate < NUM_GATES) ? gate_still_energy_values_[gate] : 0.0f;
+  }
+
+ protected:
+  static constexpr size_t MAX_BUF = 256;
+  std::unique_ptr<uint8_t[]> buf_{};
+  size_t buf_pos_{0};
+  uart::UARTDevice *uart_{nullptr};
+
+  static constexpr size_t MAX_CMD_FRAME = 64;
+  static constexpr size_t MAX_CMD_QUEUE_DEPTH = 32;
+  struct QueuedCmd {
+    uint8_t frame[MAX_CMD_FRAME];
+    size_t len{0};
+  };
+  QueuedCmd cmd_queue_[MAX_CMD_QUEUE_DEPTH]{};
+  size_t cmd_queue_head_{0};
+  size_t cmd_queue_count_{0};
+  bool waiting_for_ack_{false};
+  uint32_t ack_wait_start_{0};
+  static const uint32_t ACK_TIMEOUT_MS = 1000;
+
+  static uint16_t to_uint16_(uint8_t lo, uint8_t hi);
+
+  void process_queue_();
+  void on_ack_received_();
+  void queue_enter_config_();
+  void queue_exit_config_();
+  void queue_config_command_(uint16_t command, const uint8_t *data, size_t data_len);
+  void enqueue_frame_(const QueuedCmd &cmd);
+  bool dequeue_frame_(QueuedCmd &cmd);
+  void parse_data_frame_(const uint8_t *buf, size_t len);
+  void handle_ack_frame_(const uint8_t *buf, size_t len);
+
+  static void publish_sensor_(sensor::Sensor *s, float val);
+  static void put_uint16_le_(uint8_t *buf, uint16_t val);
+  static void put_uint32_le_(uint8_t *buf, uint32_t val);
+
+  bool validate_backend_config_(LD2410BackendConfig &cfg) const;
+  void save_backend_config_();
+
+  LD2410BackendConfig config_{};
+  ESPPreferenceObject config_pref_;
+  float gate_move_energy_values_[NUM_GATES]{};
+  float gate_still_energy_values_[NUM_GATES]{};
+  DeviceClassMeta device_class_meta_{};
+  UnitMeta unit_meta_{};
+  IconMeta icon_meta_{};
+
+  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_presence_binary_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_moving_target_binary_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_still_target_binary_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicTextSensor> runtime_radar_firmware_text_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_moving_distance_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_still_distance_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_moving_energy_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_still_energy_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_detection_distance_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_light_sensor_{};
+  std::unique_ptr<Satellite1RadarButton> runtime_factory_reset_button_{};
+  std::unique_ptr<Satellite1RadarButton> runtime_restart_button_{};
+  std::unique_ptr<Satellite1RadarButton> runtime_query_params_button_{};
+};
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -102,6 +102,8 @@ void LD2450Handler::create_and_register_entities() {
   }
 
   for (size_t i = 0; i < NUM_ZONES; i++) {
+    if (this->config_.zones[i].points_count < 3)
+      continue;
     if (this->zone_state[i] != nullptr)
       continue;
     this->runtime_zone_state_text_sensor_[i].reset(new Satellite1RadarDynamicTextSensor());
@@ -293,7 +295,17 @@ bool LD2450Handler::set_backend_config(const LD2450BackendConfig &cfg) {
 }
 
 bool LD2450Handler::entity_layout_matches_(const LD2450BackendConfig &lhs, const LD2450BackendConfig &rhs) const {
-  return lhs.multi_target_enabled == rhs.multi_target_enabled;
+  if (lhs.multi_target_enabled != rhs.multi_target_enabled)
+    return false;
+
+  for (size_t i = 0; i < NUM_ZONES; i++) {
+    const bool lhs_defined = lhs.zones[i].points_count >= 3;
+    const bool rhs_defined = rhs.zones[i].points_count >= 3;
+    if (lhs_defined != rhs_defined)
+      return false;
+  }
+
+  return true;
 }
 
 void LD2450Handler::set_bluetooth_enabled(bool enabled) {

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -1,0 +1,656 @@
+#include "ld2450_handler.h"
+
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include <cmath>
+#include <cstring>
+
+namespace esphome {
+namespace satellite1_radar {
+
+static const char *const TAG_LD2450 = "satellite1_radar.ld2450";
+static constexpr size_t MAX_UART_BYTES_PER_LOOP = 128;
+static const uint8_t LD2450_ENABLE_CONFIG[] = {0xFD, 0xFC, 0xFB, 0xFA, 0x04, 0x00, 0xFF,
+                                               0x00, 0x01, 0x00, 0x04, 0x03, 0x02, 0x01};
+static const uint8_t LD2450_FRAME_HEADER[] = {0xFD, 0xFC, 0xFB, 0xFA};
+static const uint8_t LD2450_DISABLE_CONFIG[] = {0xFD, 0xFC, 0xFB, 0xFA, 0x02, 0x00, 0xFE, 0x00, 0x04, 0x03, 0x02, 0x01};
+
+static inline bool deadline_passed_(uint32_t deadline, uint32_t now) {
+  return static_cast<int32_t>(now - deadline) >= 0;
+}
+
+void LD2450Handler::setup(uart::UARTDevice *uart) {
+  ESP_LOGI(TAG_LD2450, "Initializing LD2450 handler");
+  uart_ = uart;
+  if (!buf_) {
+    buf_ = std::unique_ptr<uint8_t[]>(new uint8_t[MAX_BUF]());
+  }
+  fw_version_received_ = false;
+  fw_retry_count_ = 0;
+  fw_next_retry_ms_ = millis() + 2000;
+  config_pref_ = global_preferences->make_preference<LD2450BackendConfig>(fnv1_hash("sat1.ld2450.config"));
+  LD2450BackendConfig loaded;
+  if (config_pref_.load(&loaded)) {
+    this->set_backend_config(loaded);
+  }
+}
+
+void LD2450Handler::create_and_register_entities() {
+  if (this->presence_sensor == nullptr) {
+    this->runtime_presence_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
+    this->runtime_presence_binary_sensor_->configure_dynamic("Room Presence", ENTITY_CATEGORY_NONE, false,
+                                                             this->device_class_meta_.occupancy);
+    App.register_binary_sensor(this->runtime_presence_binary_sensor_.get());
+    this->presence_sensor = this->runtime_presence_binary_sensor_.get();
+  }
+
+  if (this->moving_target_sensor == nullptr) {
+    this->runtime_moving_target_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
+    this->runtime_moving_target_binary_sensor_->configure_dynamic("Radar Target Moving", ENTITY_CATEGORY_NONE, false,
+                                                                  this->device_class_meta_.motion);
+    App.register_binary_sensor(this->runtime_moving_target_binary_sensor_.get());
+    this->moving_target_sensor = this->runtime_moving_target_binary_sensor_.get();
+  }
+
+  if (this->still_target_sensor == nullptr) {
+    this->runtime_still_target_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
+    this->runtime_still_target_binary_sensor_->configure_dynamic("Radar Target Still", ENTITY_CATEGORY_NONE, false,
+                                                                 this->device_class_meta_.occupancy);
+    App.register_binary_sensor(this->runtime_still_target_binary_sensor_.get());
+    this->still_target_sensor = this->runtime_still_target_binary_sensor_.get();
+  }
+
+  if (this->version_text_sensor == nullptr) {
+    this->runtime_radar_firmware_text_sensor_.reset(new Satellite1RadarDynamicTextSensor());
+    this->runtime_radar_firmware_text_sensor_->configure_dynamic("Radar Firmware", ENTITY_CATEGORY_DIAGNOSTIC, false,
+                                                                 this->icon_meta_.chip);
+    App.register_text_sensor(this->runtime_radar_firmware_text_sensor_.get());
+    this->version_text_sensor = this->runtime_radar_firmware_text_sensor_.get();
+  }
+
+  if (this->target_count == nullptr) {
+    this->runtime_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_target_count_sensor_->configure_dynamic("Radar Targets Total", ENTITY_CATEGORY_NONE, false, 0, 0,
+                                                          this->icon_meta_.account_multiple, true,
+                                                          sensor::STATE_CLASS_MEASUREMENT, 0);
+    App.register_sensor(this->runtime_target_count_sensor_.get());
+    this->target_count = this->runtime_target_count_sensor_.get();
+  }
+
+  if (this->still_target_count == nullptr) {
+    this->runtime_still_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_still_target_count_sensor_->configure_dynamic("Radar Targets Still", ENTITY_CATEGORY_NONE, false, 0,
+                                                                0, this->icon_meta_.account, true,
+                                                                sensor::STATE_CLASS_MEASUREMENT, 0);
+    App.register_sensor(this->runtime_still_target_count_sensor_.get());
+    this->still_target_count = this->runtime_still_target_count_sensor_.get();
+  }
+
+  if (this->moving_target_count == nullptr) {
+    this->runtime_moving_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
+    this->runtime_moving_target_count_sensor_->configure_dynamic("Radar Targets Moving", ENTITY_CATEGORY_NONE, false,
+                                                                 0, 0, this->icon_meta_.account_arrow_right, true,
+                                                                 sensor::STATE_CLASS_MEASUREMENT, 0);
+    App.register_sensor(this->runtime_moving_target_count_sensor_.get());
+    this->moving_target_count = this->runtime_moving_target_count_sensor_.get();
+  }
+
+  for (size_t i = 0; i < NUM_ZONES; i++) {
+    if (this->zone_state[i] != nullptr)
+      continue;
+    this->runtime_zone_state_text_sensor_[i].reset(new Satellite1RadarDynamicTextSensor());
+    switch (i) {
+      case 0:
+        this->runtime_zone_state_text_sensor_[i]->configure_dynamic("Radar Zone 1", ENTITY_CATEGORY_NONE, false,
+                                                                     this->icon_meta_.motion_sensor);
+        break;
+      case 1:
+        this->runtime_zone_state_text_sensor_[i]->configure_dynamic("Radar Zone 2", ENTITY_CATEGORY_NONE, false,
+                                                                     this->icon_meta_.motion_sensor);
+        break;
+      default:
+        this->runtime_zone_state_text_sensor_[i]->configure_dynamic("Radar Zone 3", ENTITY_CATEGORY_NONE, false,
+                                                                     this->icon_meta_.motion_sensor);
+        break;
+    }
+    App.register_text_sensor(this->runtime_zone_state_text_sensor_[i].get());
+    this->zone_state[i] = this->runtime_zone_state_text_sensor_[i].get();
+  }
+
+  if (this->runtime_factory_reset_button_ == nullptr) {
+    this->runtime_factory_reset_button_.reset(new Satellite1RadarButton());
+    this->runtime_factory_reset_button_->configure_dynamic("Radar Factory Reset", ENTITY_CATEGORY_DIAGNOSTIC, false,
+                                                           this->icon_meta_.factory);
+    this->runtime_factory_reset_button_->add_on_press_callback([this]() { this->factory_reset(); });
+    App.register_button(this->runtime_factory_reset_button_.get());
+  }
+
+  if (this->runtime_restart_button_ == nullptr) {
+    this->runtime_restart_button_.reset(new Satellite1RadarButton());
+    this->runtime_restart_button_->configure_dynamic("Radar Restart", ENTITY_CATEGORY_DIAGNOSTIC, false,
+                                                     this->icon_meta_.restart);
+    this->runtime_restart_button_->add_on_press_callback([this]() { this->restart(); });
+    App.register_button(this->runtime_restart_button_.get());
+  }
+}
+
+void LD2450Handler::loop(uart::UARTDevice *uart) {
+  uart_ = uart;
+
+  if (!buf_)
+    return;
+
+  uint32_t now = millis();
+
+  if (!fw_version_received_ && !fw_query_in_flight_ && fw_retry_count_ < FW_MAX_RETRIES &&
+      deadline_passed_(fw_next_retry_ms_, now)) {
+    request_firmware_version_();
+  }
+
+  if (fw_query_in_flight_ && deadline_passed_(fw_query_timeout_ms_, now)) {
+    fw_query_in_flight_ = false;
+    fw_next_retry_ms_ = now + 3000;
+    ESP_LOGW(TAG_LD2450, "Firmware query timeout (attempt %d/%d)", fw_retry_count_, FW_MAX_RETRIES);
+  }
+
+  size_t bytes_processed = 0;
+  while (uart_->available() && bytes_processed < MAX_UART_BYTES_PER_LOOP) {
+    uint8_t byte;
+    if (!uart_->read_byte(&byte))
+      break;
+    bytes_processed++;
+
+    if (buf_pos_ < MAX_BUF)
+      buf_[buf_pos_++] = byte;
+    else
+      buf_pos_ = 0;
+
+    if (buf_pos_ >= 10 && buf_[buf_pos_ - 4] == 0x04 && buf_[buf_pos_ - 3] == 0x03 && buf_[buf_pos_ - 2] == 0x02 &&
+        buf_[buf_pos_ - 1] == 0x01) {
+      handle_ack_frame_(buf_.get(), buf_pos_);
+      buf_pos_ = 0;
+      continue;
+    }
+
+    if (buf_pos_ >= DATA_FRAME_SIZE && buf_[0] == 0xAA && buf_[1] == 0xFF && buf_[2] == 0x03 && buf_[3] == 0x00 &&
+        buf_[28] == 0x55 && buf_[29] == 0xCC) {
+      parse_data_frame_(buf_.get());
+      buf_pos_ = 0;
+    }
+  }
+
+  step_command_tx_();
+}
+
+void LD2450Handler::factory_reset(uart::UARTDevice *uart) {
+  uart_ = uart;
+  static const uint8_t cmd[] = {0x02, 0x00, 0xA2, 0x00, 0x04, 0x03, 0x02, 0x01};
+  send_command_(cmd, sizeof(cmd));
+  ESP_LOGI(TAG_LD2450, "Factory reset command sent");
+}
+
+void LD2450Handler::restart(uart::UARTDevice *uart) {
+  uart_ = uart;
+  static const uint8_t cmd[] = {0x02, 0x00, 0xA3, 0x00, 0x04, 0x03, 0x02, 0x01};
+  send_command_(cmd, sizeof(cmd));
+  ESP_LOGI(TAG_LD2450, "Restart command sent");
+}
+
+void LD2450Handler::set_single_target() {
+  static const uint8_t cmd[] = {0x02, 0x00, 0x80, 0x00, 0x04, 0x03, 0x02, 0x01};
+  send_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::set_multi_target() {
+  static const uint8_t cmd[] = {0x02, 0x00, 0x90, 0x00, 0x04, 0x03, 0x02, 0x01};
+  send_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::turn_bluetooth_on() {
+  static const uint8_t cmd[] = {0x04, 0x00, 0xA4, 0x00, 0x01, 0x00, 0x04, 0x03, 0x02, 0x01};
+  send_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::turn_bluetooth_off() {
+  static const uint8_t cmd[] = {0x04, 0x00, 0xA4, 0x00, 0x00, 0x00, 0x04, 0x03, 0x02, 0x01};
+  send_command_(cmd, sizeof(cmd));
+}
+
+bool LD2450Handler::validate_backend_config_(LD2450BackendConfig &cfg) const {
+  if (cfg.detection_range_cm > 600)
+    return false;
+  if (cfg.stability > 10)
+    return false;
+
+  for (size_t z = 0; z < NUM_ZONES; z++) {
+    if (cfg.zones[z].points_count > MAX_ZONE_POINTS)
+      return false;
+    for (size_t p = 0; p < cfg.zones[z].points_count; p++) {
+      if (cfg.zones[z].points[p].x < -6000 || cfg.zones[z].points[p].x > 6000)
+        return false;
+      if (cfg.zones[z].points[p].y < -6000 || cfg.zones[z].points[p].y > 6000)
+        return false;
+    }
+  }
+
+  if (cfg.exclusion.points_count > MAX_ZONE_POINTS)
+    return false;
+  for (size_t p = 0; p < cfg.exclusion.points_count; p++) {
+    if (cfg.exclusion.points[p].x < -6000 || cfg.exclusion.points[p].x > 6000)
+      return false;
+    if (cfg.exclusion.points[p].y < -6000 || cfg.exclusion.points[p].y > 6000)
+      return false;
+  }
+  return true;
+}
+
+void LD2450Handler::save_backend_config_() { config_pref_.save(&config_); }
+
+bool LD2450Handler::set_backend_config(const LD2450BackendConfig &cfg) {
+  LD2450BackendConfig candidate = cfg;
+  if (!validate_backend_config_(candidate))
+    return false;
+
+  bool bluetooth_changed = (candidate.bluetooth_enabled != config_.bluetooth_enabled);
+  bool multi_target_changed = (candidate.multi_target_enabled != config_.multi_target_enabled);
+
+  config_ = candidate;
+  save_backend_config_();
+
+  if (bluetooth_changed) {
+    if (config_.bluetooth_enabled)
+      turn_bluetooth_on();
+    else
+      turn_bluetooth_off();
+  }
+  if (multi_target_changed) {
+    if (config_.multi_target_enabled)
+      set_multi_target();
+    else
+      set_single_target();
+  }
+
+  return true;
+}
+
+void LD2450Handler::set_bluetooth_enabled(bool enabled) {
+  if (config_.bluetooth_enabled == enabled)
+    return;
+  config_.bluetooth_enabled = enabled;
+  save_backend_config_();
+  if (enabled)
+    turn_bluetooth_on();
+  else
+    turn_bluetooth_off();
+}
+
+void LD2450Handler::set_multi_target_enabled(bool enabled) {
+  if (config_.multi_target_enabled == enabled)
+    return;
+  config_.multi_target_enabled = enabled;
+  save_backend_config_();
+  if (enabled)
+    set_multi_target();
+  else
+    set_single_target();
+}
+
+uint16_t LD2450Handler::to_uint16(uint8_t lo, uint8_t hi) { return (static_cast<uint16_t>(hi) << 8) | lo; }
+
+int16_t LD2450Handler::to_signed(uint16_t val) {
+  return (val & 0x8000) ? static_cast<int16_t>(val & 0x7FFF) : -static_cast<int16_t>(val & 0x7FFF);
+}
+
+void LD2450Handler::parse_data_frame_(const uint8_t *buf) {
+  int total_count = 0;
+  int still_count = 0;
+  int moving_count = 0;
+  bool any_target = false;
+  bool any_moving = false;
+  bool any_still = false;
+
+  for (size_t t = 0; t < NUM_TARGETS; t++) {
+    size_t base = 4 + t * 8;
+    uint16_t raw_x = to_uint16(buf[base], buf[base + 1]);
+    uint16_t raw_y = to_uint16(buf[base + 2], buf[base + 3]);
+    uint16_t raw_speed = to_uint16(buf[base + 4], buf[base + 5]);
+    float x_cm = -static_cast<float>(to_signed(raw_x)) / 10.0f;
+    float y_cm = static_cast<float>(to_signed(raw_y)) / 10.0f;
+    float speed = -static_cast<float>(to_signed(raw_speed));
+    float dist = std::sqrt(x_cm * x_cm + y_cm * y_cm);
+    bool valid = (dist > 0.0f);
+    target_valid_[t] = valid;
+    target_x_cm_[t] = valid ? x_cm : 0.0f;
+    target_y_cm_[t] = valid ? y_cm : 0.0f;
+    target_speed_cm_s_[t] = valid ? speed : 0.0f;
+    target_distance_cm_[t] = valid ? dist : 0.0f;
+
+    float pub_x = valid ? x_cm : 0.0f;
+    float pub_y = valid ? y_cm : 0.0f;
+
+    if (valid && !is_beyond_detection_range_(dist) && !is_in_exclusion_zone_(x_cm, y_cm)) {
+      total_count++;
+      any_target = true;
+
+      if (std::fabs(speed) > 0.0f) {
+        moving_count++;
+        any_moving = true;
+      } else {
+        still_count++;
+        any_still = true;
+      }
+    }
+
+    if (on_target_update) {
+      on_target_update(static_cast<int>(t), pub_x, pub_y);
+    }
+
+  }
+
+  int threshold = get_stability_threshold_();
+
+  debounce_sensor_(pub_total_count_, cand_total_count_, streak_total_, total_count, threshold, target_count);
+  debounce_sensor_(pub_still_count_, cand_still_count_, streak_still_, still_count, threshold, still_target_count);
+  debounce_sensor_(pub_moving_count_, cand_moving_count_, streak_moving_, moving_count, threshold, moving_target_count);
+
+  debounce_binary_(pub_presence_, cand_presence_, streak_presence_, any_target, threshold, presence_sensor);
+  debounce_binary_(pub_has_moving_, cand_has_moving_, streak_has_moving_, any_moving, threshold, moving_target_sensor);
+  debounce_binary_(pub_has_still_, cand_has_still_, streak_has_still_, any_still, threshold, still_target_sensor);
+
+  update_zone_states_(threshold);
+}
+
+bool LD2450Handler::point_in_polygon_(const Point *points, size_t count, float x, float y) {
+  if (points == nullptr)
+    return false;
+  if (count < 3 || count > MAX_ZONE_POINTS)
+    return false;
+
+  float xs[MAX_ZONE_POINTS], ys[MAX_ZONE_POINTS];
+  for (size_t i = 0; i < count; i++) {
+    xs[i] = static_cast<float>(points[i].x);
+    ys[i] = static_cast<float>(points[i].y);
+  }
+
+  bool inside = false;
+  for (size_t i = 0, j = count - 1; i < count; j = i++) {
+    if (((ys[i] > y) != (ys[j] > y)) && (x < (xs[j] - xs[i]) * (y - ys[i]) / (ys[j] - ys[i]) + xs[i]))
+      inside = !inside;
+  }
+  return inside;
+}
+
+bool LD2450Handler::is_in_exclusion_zone_(float x, float y) {
+  return point_in_polygon_(config_.exclusion.points, config_.exclusion.points_count, x, y);
+}
+
+bool LD2450Handler::is_beyond_detection_range_(float dist) {
+  if (config_.detection_range_cm == 0)
+    return false;
+  return dist > static_cast<float>(config_.detection_range_cm);
+}
+
+void LD2450Handler::update_zone_states_(int threshold) {
+  for (size_t z = 0; z < NUM_ZONES; z++) {
+    if (zone_state[z] == nullptr)
+      continue;
+
+    const Polygon &zone = config_.zones[z];
+    if (zone.points_count < 3) {
+      debounce_zone_(static_cast<int>(z), "Undefined", threshold);
+      continue;
+    }
+
+    int best = -1;
+
+    for (size_t t = 0; t < NUM_TARGETS; t++) {
+      if (!target_valid_[t])
+        continue;
+
+      float tx = target_x_cm_[t];
+      float ty = target_y_cm_[t];
+      float ts = target_speed_cm_s_[t];
+      float td = target_distance_cm_[t];
+
+      if (td <= 0.0f)
+        continue;
+
+      if (is_beyond_detection_range_(td))
+        continue;
+
+      if (is_in_exclusion_zone_(tx, ty))
+        continue;
+
+      if (point_in_polygon_(zone.points, zone.points_count, tx, ty)) {
+        if (ts > 0.0f) {
+          best = 2;
+          break;
+        } else if (ts < 0.0f) {
+          if (best < 1)
+            best = 1;
+        } else {
+          if (best < 0)
+            best = 0;
+        }
+      }
+    }
+
+    const char *state_str = (best == 2) ? "Approaching" : (best == 1) ? "Moving Away" : (best == 0) ? "Still" : "Clear";
+    debounce_zone_(static_cast<int>(z), state_str, threshold);
+  }
+}
+
+void LD2450Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
+  if (len < 10)
+    return;
+  if (buf[0] != 0xFD || buf[1] != 0xFC || buf[2] != 0xFB || buf[3] != 0xFA)
+    return;
+
+  uint16_t cmd_word = to_uint16(buf[6], buf[7]);
+
+  if (cmd_word == 0x01A0 && len >= 20) {
+    char ver[32];
+    snprintf(ver, sizeof(ver), "V%u.%02X.%02X%02X%02X%02X", buf[13], buf[12], buf[17], buf[16], buf[15], buf[14]);
+    if (version_text_sensor != nullptr)
+      version_text_sensor->publish_state(ver);
+    fw_version_received_ = true;
+    fw_query_in_flight_ = false;
+    ESP_LOGI(TAG_LD2450, "Firmware version: %s", ver);
+  }
+
+  if (cmd_word == 0x01A5 && len >= 16) {
+    char mac[20];
+    snprintf(mac, sizeof(mac), "%02X:%02X:%02X:%02X:%02X:%02X", buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]);
+    ESP_LOGI(TAG_LD2450, "BT MAC: %s", mac);
+  }
+}
+
+void LD2450Handler::request_firmware_version_() {
+  if (fw_query_in_flight_ || fw_version_received_ || fw_retry_count_ >= FW_MAX_RETRIES)
+    return;
+
+  static const uint8_t cmd[] = {0x02, 0x00, 0xA0, 0x00, 0x04, 0x03, 0x02, 0x01};
+  uint32_t now = millis();
+  fw_retry_count_++;
+  fw_query_in_flight_ = true;
+  fw_query_timeout_ms_ = now + 5000;
+  fw_next_retry_ms_ = now + 3000;
+  ESP_LOGI(TAG_LD2450, "Requesting firmware version (attempt %d/%d)", fw_retry_count_, FW_MAX_RETRIES);
+  enqueue_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::enqueue_command_(const uint8_t *cmd, size_t len) {
+  if (cmd == nullptr || len == 0)
+    return;
+  if (len > MAX_CMD_LEN) {
+    ESP_LOGW(TAG_LD2450, "Command too long (%u > %u), dropping", static_cast<unsigned int>(len),
+             static_cast<unsigned int>(MAX_CMD_LEN));
+    return;
+  }
+
+  QueuedCommand queued{};
+  memcpy(queued.bytes, cmd, len);
+  queued.len = len;
+
+  if (command_queue_count_ == MAX_COMMAND_QUEUE_DEPTH) {
+    command_queue_head_ = (command_queue_head_ + 1) % MAX_COMMAND_QUEUE_DEPTH;
+    command_queue_count_--;
+    ESP_LOGW(TAG_LD2450, "Command queue full, dropping oldest");
+  }
+
+  const size_t tail = (command_queue_head_ + command_queue_count_) % MAX_COMMAND_QUEUE_DEPTH;
+  command_queue_[tail] = queued;
+  command_queue_count_++;
+}
+
+bool LD2450Handler::dequeue_command_(QueuedCommand &queued) {
+  if (command_queue_count_ == 0)
+    return false;
+
+  queued = command_queue_[command_queue_head_];
+  command_queue_head_ = (command_queue_head_ + 1) % MAX_COMMAND_QUEUE_DEPTH;
+  command_queue_count_--;
+  return true;
+}
+
+void LD2450Handler::step_command_tx_() {
+  if (uart_ == nullptr)
+    return;
+
+  uint32_t now = millis();
+  switch (tx_state_) {
+    case TxState::IDLE:
+      if (!has_active_command_ && !dequeue_command_(active_command_))
+        return;
+      has_active_command_ = true;
+      uart_->write_array(LD2450_ENABLE_CONFIG, sizeof(LD2450_ENABLE_CONFIG));
+      uart_->flush();
+      tx_state_ = TxState::WAIT_ENABLE;
+      tx_deadline_ms_ = now + 50;
+      return;
+
+    case TxState::WAIT_ENABLE:
+      if (!deadline_passed_(tx_deadline_ms_, now))
+        return;
+      if (!has_active_command_) {
+        tx_state_ = TxState::IDLE;
+        return;
+      }
+      uart_->write_array(LD2450_FRAME_HEADER, sizeof(LD2450_FRAME_HEADER));
+      uart_->write_array(active_command_.bytes, active_command_.len);
+      uart_->flush();
+      tx_state_ = TxState::WAIT_AFTER_COMMAND;
+      tx_deadline_ms_ = now + 50;
+      return;
+
+    case TxState::WAIT_AFTER_COMMAND:
+      if (!deadline_passed_(tx_deadline_ms_, now))
+        return;
+      uart_->write_array(LD2450_DISABLE_CONFIG, sizeof(LD2450_DISABLE_CONFIG));
+      uart_->flush();
+      tx_state_ = TxState::WAIT_DISABLE;
+      tx_deadline_ms_ = now + 20;
+      return;
+
+    case TxState::WAIT_DISABLE:
+      if (!deadline_passed_(tx_deadline_ms_, now))
+        return;
+      has_active_command_ = false;
+      tx_state_ = TxState::IDLE;
+      return;
+  }
+}
+
+void LD2450Handler::send_command_(const uint8_t *cmd, size_t len) { enqueue_command_(cmd, len); }
+
+int LD2450Handler::get_stability_threshold_() {
+  int val = static_cast<int>(config_.stability);
+  return (val < 0) ? 0 : val;
+}
+
+void LD2450Handler::debounce_sensor_(int &pub, int &cand, int &streak, int raw, int threshold, sensor::Sensor *s) {
+  if (s == nullptr)
+    return;
+  if (threshold <= 0 || pub == -1) {
+    pub = raw;
+    s->publish_state(static_cast<float>(raw));
+    return;
+  }
+  if (raw == pub) {
+    streak = 0;
+    return;
+  }
+  if (raw == cand) {
+    streak++;
+  } else {
+    cand = raw;
+    streak = 1;
+  }
+  if (streak >= threshold) {
+    pub = raw;
+    s->publish_state(static_cast<float>(raw));
+    streak = 0;
+  }
+}
+
+void LD2450Handler::debounce_binary_(int &pub, int &cand, int &streak, bool raw, int threshold,
+                                     binary_sensor::BinarySensor *s) {
+  if (s == nullptr)
+    return;
+  int raw_int = raw ? 1 : 0;
+  if (threshold <= 0 || pub == -1) {
+    pub = raw_int;
+    s->publish_state(raw);
+    return;
+  }
+  if (raw_int == pub) {
+    streak = 0;
+    return;
+  }
+  if (raw_int == cand) {
+    streak++;
+  } else {
+    cand = raw_int;
+    streak = 1;
+  }
+  if (streak >= threshold) {
+    pub = raw_int;
+    s->publish_state(raw);
+    streak = 0;
+  }
+}
+
+void LD2450Handler::debounce_zone_(int z, const std::string &raw, int threshold) {
+  if (zone_state[z] == nullptr)
+    return;
+  if (threshold <= 0 || pub_zone_state_[z].empty()) {
+    pub_zone_state_[z] = raw;
+    zone_state[z]->publish_state(raw);
+    return;
+  }
+  if (raw == pub_zone_state_[z]) {
+    streak_zone_[z] = 0;
+    return;
+  }
+  if (raw == cand_zone_state_[z]) {
+    streak_zone_[z]++;
+  } else {
+    cand_zone_state_[z] = raw;
+    streak_zone_[z] = 1;
+  }
+  if (streak_zone_[z] >= threshold) {
+    pub_zone_state_[z] = raw;
+    zone_state[z]->publish_state(raw);
+    streak_zone_[z] = 0;
+  }
+}
+
+void LD2450Handler::publish_sensor_(sensor::Sensor *s, float val) {
+  if (s != nullptr)
+    s->publish_state(val);
+}
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -217,12 +217,12 @@ void LD2450Handler::set_multi_target() {
 
 void LD2450Handler::turn_bluetooth_on() {
   static const uint8_t cmd[] = {0x04, 0x00, 0xA4, 0x00, 0x01, 0x00, 0x04, 0x03, 0x02, 0x01};
-  send_command_(cmd, sizeof(cmd));
+  enqueue_with_retries_(cmd, sizeof(cmd), true);
 }
 
 void LD2450Handler::turn_bluetooth_off() {
   static const uint8_t cmd[] = {0x04, 0x00, 0xA4, 0x00, 0x00, 0x00, 0x04, 0x03, 0x02, 0x01};
-  send_command_(cmd, sizeof(cmd));
+  enqueue_with_retries_(cmd, sizeof(cmd), true);
 }
 
 bool LD2450Handler::validate_backend_config_(LD2450BackendConfig &cfg) const {
@@ -271,7 +271,6 @@ bool LD2450Handler::set_backend_config(const LD2450BackendConfig &cfg) {
       turn_bluetooth_on();
     else
       turn_bluetooth_off();
-    schedule_post_bluetooth_sync_();
   }
   if (multi_target_changed) {
     if (config_.multi_target_enabled)
@@ -292,7 +291,6 @@ void LD2450Handler::set_bluetooth_enabled(bool enabled) {
     turn_bluetooth_on();
   else
     turn_bluetooth_off();
-  schedule_post_bluetooth_sync_();
 }
 
 void LD2450Handler::set_multi_target_enabled(bool enabled) {
@@ -458,6 +456,7 @@ void LD2450Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
 
   uint16_t cmd_word = to_uint16(buf[6], buf[7]);
   uint8_t status = buf[8];
+  mark_tx_ack_(cmd_word, status);
 
   if (status != 0) {
     ESP_LOGW(TAG_LD2450, "Command 0x%04X failed (status=%u)", cmd_word, status);
@@ -481,6 +480,10 @@ void LD2450Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
 
   if (cmd_word == 0x01A4 && status == 0) {
     ESP_LOGI(TAG_LD2450, "Bluetooth %s command acknowledged", config_.bluetooth_enabled ? "enable" : "disable");
+    if (bt_sync_requested_) {
+      bt_sync_requested_ = false;
+      schedule_post_bluetooth_sync_();
+    }
   }
 }
 
@@ -535,6 +538,87 @@ void LD2450Handler::schedule_post_bluetooth_sync_() {
   ESP_LOGI(TAG_LD2450, "Scheduled restart/readback for Bluetooth %s", config_.bluetooth_enabled ? "enable" : "disable");
 }
 
+void LD2450Handler::enqueue_with_retries_(const uint8_t *cmd, size_t len, bool schedule_bt_sync) {
+  if (schedule_bt_sync)
+    bt_sync_requested_ = true;
+  enqueue_command_(cmd, len);
+}
+
+void LD2450Handler::mark_tx_ack_(uint16_t cmd_word, uint8_t status) {
+  tx_ack_cmd_ = cmd_word;
+  tx_ack_status_ = status;
+  tx_ack_pending_ = true;
+}
+
+bool LD2450Handler::consume_tx_ack_(uint16_t expected_cmd, uint8_t &status_out) {
+  if (!tx_ack_pending_)
+    return false;
+
+  const uint16_t ack_cmd = tx_ack_cmd_;
+  const uint8_t ack_status = tx_ack_status_;
+  tx_ack_pending_ = false;
+
+  if (ack_cmd != expected_cmd) {
+    ESP_LOGD(TAG_LD2450, "Ignoring ACK for 0x%04X while waiting for 0x%04X", ack_cmd, expected_cmd);
+    return false;
+  }
+
+  status_out = ack_status;
+  return true;
+}
+
+void LD2450Handler::mark_command_failed_(uint16_t cmd_word, const char *reason) {
+  last_failed_cmd_ = cmd_word;
+  ack_failure_count_++;
+  ESP_LOGW(TAG_LD2450, "Command 0x%04X failed (%s)", cmd_word, reason);
+}
+
+uint16_t LD2450Handler::command_word_(const QueuedCommand &queued) const {
+  if (queued.len < 4)
+    return 0;
+  return to_uint16(queued.bytes[2], queued.bytes[3]);
+}
+
+void LD2450Handler::drop_active_command_(const char *reason) {
+  const uint16_t cmd_word = command_word_(active_command_);
+  if (cmd_word == 0x01A4 && bt_sync_requested_) {
+    bt_sync_requested_ = false;
+    ESP_LOGW(TAG_LD2450, "Bluetooth command dropped (%s), skipping restart/readback sync", reason);
+  }
+  if (cmd_word != 0)
+    mark_command_failed_(cmd_word, reason);
+  has_active_command_ = false;
+  drop_active_after_disable_ = false;
+  tx_retry_count_ = 0;
+  tx_expected_ack_cmd_ = 0;
+  tx_state_ = TxState::IDLE;
+}
+
+void LD2450Handler::send_enable_config_() {
+  uart_.write_array(LD2450_ENABLE_CONFIG, sizeof(LD2450_ENABLE_CONFIG));
+  uart_.flush();
+  tx_expected_ack_cmd_ = 0x00FF;
+  tx_deadline_ms_ = millis() + COMMAND_ACK_TIMEOUT_MS;
+  tx_state_ = TxState::WAIT_ENABLE_ACK;
+}
+
+void LD2450Handler::send_active_command_() {
+  uart_.write_array(LD2450_FRAME_HEADER, sizeof(LD2450_FRAME_HEADER));
+  uart_.write_array(active_command_.bytes, active_command_.len);
+  uart_.flush();
+  tx_expected_ack_cmd_ = command_word_(active_command_);
+  tx_deadline_ms_ = millis() + COMMAND_ACK_TIMEOUT_MS;
+  tx_state_ = TxState::WAIT_COMMAND_ACK;
+}
+
+void LD2450Handler::send_disable_config_() {
+  uart_.write_array(LD2450_DISABLE_CONFIG, sizeof(LD2450_DISABLE_CONFIG));
+  uart_.flush();
+  tx_expected_ack_cmd_ = 0x00FE;
+  tx_deadline_ms_ = millis() + COMMAND_ACK_TIMEOUT_MS;
+  tx_state_ = TxState::WAIT_DISABLE_ACK;
+}
+
 void LD2450Handler::enqueue_command_(const uint8_t *cmd, size_t len) {
   if (cmd == nullptr || len == 0)
     return;
@@ -570,46 +654,105 @@ bool LD2450Handler::dequeue_command_(QueuedCommand &queued) {
 }
 
 void LD2450Handler::step_command_tx_() {
-  uint32_t now = millis();
+  const uint32_t now = millis();
+  uint8_t ack_status = 0;
+
   switch (tx_state_) {
-    case TxState::IDLE:
+    case TxState::IDLE: {
       if (!has_active_command_ && !dequeue_command_(active_command_))
         return;
       has_active_command_ = true;
-      uart_.write_array(LD2450_ENABLE_CONFIG, sizeof(LD2450_ENABLE_CONFIG));
-      uart_.flush();
-      tx_state_ = TxState::WAIT_ENABLE;
-      tx_deadline_ms_ = now + 50;
+      tx_retry_count_ = 0;
+      drop_active_after_disable_ = false;
+      send_enable_config_();
+      return;
+    }
+
+    case TxState::WAIT_ENABLE_ACK:
+      if (consume_tx_ack_(tx_expected_ack_cmd_, ack_status)) {
+        if (ack_status == 0) {
+          send_active_command_();
+          return;
+        }
+        if (tx_retry_count_ < COMMAND_MAX_RETRIES) {
+          tx_retry_count_++;
+          ESP_LOGW(TAG_LD2450, "Enable config ACK failed (status=%u), retry %u/%u", ack_status, tx_retry_count_,
+                   COMMAND_MAX_RETRIES);
+          send_enable_config_();
+          return;
+        }
+        drop_active_command_("enable config ack failure");
+        return;
+      }
+      if (deadline_passed_(tx_deadline_ms_, now)) {
+        ack_timeout_count_++;
+        if (tx_retry_count_ < COMMAND_MAX_RETRIES) {
+          tx_retry_count_++;
+          ESP_LOGW(TAG_LD2450, "Enable config ACK timeout, retry %u/%u", tx_retry_count_, COMMAND_MAX_RETRIES);
+          send_enable_config_();
+          return;
+        }
+        drop_active_command_("enable config ack timeout");
+      }
       return;
 
-    case TxState::WAIT_ENABLE:
-      if (!deadline_passed_(tx_deadline_ms_, now))
+    case TxState::WAIT_COMMAND_ACK:
+      if (consume_tx_ack_(tx_expected_ack_cmd_, ack_status)) {
+        if (ack_status == 0) {
+          send_disable_config_();
+          return;
+        }
+        if (tx_retry_count_ < COMMAND_MAX_RETRIES) {
+          tx_retry_count_++;
+          ESP_LOGW(TAG_LD2450, "Command ACK failed (cmd=0x%04X status=%u), retry %u/%u", tx_expected_ack_cmd_,
+                   ack_status, tx_retry_count_, COMMAND_MAX_RETRIES);
+          send_enable_config_();
+          return;
+        }
+        drop_active_after_disable_ = true;
+        send_disable_config_();
         return;
-      if (!has_active_command_) {
+      }
+      if (deadline_passed_(tx_deadline_ms_, now)) {
+        ack_timeout_count_++;
+        if (tx_retry_count_ < COMMAND_MAX_RETRIES) {
+          tx_retry_count_++;
+          ESP_LOGW(TAG_LD2450, "Command ACK timeout (cmd=0x%04X), retry %u/%u", tx_expected_ack_cmd_, tx_retry_count_,
+                   COMMAND_MAX_RETRIES);
+          send_enable_config_();
+          return;
+        }
+        drop_active_after_disable_ = true;
+        send_disable_config_();
+      }
+      return;
+
+    case TxState::WAIT_DISABLE_ACK:
+      if (consume_tx_ack_(tx_expected_ack_cmd_, ack_status)) {
+        if (ack_status != 0)
+          ESP_LOGW(TAG_LD2450, "Disable config ACK failed (status=%u)", ack_status);
+        if (drop_active_after_disable_) {
+          drop_active_command_("command ack retries exhausted");
+          return;
+        }
+        has_active_command_ = false;
+        tx_retry_count_ = 0;
+        tx_expected_ack_cmd_ = 0;
         tx_state_ = TxState::IDLE;
         return;
       }
-      uart_.write_array(LD2450_FRAME_HEADER, sizeof(LD2450_FRAME_HEADER));
-      uart_.write_array(active_command_.bytes, active_command_.len);
-      uart_.flush();
-      tx_state_ = TxState::WAIT_AFTER_COMMAND;
-      tx_deadline_ms_ = now + 50;
-      return;
-
-    case TxState::WAIT_AFTER_COMMAND:
-      if (!deadline_passed_(tx_deadline_ms_, now))
-        return;
-      uart_.write_array(LD2450_DISABLE_CONFIG, sizeof(LD2450_DISABLE_CONFIG));
-      uart_.flush();
-      tx_state_ = TxState::WAIT_DISABLE;
-      tx_deadline_ms_ = now + 20;
-      return;
-
-    case TxState::WAIT_DISABLE:
-      if (!deadline_passed_(tx_deadline_ms_, now))
-        return;
-      has_active_command_ = false;
-      tx_state_ = TxState::IDLE;
+      if (deadline_passed_(tx_deadline_ms_, now)) {
+        ack_timeout_count_++;
+        ESP_LOGW(TAG_LD2450, "Disable config ACK timeout");
+        if (drop_active_after_disable_) {
+          drop_active_command_("disable config ack timeout after command failure");
+          return;
+        }
+        has_active_command_ = false;
+        tx_retry_count_ = 0;
+        tx_expected_ack_cmd_ = 0;
+        tx_state_ = TxState::IDLE;
+      }
       return;
   }
 }

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -581,7 +581,7 @@ uint16_t LD2450Handler::command_word_(const QueuedCommand &queued) const {
 
 void LD2450Handler::drop_active_command_(const char *reason) {
   const uint16_t cmd_word = command_word_(active_command_);
-  if (cmd_word == 0x01A4 && bt_sync_requested_) {
+  if (cmd_word == 0x00A4 && bt_sync_requested_) {
     bt_sync_requested_ = false;
     ESP_LOGW(TAG_LD2450, "Bluetooth command dropped (%s), skipping restart/readback sync", reason);
   }
@@ -597,7 +597,7 @@ void LD2450Handler::drop_active_command_(const char *reason) {
 void LD2450Handler::send_enable_config_() {
   uart_.write_array(LD2450_ENABLE_CONFIG, sizeof(LD2450_ENABLE_CONFIG));
   uart_.flush();
-  tx_expected_ack_cmd_ = 0x00FF;
+  tx_expected_ack_cmd_ = 0x01FF;
   tx_deadline_ms_ = millis() + COMMAND_ACK_TIMEOUT_MS;
   tx_state_ = TxState::WAIT_ENABLE_ACK;
 }
@@ -606,7 +606,7 @@ void LD2450Handler::send_active_command_() {
   uart_.write_array(LD2450_FRAME_HEADER, sizeof(LD2450_FRAME_HEADER));
   uart_.write_array(active_command_.bytes, active_command_.len);
   uart_.flush();
-  tx_expected_ack_cmd_ = command_word_(active_command_);
+  tx_expected_ack_cmd_ = command_word_(active_command_) | 0x0100;
   tx_deadline_ms_ = millis() + COMMAND_ACK_TIMEOUT_MS;
   tx_state_ = TxState::WAIT_COMMAND_ACK;
 }
@@ -614,7 +614,7 @@ void LD2450Handler::send_active_command_() {
 void LD2450Handler::send_disable_config_() {
   uart_.write_array(LD2450_DISABLE_CONFIG, sizeof(LD2450_DISABLE_CONFIG));
   uart_.flush();
-  tx_expected_ack_cmd_ = 0x00FE;
+  tx_expected_ack_cmd_ = 0x01FE;
   tx_deadline_ms_ = millis() + COMMAND_ACK_TIMEOUT_MS;
   tx_state_ = TxState::WAIT_DISABLE_ACK;
 }

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -48,28 +48,20 @@ void LD2450Handler::create_and_register_entities() {
     this->presence_sensor = this->runtime_presence_binary_sensor_.get();
   }
 
-  if (this->moving_target_sensor == nullptr) {
-    this->runtime_moving_target_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
-    this->runtime_moving_target_binary_sensor_->configure_dynamic("Radar Target Moving", ENTITY_CATEGORY_NONE, false,
-                                                                  this->device_class_meta_.motion);
-    App.register_binary_sensor(this->runtime_moving_target_binary_sensor_.get());
-    this->moving_target_sensor = this->runtime_moving_target_binary_sensor_.get();
-  }
-
-  if (this->still_target_sensor == nullptr) {
-    this->runtime_still_target_binary_sensor_.reset(new Satellite1RadarDynamicBinarySensor());
-    this->runtime_still_target_binary_sensor_->configure_dynamic("Radar Target Still", ENTITY_CATEGORY_NONE, false,
-                                                                 this->device_class_meta_.occupancy);
-    App.register_binary_sensor(this->runtime_still_target_binary_sensor_.get());
-    this->still_target_sensor = this->runtime_still_target_binary_sensor_.get();
-  }
-
   if (this->version_text_sensor == nullptr) {
     this->runtime_radar_firmware_text_sensor_.reset(new Satellite1RadarDynamicTextSensor());
     this->runtime_radar_firmware_text_sensor_->configure_dynamic("Radar Firmware", ENTITY_CATEGORY_DIAGNOSTIC, false,
                                                                  this->icon_meta_.chip);
     App.register_text_sensor(this->runtime_radar_firmware_text_sensor_.get());
     this->version_text_sensor = this->runtime_radar_firmware_text_sensor_.get();
+  }
+
+  if (this->target_state_text_sensor == nullptr) {
+    this->runtime_target_state_text_sensor_.reset(new Satellite1RadarDynamicTextSensor());
+    this->runtime_target_state_text_sensor_->configure_dynamic("Radar Target", ENTITY_CATEGORY_NONE, false,
+                                                               this->icon_meta_.motion_sensor);
+    App.register_text_sensor(this->runtime_target_state_text_sensor_.get());
+    this->target_state_text_sensor = this->runtime_target_state_text_sensor_.get();
   }
 
   if (config_.multi_target_enabled) {
@@ -341,8 +333,9 @@ void LD2450Handler::parse_data_frame_(const uint8_t *buf) {
   int still_count = 0;
   int moving_count = 0;
   bool any_target = false;
-  bool any_moving = false;
   bool any_still = false;
+  bool any_approaching = false;
+  bool any_moving_away = false;
 
   for (size_t t = 0; t < NUM_TARGETS; t++) {
     size_t base = 4 + t * 8;
@@ -369,7 +362,11 @@ void LD2450Handler::parse_data_frame_(const uint8_t *buf) {
 
       if (std::fabs(speed) > 0.0f) {
         moving_count++;
-        any_moving = true;
+        if (speed > 0.0f) {
+          any_approaching = true;
+        } else {
+          any_moving_away = true;
+        }
       } else {
         still_count++;
         any_still = true;
@@ -388,8 +385,12 @@ void LD2450Handler::parse_data_frame_(const uint8_t *buf) {
   debounce_sensor_(pub_moving_count_, cand_moving_count_, streak_moving_, moving_count, threshold, moving_target_count);
 
   debounce_binary_(pub_presence_, cand_presence_, streak_presence_, any_target, threshold, presence_sensor);
-  debounce_binary_(pub_has_moving_, cand_has_moving_, streak_has_moving_, any_moving, threshold, moving_target_sensor);
-  debounce_binary_(pub_has_still_, cand_has_still_, streak_has_still_, any_still, threshold, still_target_sensor);
+
+  const char *target_state = any_approaching ? "Approaching"
+                             : any_moving_away ? "Moving Away"
+                             : any_still ? "Still"
+                                         : "Clear";
+  debounce_target_state_(target_state, threshold);
 
   update_zone_states_(threshold);
 }
@@ -872,6 +873,31 @@ void LD2450Handler::debounce_zone_(int z, const std::string &raw, int threshold)
     pub_zone_state_[z] = raw;
     zone_state[z]->publish_state(raw);
     streak_zone_[z] = 0;
+  }
+}
+
+void LD2450Handler::debounce_target_state_(const std::string &raw, int threshold) {
+  if (target_state_text_sensor == nullptr)
+    return;
+  if (threshold <= 0 || pub_target_state_.empty()) {
+    pub_target_state_ = raw;
+    target_state_text_sensor->publish_state(raw);
+    return;
+  }
+  if (raw == pub_target_state_) {
+    streak_target_state_ = 0;
+    return;
+  }
+  if (raw == cand_target_state_) {
+    streak_target_state_++;
+  } else {
+    cand_target_state_ = raw;
+    streak_target_state_ = 1;
+  }
+  if (streak_target_state_ >= threshold) {
+    pub_target_state_ = raw;
+    target_state_text_sensor->publish_state(raw);
+    streak_target_state_ = 0;
   }
 }
 

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -155,6 +155,18 @@ void LD2450Handler::loop(uart::UARTDevice *uart) {
     ESP_LOGW(TAG_LD2450, "Firmware query timeout (attempt %d/%d)", fw_retry_count_, FW_MAX_RETRIES);
   }
 
+  if (bt_restart_pending_ && deadline_passed_(bt_restart_due_ms_, now)) {
+    bt_restart_pending_ = false;
+    restart_radar_();
+    bt_readback_pending_ = true;
+    bt_readback_due_ms_ = now + BT_READBACK_DELAY_MS;
+  }
+
+  if (bt_readback_pending_ && deadline_passed_(bt_readback_due_ms_, now)) {
+    bt_readback_pending_ = false;
+    request_full_status_();
+  }
+
   size_t bytes_processed = 0;
   while (uart_->available() && bytes_processed < MAX_UART_BYTES_PER_LOOP) {
     uint8_t byte;
@@ -264,6 +276,7 @@ bool LD2450Handler::set_backend_config(const LD2450BackendConfig &cfg) {
       turn_bluetooth_on();
     else
       turn_bluetooth_off();
+    schedule_post_bluetooth_sync_();
   }
   if (multi_target_changed) {
     if (config_.multi_target_enabled)
@@ -284,6 +297,7 @@ void LD2450Handler::set_bluetooth_enabled(bool enabled) {
     turn_bluetooth_on();
   else
     turn_bluetooth_off();
+  schedule_post_bluetooth_sync_();
 }
 
 void LD2450Handler::set_multi_target_enabled(bool enabled) {
@@ -448,8 +462,13 @@ void LD2450Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
     return;
 
   uint16_t cmd_word = to_uint16(buf[6], buf[7]);
+  uint8_t status = buf[8];
 
-  if (cmd_word == 0x01A0 && len >= 20) {
+  if (status != 0) {
+    ESP_LOGW(TAG_LD2450, "Command 0x%04X failed (status=%u)", cmd_word, status);
+  }
+
+  if (cmd_word == 0x01A0 && status == 0 && len >= 20) {
     char ver[32];
     snprintf(ver, sizeof(ver), "V%u.%02X.%02X%02X%02X%02X", buf[13], buf[12], buf[17], buf[16], buf[15], buf[14]);
     if (version_text_sensor != nullptr)
@@ -459,10 +478,14 @@ void LD2450Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
     ESP_LOGI(TAG_LD2450, "Firmware version: %s", ver);
   }
 
-  if (cmd_word == 0x01A5 && len >= 16) {
+  if (cmd_word == 0x01A5 && status == 0 && len >= 16) {
     char mac[20];
     snprintf(mac, sizeof(mac), "%02X:%02X:%02X:%02X:%02X:%02X", buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]);
     ESP_LOGI(TAG_LD2450, "BT MAC: %s", mac);
+  }
+
+  if (cmd_word == 0x01A4 && status == 0) {
+    ESP_LOGI(TAG_LD2450, "Bluetooth %s command acknowledged", config_.bluetooth_enabled ? "enable" : "disable");
   }
 }
 
@@ -478,6 +501,43 @@ void LD2450Handler::request_firmware_version_() {
   fw_next_retry_ms_ = now + 3000;
   ESP_LOGI(TAG_LD2450, "Requesting firmware version (attempt %d/%d)", fw_retry_count_, FW_MAX_RETRIES);
   enqueue_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::request_mac_address_() {
+  static const uint8_t cmd[] = {0x04, 0x00, 0xA5, 0x00, 0x01, 0x00, 0x04, 0x03, 0x02, 0x01};
+  enqueue_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::query_target_tracking_mode_() {
+  static const uint8_t cmd[] = {0x02, 0x00, 0x91, 0x00, 0x04, 0x03, 0x02, 0x01};
+  enqueue_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::query_zone_() {
+  static const uint8_t cmd[] = {0x02, 0x00, 0xC1, 0x00, 0x04, 0x03, 0x02, 0x01};
+  enqueue_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::restart_radar_() {
+  static const uint8_t cmd[] = {0x02, 0x00, 0xA3, 0x00, 0x04, 0x03, 0x02, 0x01};
+  ESP_LOGI(TAG_LD2450, "Restarting radar after Bluetooth change");
+  enqueue_command_(cmd, sizeof(cmd));
+}
+
+void LD2450Handler::request_full_status_() {
+  ESP_LOGI(TAG_LD2450, "Reading back status after Bluetooth change");
+  request_firmware_version_();
+  request_mac_address_();
+  query_target_tracking_mode_();
+  query_zone_();
+}
+
+void LD2450Handler::schedule_post_bluetooth_sync_() {
+  const uint32_t now = millis();
+  bt_restart_pending_ = true;
+  bt_restart_due_ms_ = now + BT_RESTART_DELAY_MS;
+  bt_readback_pending_ = false;
+  ESP_LOGI(TAG_LD2450, "Scheduled restart/readback for Bluetooth %s", config_.bluetooth_enabled ? "enable" : "disable");
 }
 
 void LD2450Handler::enqueue_command_(const uint8_t *cmd, size_t len) {

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -196,15 +196,13 @@ void LD2450Handler::loop(uart::UARTDevice *uart) {
   step_command_tx_();
 }
 
-void LD2450Handler::factory_reset(uart::UARTDevice *uart) {
-  uart_ = uart;
+void LD2450Handler::factory_reset() {
   static const uint8_t cmd[] = {0x02, 0x00, 0xA2, 0x00, 0x04, 0x03, 0x02, 0x01};
   send_command_(cmd, sizeof(cmd));
   ESP_LOGI(TAG_LD2450, "Factory reset command sent");
 }
 
-void LD2450Handler::restart(uart::UARTDevice *uart) {
-  uart_ = uart;
+void LD2450Handler::restart() {
   static const uint8_t cmd[] = {0x02, 0x00, 0xA3, 0x00, 0x04, 0x03, 0x02, 0x01};
   send_command_(cmd, sizeof(cmd));
   ESP_LOGI(TAG_LD2450, "Restart command sent");

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -90,8 +90,8 @@ void LD2450Handler::create_and_register_entities() {
 
   if (this->moving_target_count == nullptr) {
     this->runtime_moving_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
-    this->runtime_moving_target_count_sensor_->configure_dynamic("Radar Targets Moving", ENTITY_CATEGORY_NONE, false,
-                                                                 0, 0, this->icon_meta_.account_arrow_right, true,
+    this->runtime_moving_target_count_sensor_->configure_dynamic("Radar Targets Moving", ENTITY_CATEGORY_NONE, false, 0,
+                                                                 0, this->icon_meta_.account_arrow_right, true,
                                                                  sensor::STATE_CLASS_MEASUREMENT, 0);
     App.register_sensor(this->runtime_moving_target_count_sensor_.get());
     this->moving_target_count = this->runtime_moving_target_count_sensor_.get();
@@ -104,15 +104,15 @@ void LD2450Handler::create_and_register_entities() {
     switch (i) {
       case 0:
         this->runtime_zone_state_text_sensor_[i]->configure_dynamic("Radar Zone 1", ENTITY_CATEGORY_NONE, false,
-                                                                     this->icon_meta_.motion_sensor);
+                                                                    this->icon_meta_.motion_sensor);
         break;
       case 1:
         this->runtime_zone_state_text_sensor_[i]->configure_dynamic("Radar Zone 2", ENTITY_CATEGORY_NONE, false,
-                                                                     this->icon_meta_.motion_sensor);
+                                                                    this->icon_meta_.motion_sensor);
         break;
       default:
         this->runtime_zone_state_text_sensor_[i]->configure_dynamic("Radar Zone 3", ENTITY_CATEGORY_NONE, false,
-                                                                     this->icon_meta_.motion_sensor);
+                                                                    this->icon_meta_.motion_sensor);
         break;
     }
     App.register_text_sensor(this->runtime_zone_state_text_sensor_[i].get());
@@ -346,7 +346,6 @@ void LD2450Handler::parse_data_frame_(const uint8_t *buf) {
     if (on_target_update) {
       on_target_update(static_cast<int>(t), pub_x, pub_y);
     }
-
   }
 
   int threshold = get_stability_threshold_();

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -76,8 +76,8 @@ void LD2450Handler::create_and_register_entities() {
 
     if (this->still_target_count == nullptr) {
       this->runtime_still_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
-      this->runtime_still_target_count_sensor_->configure_dynamic("Radar Targets Still", ENTITY_CATEGORY_NONE, false,
-                                                                  0, 0, this->icon_meta_.account, true,
+      this->runtime_still_target_count_sensor_->configure_dynamic("Radar Targets Still", ENTITY_CATEGORY_NONE, false, 0,
+                                                                  0, this->icon_meta_.account, true,
                                                                   sensor::STATE_CLASS_MEASUREMENT, 0);
       App.register_sensor(this->runtime_still_target_count_sensor_.get());
       this->still_target_count = this->runtime_still_target_count_sensor_.get();
@@ -386,10 +386,10 @@ void LD2450Handler::parse_data_frame_(const uint8_t *buf) {
 
   debounce_binary_(pub_presence_, cand_presence_, streak_presence_, any_target, threshold, presence_sensor);
 
-  const char *target_state = any_approaching ? "Approaching"
+  const char *target_state = any_approaching   ? "Approaching"
                              : any_moving_away ? "Moving Away"
-                             : any_still ? "Still"
-                                         : "Clear";
+                             : any_still       ? "Still"
+                                               : "Clear";
   debounce_target_state_(target_state, threshold);
 
   update_zone_states_(threshold);

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -34,6 +34,9 @@ void LD2450Handler::setup() {
   if (config_pref_.load(&loaded)) {
     this->set_backend_config(loaded);
   }
+  boot_config_ = config_;
+  boot_config_initialized_ = true;
+  reboot_required_ = false;
 }
 
 void LD2450Handler::create_and_register_entities() {
@@ -69,31 +72,33 @@ void LD2450Handler::create_and_register_entities() {
     this->version_text_sensor = this->runtime_radar_firmware_text_sensor_.get();
   }
 
-  if (this->target_count == nullptr) {
-    this->runtime_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
-    this->runtime_target_count_sensor_->configure_dynamic("Radar Targets Total", ENTITY_CATEGORY_NONE, false, 0, 0,
-                                                          this->icon_meta_.account_multiple, true,
-                                                          sensor::STATE_CLASS_MEASUREMENT, 0);
-    App.register_sensor(this->runtime_target_count_sensor_.get());
-    this->target_count = this->runtime_target_count_sensor_.get();
-  }
+  if (config_.multi_target_enabled) {
+    if (this->target_count == nullptr) {
+      this->runtime_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
+      this->runtime_target_count_sensor_->configure_dynamic("Radar Targets Total", ENTITY_CATEGORY_NONE, false, 0, 0,
+                                                            this->icon_meta_.account_multiple, true,
+                                                            sensor::STATE_CLASS_MEASUREMENT, 0);
+      App.register_sensor(this->runtime_target_count_sensor_.get());
+      this->target_count = this->runtime_target_count_sensor_.get();
+    }
 
-  if (this->still_target_count == nullptr) {
-    this->runtime_still_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
-    this->runtime_still_target_count_sensor_->configure_dynamic("Radar Targets Still", ENTITY_CATEGORY_NONE, false, 0,
-                                                                0, this->icon_meta_.account, true,
-                                                                sensor::STATE_CLASS_MEASUREMENT, 0);
-    App.register_sensor(this->runtime_still_target_count_sensor_.get());
-    this->still_target_count = this->runtime_still_target_count_sensor_.get();
-  }
+    if (this->still_target_count == nullptr) {
+      this->runtime_still_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
+      this->runtime_still_target_count_sensor_->configure_dynamic("Radar Targets Still", ENTITY_CATEGORY_NONE, false,
+                                                                  0, 0, this->icon_meta_.account, true,
+                                                                  sensor::STATE_CLASS_MEASUREMENT, 0);
+      App.register_sensor(this->runtime_still_target_count_sensor_.get());
+      this->still_target_count = this->runtime_still_target_count_sensor_.get();
+    }
 
-  if (this->moving_target_count == nullptr) {
-    this->runtime_moving_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
-    this->runtime_moving_target_count_sensor_->configure_dynamic("Radar Targets Moving", ENTITY_CATEGORY_NONE, false, 0,
-                                                                 0, this->icon_meta_.account_arrow_right, true,
-                                                                 sensor::STATE_CLASS_MEASUREMENT, 0);
-    App.register_sensor(this->runtime_moving_target_count_sensor_.get());
-    this->moving_target_count = this->runtime_moving_target_count_sensor_.get();
+    if (this->moving_target_count == nullptr) {
+      this->runtime_moving_target_count_sensor_.reset(new Satellite1RadarDynamicSensor());
+      this->runtime_moving_target_count_sensor_->configure_dynamic("Radar Targets Moving", ENTITY_CATEGORY_NONE, false,
+                                                                   0, 0, this->icon_meta_.account_arrow_right, true,
+                                                                   sensor::STATE_CLASS_MEASUREMENT, 0);
+      App.register_sensor(this->runtime_moving_target_count_sensor_.get());
+      this->moving_target_count = this->runtime_moving_target_count_sensor_.get();
+    }
   }
 
   for (size_t i = 0; i < NUM_ZONES; i++) {
@@ -253,7 +258,10 @@ bool LD2450Handler::validate_backend_config_(LD2450BackendConfig &cfg) const {
   return true;
 }
 
-void LD2450Handler::save_backend_config_() { config_pref_.save(&config_); }
+void LD2450Handler::save_backend_config_() {
+  config_pref_.save(&config_);
+  global_preferences->sync();
+}
 
 bool LD2450Handler::set_backend_config(const LD2450BackendConfig &cfg) {
   LD2450BackendConfig candidate = cfg;
@@ -265,6 +273,8 @@ bool LD2450Handler::set_backend_config(const LD2450BackendConfig &cfg) {
 
   config_ = candidate;
   save_backend_config_();
+  if (boot_config_initialized_)
+    reboot_required_ = !entity_layout_matches_(config_, boot_config_);
 
   if (bluetooth_changed) {
     if (config_.bluetooth_enabled)
@@ -280,6 +290,10 @@ bool LD2450Handler::set_backend_config(const LD2450BackendConfig &cfg) {
   }
 
   return true;
+}
+
+bool LD2450Handler::entity_layout_matches_(const LD2450BackendConfig &lhs, const LD2450BackendConfig &rhs) const {
+  return lhs.multi_target_enabled == rhs.multi_target_enabled;
 }
 
 void LD2450Handler::set_bluetooth_enabled(bool enabled) {

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -671,6 +671,7 @@ void LD2450Handler::step_command_tx_() {
     case TxState::WAIT_ENABLE_ACK:
       if (consume_tx_ack_(tx_expected_ack_cmd_, ack_status)) {
         if (ack_status == 0) {
+          config_session_open_ = true;
           send_active_command_();
           return;
         }
@@ -679,6 +680,11 @@ void LD2450Handler::step_command_tx_() {
           ESP_LOGW(TAG_LD2450, "Enable config ACK failed (status=%u), retry %u/%u", ack_status, tx_retry_count_,
                    COMMAND_MAX_RETRIES);
           send_enable_config_();
+          return;
+        }
+        if (config_session_open_) {
+          drop_active_after_disable_ = true;
+          send_disable_config_();
           return;
         }
         drop_active_command_("enable config ack failure");
@@ -690,6 +696,11 @@ void LD2450Handler::step_command_tx_() {
           tx_retry_count_++;
           ESP_LOGW(TAG_LD2450, "Enable config ACK timeout, retry %u/%u", tx_retry_count_, COMMAND_MAX_RETRIES);
           send_enable_config_();
+          return;
+        }
+        if (config_session_open_) {
+          drop_active_after_disable_ = true;
+          send_disable_config_();
           return;
         }
         drop_active_command_("enable config ack timeout");
@@ -709,8 +720,12 @@ void LD2450Handler::step_command_tx_() {
           send_enable_config_();
           return;
         }
-        drop_active_after_disable_ = true;
-        send_disable_config_();
+        if (config_session_open_) {
+          drop_active_after_disable_ = true;
+          send_disable_config_();
+          return;
+        }
+        drop_active_command_("command ack retries exhausted");
         return;
       }
       if (deadline_passed_(tx_deadline_ms_, now)) {
@@ -722,8 +737,12 @@ void LD2450Handler::step_command_tx_() {
           send_enable_config_();
           return;
         }
-        drop_active_after_disable_ = true;
-        send_disable_config_();
+        if (config_session_open_) {
+          drop_active_after_disable_ = true;
+          send_disable_config_();
+          return;
+        }
+        drop_active_command_("command ack timeout");
       }
       return;
 
@@ -731,6 +750,7 @@ void LD2450Handler::step_command_tx_() {
       if (consume_tx_ack_(tx_expected_ack_cmd_, ack_status)) {
         if (ack_status != 0)
           ESP_LOGW(TAG_LD2450, "Disable config ACK failed (status=%u)", ack_status);
+        config_session_open_ = false;
         if (drop_active_after_disable_) {
           drop_active_command_("command ack retries exhausted");
           return;
@@ -744,6 +764,7 @@ void LD2450Handler::step_command_tx_() {
       if (deadline_passed_(tx_deadline_ms_, now)) {
         ack_timeout_count_++;
         ESP_LOGW(TAG_LD2450, "Disable config ACK timeout");
+        config_session_open_ = false;
         if (drop_active_after_disable_) {
           drop_active_command_("disable config ack timeout after command failure");
           return;

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -217,12 +217,12 @@ void LD2450Handler::set_multi_target() {
 
 void LD2450Handler::turn_bluetooth_on() {
   static const uint8_t cmd[] = {0x04, 0x00, 0xA4, 0x00, 0x01, 0x00, 0x04, 0x03, 0x02, 0x01};
-  enqueue_with_retries_(cmd, sizeof(cmd), true);
+  enqueue_command_(cmd, sizeof(cmd));
 }
 
 void LD2450Handler::turn_bluetooth_off() {
   static const uint8_t cmd[] = {0x04, 0x00, 0xA4, 0x00, 0x00, 0x00, 0x04, 0x03, 0x02, 0x01};
-  enqueue_with_retries_(cmd, sizeof(cmd), true);
+  enqueue_command_(cmd, sizeof(cmd));
 }
 
 bool LD2450Handler::validate_backend_config_(LD2450BackendConfig &cfg) const {
@@ -480,10 +480,7 @@ void LD2450Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
 
   if (cmd_word == 0x01A4 && status == 0) {
     ESP_LOGI(TAG_LD2450, "Bluetooth %s command acknowledged", config_.bluetooth_enabled ? "enable" : "disable");
-    if (bt_sync_requested_) {
-      bt_sync_requested_ = false;
-      schedule_post_bluetooth_sync_();
-    }
+    schedule_post_bluetooth_sync_();
   }
 }
 
@@ -538,12 +535,6 @@ void LD2450Handler::schedule_post_bluetooth_sync_() {
   ESP_LOGI(TAG_LD2450, "Scheduled restart/readback for Bluetooth %s", config_.bluetooth_enabled ? "enable" : "disable");
 }
 
-void LD2450Handler::enqueue_with_retries_(const uint8_t *cmd, size_t len, bool schedule_bt_sync) {
-  if (schedule_bt_sync)
-    bt_sync_requested_ = true;
-  enqueue_command_(cmd, len);
-}
-
 void LD2450Handler::mark_tx_ack_(uint16_t cmd_word, uint8_t status) {
   tx_ack_cmd_ = cmd_word;
   tx_ack_status_ = status;
@@ -581,10 +572,6 @@ uint16_t LD2450Handler::command_word_(const QueuedCommand &queued) const {
 
 void LD2450Handler::drop_active_command_(const char *reason) {
   const uint16_t cmd_word = command_word_(active_command_);
-  if (cmd_word == 0x00A4 && bt_sync_requested_) {
-    bt_sync_requested_ = false;
-    ESP_LOGW(TAG_LD2450, "Bluetooth command dropped (%s), skipping restart/readback sync", reason);
-  }
   if (cmd_word != 0)
     mark_command_failed_(cmd_word, reason);
   has_active_command_ = false;

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -21,9 +21,8 @@ static inline bool deadline_passed_(uint32_t deadline, uint32_t now) {
   return static_cast<int32_t>(now - deadline) >= 0;
 }
 
-void LD2450Handler::setup(uart::UARTDevice *uart) {
+void LD2450Handler::setup() {
   ESP_LOGI(TAG_LD2450, "Initializing LD2450 handler");
-  uart_ = uart;
   if (!buf_) {
     buf_ = std::unique_ptr<uint8_t[]>(new uint8_t[MAX_BUF]());
   }
@@ -136,9 +135,7 @@ void LD2450Handler::create_and_register_entities() {
   }
 }
 
-void LD2450Handler::loop(uart::UARTDevice *uart) {
-  uart_ = uart;
-
+void LD2450Handler::loop() {
   if (!buf_)
     return;
 
@@ -168,9 +165,9 @@ void LD2450Handler::loop(uart::UARTDevice *uart) {
   }
 
   size_t bytes_processed = 0;
-  while (uart_->available() && bytes_processed < MAX_UART_BYTES_PER_LOOP) {
+  while (uart_.available() && bytes_processed < MAX_UART_BYTES_PER_LOOP) {
     uint8_t byte;
-    if (!uart_->read_byte(&byte))
+    if (!uart_.read_byte(&byte))
       break;
     bytes_processed++;
 
@@ -573,17 +570,14 @@ bool LD2450Handler::dequeue_command_(QueuedCommand &queued) {
 }
 
 void LD2450Handler::step_command_tx_() {
-  if (uart_ == nullptr)
-    return;
-
   uint32_t now = millis();
   switch (tx_state_) {
     case TxState::IDLE:
       if (!has_active_command_ && !dequeue_command_(active_command_))
         return;
       has_active_command_ = true;
-      uart_->write_array(LD2450_ENABLE_CONFIG, sizeof(LD2450_ENABLE_CONFIG));
-      uart_->flush();
+      uart_.write_array(LD2450_ENABLE_CONFIG, sizeof(LD2450_ENABLE_CONFIG));
+      uart_.flush();
       tx_state_ = TxState::WAIT_ENABLE;
       tx_deadline_ms_ = now + 50;
       return;
@@ -595,9 +589,9 @@ void LD2450Handler::step_command_tx_() {
         tx_state_ = TxState::IDLE;
         return;
       }
-      uart_->write_array(LD2450_FRAME_HEADER, sizeof(LD2450_FRAME_HEADER));
-      uart_->write_array(active_command_.bytes, active_command_.len);
-      uart_->flush();
+      uart_.write_array(LD2450_FRAME_HEADER, sizeof(LD2450_FRAME_HEADER));
+      uart_.write_array(active_command_.bytes, active_command_.len);
+      uart_.flush();
       tx_state_ = TxState::WAIT_AFTER_COMMAND;
       tx_deadline_ms_ = now + 50;
       return;
@@ -605,8 +599,8 @@ void LD2450Handler::step_command_tx_() {
     case TxState::WAIT_AFTER_COMMAND:
       if (!deadline_passed_(tx_deadline_ms_, now))
         return;
-      uart_->write_array(LD2450_DISABLE_CONFIG, sizeof(LD2450_DISABLE_CONFIG));
-      uart_->flush();
+      uart_.write_array(LD2450_DISABLE_CONFIG, sizeof(LD2450_DISABLE_CONFIG));
+      uart_.flush();
       tx_state_ = TxState::WAIT_DISABLE;
       tx_deadline_ms_ = now + 20;
       return;

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -19,6 +19,7 @@ using TargetUpdateCallback = std::function<void(int target, float x, float y)>;
 
 class LD2450Handler {
  public:
+  explicit LD2450Handler(uart::UARTDevice &uart) : uart_(uart) {}
   static constexpr size_t NUM_TARGETS = 3;
   static constexpr size_t NUM_ZONES = 3;
   static constexpr size_t MAX_ZONE_POINTS = 8;
@@ -68,8 +69,8 @@ class LD2450Handler {
   void set_icon_indices(const IconMeta &meta) { this->icon_meta_ = meta; }
   void create_and_register_entities();
 
-  void setup(uart::UARTDevice *uart);
-  void loop(uart::UARTDevice *uart);
+  void setup();
+  void loop();
 
   void factory_reset();
   void restart();
@@ -91,7 +92,7 @@ class LD2450Handler {
   static const int DEFAULT_STABILITY = 5;
   std::unique_ptr<uint8_t[]> buf_{};
   size_t buf_pos_{0};
-  uart::UARTDevice *uart_{nullptr};
+  uart::UARTDevice &uart_;
   bool fw_version_received_{false};
   int fw_retry_count_{0};
   uint32_t fw_next_retry_ms_{0};

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -58,11 +58,10 @@ class LD2450Handler {
 
   // Text sensors
   text_sensor::TextSensor *version_text_sensor{nullptr};
+  text_sensor::TextSensor *target_state_text_sensor{nullptr};
 
   // Common entities (published by parent, stored as references)
   binary_sensor::BinarySensor *presence_sensor{nullptr};
-  binary_sensor::BinarySensor *moving_target_sensor{nullptr};
-  binary_sensor::BinarySensor *still_target_sensor{nullptr};
 
   void set_device_class_indices(const DeviceClassMeta &meta) { this->device_class_meta_ = meta; }
   void set_unit_indices(const UnitMeta &meta) { this->unit_meta_ = meta; }
@@ -146,13 +145,14 @@ class LD2450Handler {
 
   // Debounce state for binary sensors
   int pub_presence_{-1}, cand_presence_{-1}, streak_presence_{0};
-  int pub_has_moving_{-1}, cand_has_moving_{-1}, streak_has_moving_{0};
-  int pub_has_still_{-1}, cand_has_still_{-1}, streak_has_still_{0};
 
   // Debounce state for zone text sensors
   std::string pub_zone_state_[NUM_ZONES];
   std::string cand_zone_state_[NUM_ZONES];
   int streak_zone_[NUM_ZONES]{};
+  std::string pub_target_state_;
+  std::string cand_target_state_;
+  int streak_target_state_{0};
 
   static uint16_t to_uint16(uint8_t lo, uint8_t hi);
   static int16_t to_signed(uint16_t val);
@@ -187,6 +187,7 @@ class LD2450Handler {
   void debounce_sensor_(int &pub, int &cand, int &streak, int raw, int threshold, sensor::Sensor *s);
   void debounce_binary_(int &pub, int &cand, int &streak, bool raw, int threshold, binary_sensor::BinarySensor *s);
   void debounce_zone_(int z, const std::string &raw, int threshold);
+  void debounce_target_state_(const std::string &raw, int threshold);
 
   static void publish_sensor_(sensor::Sensor *s, float val);
 
@@ -209,9 +210,8 @@ class LD2450Handler {
   IconMeta icon_meta_{};
 
   std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_presence_binary_sensor_{};
-  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_moving_target_binary_sensor_{};
-  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_still_target_binary_sensor_{};
   std::unique_ptr<Satellite1RadarDynamicTextSensor> runtime_radar_firmware_text_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicTextSensor> runtime_target_state_text_sensor_{};
   std::unique_ptr<Satellite1RadarDynamicTextSensor> runtime_zone_state_text_sensor_[NUM_ZONES]{};
   std::unique_ptr<Satellite1RadarDynamicSensor> runtime_target_count_sensor_{};
   std::unique_ptr<Satellite1RadarDynamicSensor> runtime_still_target_count_sensor_{};

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -71,10 +71,8 @@ class LD2450Handler {
   void setup(uart::UARTDevice *uart);
   void loop(uart::UARTDevice *uart);
 
-  void factory_reset(uart::UARTDevice *uart);
-  void restart(uart::UARTDevice *uart);
-  void factory_reset() { this->factory_reset(this->uart_); }
-  void restart() { this->restart(this->uart_); }
+  void factory_reset();
+  void restart();
 
   void set_single_target();
   void set_multi_target();

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -81,6 +81,7 @@ class LD2450Handler {
   void turn_bluetooth_off();
 
   const LD2450BackendConfig &get_backend_config() const { return config_; }
+  bool is_reboot_required() const { return reboot_required_; }
   bool set_backend_config(const LD2450BackendConfig &cfg);
   void set_bluetooth_enabled(bool enabled);
   void set_multi_target_enabled(bool enabled);
@@ -190,9 +191,13 @@ class LD2450Handler {
   static void publish_sensor_(sensor::Sensor *s, float val);
 
   bool validate_backend_config_(LD2450BackendConfig &cfg) const;
+  bool entity_layout_matches_(const LD2450BackendConfig &lhs, const LD2450BackendConfig &rhs) const;
   void save_backend_config_();
 
   LD2450BackendConfig config_{};
+  LD2450BackendConfig boot_config_{};
+  bool boot_config_initialized_{false};
+  bool reboot_required_{false};
   ESPPreferenceObject config_pref_;
   float target_x_cm_[NUM_TARGETS]{};
   float target_y_cm_[NUM_TARGETS]{};

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -102,14 +102,17 @@ class LD2450Handler {
   uint32_t bt_restart_due_ms_{0};
   bool bt_readback_pending_{false};
   uint32_t bt_readback_due_ms_{0};
+  bool bt_sync_requested_{false};
   static const uint32_t BT_RESTART_DELAY_MS = 200;
   static const uint32_t BT_READBACK_DELAY_MS = 1500;
+  static const uint32_t COMMAND_ACK_TIMEOUT_MS = 250;
+  static const uint8_t COMMAND_MAX_RETRIES = 2;
 
   enum class TxState : uint8_t {
     IDLE,
-    WAIT_ENABLE,
-    WAIT_AFTER_COMMAND,
-    WAIT_DISABLE,
+    WAIT_ENABLE_ACK,
+    WAIT_COMMAND_ACK,
+    WAIT_DISABLE_ACK,
   };
 
   struct QueuedCommand {
@@ -123,8 +126,17 @@ class LD2450Handler {
   size_t command_queue_count_{0};
   QueuedCommand active_command_{};
   bool has_active_command_{false};
+  bool drop_active_after_disable_{false};
   TxState tx_state_{TxState::IDLE};
   uint32_t tx_deadline_ms_{0};
+  uint16_t tx_expected_ack_cmd_{0};
+  uint8_t tx_retry_count_{0};
+  bool tx_ack_pending_{false};
+  uint16_t tx_ack_cmd_{0};
+  uint8_t tx_ack_status_{0};
+  uint32_t ack_timeout_count_{0};
+  uint32_t ack_failure_count_{0};
+  uint16_t last_failed_cmd_{0};
 
   // Debounce state for aggregate count sensors
   int pub_total_count_{-1}, cand_total_count_{-1}, streak_total_{0};
@@ -157,6 +169,15 @@ class LD2450Handler {
   void restart_radar_();
   void request_full_status_();
   void schedule_post_bluetooth_sync_();
+  void enqueue_with_retries_(const uint8_t *cmd, size_t len, bool schedule_bt_sync);
+  void mark_tx_ack_(uint16_t cmd_word, uint8_t status);
+  bool consume_tx_ack_(uint16_t expected_cmd, uint8_t &status_out);
+  void mark_command_failed_(uint16_t cmd_word, const char *reason);
+  void drop_active_command_(const char *reason);
+  uint16_t command_word_(const QueuedCommand &queued) const;
+  void send_enable_config_();
+  void send_active_command_();
+  void send_disable_config_();
   void enqueue_command_(const uint8_t *cmd, size_t len);
   bool dequeue_command_(QueuedCommand &queued);
   void step_command_tx_();

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -102,7 +102,6 @@ class LD2450Handler {
   uint32_t bt_restart_due_ms_{0};
   bool bt_readback_pending_{false};
   uint32_t bt_readback_due_ms_{0};
-  bool bt_sync_requested_{false};
   static const uint32_t BT_RESTART_DELAY_MS = 200;
   static const uint32_t BT_READBACK_DELAY_MS = 1500;
   static const uint32_t COMMAND_ACK_TIMEOUT_MS = 250;
@@ -170,7 +169,6 @@ class LD2450Handler {
   void restart_radar_();
   void request_full_status_();
   void schedule_post_bluetooth_sync_();
-  void enqueue_with_retries_(const uint8_t *cmd, size_t len, bool schedule_bt_sync);
   void mark_tx_ack_(uint16_t cmd_word, uint8_t status);
   bool consume_tx_ack_(uint16_t expected_cmd, uint8_t &status_out);
   void mark_command_failed_(uint16_t cmd_word, const char *reason);

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -99,6 +99,12 @@ class LD2450Handler {
   uint32_t fw_next_retry_ms_{0};
   bool fw_query_in_flight_{false};
   uint32_t fw_query_timeout_ms_{0};
+  bool bt_restart_pending_{false};
+  uint32_t bt_restart_due_ms_{0};
+  bool bt_readback_pending_{false};
+  uint32_t bt_readback_due_ms_{0};
+  static const uint32_t BT_RESTART_DELAY_MS = 200;
+  static const uint32_t BT_READBACK_DELAY_MS = 1500;
 
   enum class TxState : uint8_t {
     IDLE,
@@ -146,6 +152,12 @@ class LD2450Handler {
   void update_zone_states_(int threshold);
   void handle_ack_frame_(const uint8_t *buf, size_t len);
   void request_firmware_version_();
+  void request_mac_address_();
+  void query_target_tracking_mode_();
+  void query_zone_();
+  void restart_radar_();
+  void request_full_status_();
+  void schedule_post_bluetooth_sync_();
   void enqueue_command_(const uint8_t *cmd, size_t len);
   bool dequeue_command_(QueuedCommand &queued);
   void step_command_tx_();

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -137,6 +137,7 @@ class LD2450Handler {
   uint32_t ack_timeout_count_{0};
   uint32_t ack_failure_count_{0};
   uint16_t last_failed_cmd_{0};
+  bool config_session_open_{false};
 
   // Debounce state for aggregate count sensors
   int pub_total_count_{-1}, cand_total_count_{-1}, streak_total_{0};

--- a/esphome/components/satellite1_radar/ld2450_handler.h
+++ b/esphome/components/satellite1_radar/ld2450_handler.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/preferences.h"
+#include "radar_entities.h"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace esphome {
+namespace satellite1_radar {
+
+using TargetUpdateCallback = std::function<void(int target, float x, float y)>;
+
+class LD2450Handler {
+ public:
+  static constexpr size_t NUM_TARGETS = 3;
+  static constexpr size_t NUM_ZONES = 3;
+  static constexpr size_t MAX_ZONE_POINTS = 8;
+  static constexpr size_t DATA_FRAME_SIZE = 30;
+
+  struct Point {
+    int16_t x{0};
+    int16_t y{0};
+  };
+
+  struct Polygon {
+    uint8_t points_count{0};
+    Point points[MAX_ZONE_POINTS]{};
+  };
+
+  struct LD2450BackendConfig {
+    Polygon zones[NUM_ZONES]{};
+    Polygon exclusion{};
+    uint16_t detection_range_cm{0};
+    uint8_t stability{5};
+    uint16_t timeout_seconds{0};
+    bool bluetooth_enabled{false};
+    bool multi_target_enabled{true};
+  };
+
+  // Aggregate counts
+  sensor::Sensor *target_count{nullptr};
+  sensor::Sensor *still_target_count{nullptr};
+  sensor::Sensor *moving_target_count{nullptr};
+
+  // Per-zone state text sensors
+  text_sensor::TextSensor *zone_state[NUM_ZONES]{};
+
+  // Target update callback (set by parent when zone editor is active)
+  TargetUpdateCallback on_target_update{nullptr};
+
+  // Text sensors
+  text_sensor::TextSensor *version_text_sensor{nullptr};
+
+  // Common entities (published by parent, stored as references)
+  binary_sensor::BinarySensor *presence_sensor{nullptr};
+  binary_sensor::BinarySensor *moving_target_sensor{nullptr};
+  binary_sensor::BinarySensor *still_target_sensor{nullptr};
+
+  void set_device_class_indices(const DeviceClassMeta &meta) { this->device_class_meta_ = meta; }
+  void set_unit_indices(const UnitMeta &meta) { this->unit_meta_ = meta; }
+  void set_icon_indices(const IconMeta &meta) { this->icon_meta_ = meta; }
+  void create_and_register_entities();
+
+  void setup(uart::UARTDevice *uart);
+  void loop(uart::UARTDevice *uart);
+
+  void factory_reset(uart::UARTDevice *uart);
+  void restart(uart::UARTDevice *uart);
+  void factory_reset() { this->factory_reset(this->uart_); }
+  void restart() { this->restart(this->uart_); }
+
+  void set_single_target();
+  void set_multi_target();
+  void turn_bluetooth_on();
+  void turn_bluetooth_off();
+
+  const LD2450BackendConfig &get_backend_config() const { return config_; }
+  bool set_backend_config(const LD2450BackendConfig &cfg);
+  void set_bluetooth_enabled(bool enabled);
+  void set_multi_target_enabled(bool enabled);
+
+ protected:
+  static constexpr size_t MAX_BUF = 160;
+  static constexpr size_t MAX_CMD_LEN = 16;
+  static const int FW_MAX_RETRIES = 5;
+  static const int DEFAULT_STABILITY = 5;
+  std::unique_ptr<uint8_t[]> buf_{};
+  size_t buf_pos_{0};
+  uart::UARTDevice *uart_{nullptr};
+  bool fw_version_received_{false};
+  int fw_retry_count_{0};
+  uint32_t fw_next_retry_ms_{0};
+  bool fw_query_in_flight_{false};
+  uint32_t fw_query_timeout_ms_{0};
+
+  enum class TxState : uint8_t {
+    IDLE,
+    WAIT_ENABLE,
+    WAIT_AFTER_COMMAND,
+    WAIT_DISABLE,
+  };
+
+  struct QueuedCommand {
+    uint8_t bytes[MAX_CMD_LEN]{};
+    size_t len{0};
+  };
+
+  static constexpr size_t MAX_COMMAND_QUEUE_DEPTH = 16;
+  QueuedCommand command_queue_[MAX_COMMAND_QUEUE_DEPTH]{};
+  size_t command_queue_head_{0};
+  size_t command_queue_count_{0};
+  QueuedCommand active_command_{};
+  bool has_active_command_{false};
+  TxState tx_state_{TxState::IDLE};
+  uint32_t tx_deadline_ms_{0};
+
+  // Debounce state for aggregate count sensors
+  int pub_total_count_{-1}, cand_total_count_{-1}, streak_total_{0};
+  int pub_moving_count_{-1}, cand_moving_count_{-1}, streak_moving_{0};
+  int pub_still_count_{-1}, cand_still_count_{-1}, streak_still_{0};
+
+  // Debounce state for binary sensors
+  int pub_presence_{-1}, cand_presence_{-1}, streak_presence_{0};
+  int pub_has_moving_{-1}, cand_has_moving_{-1}, streak_has_moving_{0};
+  int pub_has_still_{-1}, cand_has_still_{-1}, streak_has_still_{0};
+
+  // Debounce state for zone text sensors
+  std::string pub_zone_state_[NUM_ZONES];
+  std::string cand_zone_state_[NUM_ZONES];
+  int streak_zone_[NUM_ZONES]{};
+
+  static uint16_t to_uint16(uint8_t lo, uint8_t hi);
+  static int16_t to_signed(uint16_t val);
+
+  void parse_data_frame_(const uint8_t *buf);
+  bool point_in_polygon_(const Point *points, size_t count, float x, float y);
+  bool is_in_exclusion_zone_(float x, float y);
+  bool is_beyond_detection_range_(float dist);
+  void update_zone_states_(int threshold);
+  void handle_ack_frame_(const uint8_t *buf, size_t len);
+  void request_firmware_version_();
+  void enqueue_command_(const uint8_t *cmd, size_t len);
+  bool dequeue_command_(QueuedCommand &queued);
+  void step_command_tx_();
+  void send_command_(const uint8_t *cmd, size_t len);
+  int get_stability_threshold_();
+
+  void debounce_sensor_(int &pub, int &cand, int &streak, int raw, int threshold, sensor::Sensor *s);
+  void debounce_binary_(int &pub, int &cand, int &streak, bool raw, int threshold, binary_sensor::BinarySensor *s);
+  void debounce_zone_(int z, const std::string &raw, int threshold);
+
+  static void publish_sensor_(sensor::Sensor *s, float val);
+
+  bool validate_backend_config_(LD2450BackendConfig &cfg) const;
+  void save_backend_config_();
+
+  LD2450BackendConfig config_{};
+  ESPPreferenceObject config_pref_;
+  float target_x_cm_[NUM_TARGETS]{};
+  float target_y_cm_[NUM_TARGETS]{};
+  float target_speed_cm_s_[NUM_TARGETS]{};
+  float target_distance_cm_[NUM_TARGETS]{};
+  bool target_valid_[NUM_TARGETS]{};
+  DeviceClassMeta device_class_meta_{};
+  UnitMeta unit_meta_{};
+  IconMeta icon_meta_{};
+
+  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_presence_binary_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_moving_target_binary_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicBinarySensor> runtime_still_target_binary_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicTextSensor> runtime_radar_firmware_text_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicTextSensor> runtime_zone_state_text_sensor_[NUM_ZONES]{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_target_count_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_still_target_count_sensor_{};
+  std::unique_ptr<Satellite1RadarDynamicSensor> runtime_moving_target_count_sensor_{};
+  std::unique_ptr<Satellite1RadarButton> runtime_factory_reset_button_{};
+  std::unique_ptr<Satellite1RadarButton> runtime_restart_button_{};
+};
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/radar_entities.cpp
+++ b/esphome/components/satellite1_radar/radar_entities.cpp
@@ -1,0 +1,13 @@
+#include "radar_entities.h"
+
+namespace esphome {
+namespace satellite1_radar {
+
+void Satellite1RadarTunerSwitch::write_state(bool state) {
+  this->publish_state(state);
+  if (this->write_callback_)
+    this->write_callback_(state);
+}
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/radar_entities.h
+++ b/esphome/components/satellite1_radar/radar_entities.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/button/button.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include <functional>
+
+namespace esphome {
+namespace satellite1_radar {
+
+struct DeviceClassMeta {
+  uint8_t distance{0};
+  uint8_t illuminance{0};
+  uint8_t occupancy{0};
+  uint8_t motion{0};
+};
+
+struct UnitMeta {
+  uint8_t centimeter{0};
+  uint8_t percent{0};
+};
+
+struct IconMeta {
+  uint8_t radar{0};
+  uint8_t chip{0};
+  uint8_t signal{0};
+  uint8_t motion_sensor{0};
+  uint8_t account_multiple{0};
+  uint8_t account{0};
+  uint8_t account_arrow_right{0};
+  uint8_t tune_vertical{0};
+  uint8_t factory{0};
+  uint8_t restart{0};
+  uint8_t database_refresh{0};
+};
+
+inline uint32_t pack_entity_fields(uint8_t device_class_idx, uint8_t uom_idx, uint8_t icon_idx, bool internal,
+                                   bool disabled_by_default, EntityCategory entity_category) {
+  return (static_cast<uint32_t>(device_class_idx) << ENTITY_FIELD_DC_SHIFT) |
+         (static_cast<uint32_t>(uom_idx) << ENTITY_FIELD_UOM_SHIFT) |
+         (static_cast<uint32_t>(icon_idx) << ENTITY_FIELD_ICON_SHIFT) |
+         (static_cast<uint32_t>(internal) << ENTITY_FIELD_INTERNAL_SHIFT) |
+         (static_cast<uint32_t>(disabled_by_default) << ENTITY_FIELD_DISABLED_BY_DEFAULT_SHIFT) |
+         (static_cast<uint32_t>(entity_category) << ENTITY_FIELD_ENTITY_CATEGORY_SHIFT);
+}
+
+class Satellite1RadarDynamicSensor : public sensor::Sensor {
+ public:
+  void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
+                         bool disabled_by_default = false, uint8_t device_class_idx = 0, uint8_t uom_idx = 0,
+                         uint8_t icon_idx = 0, bool has_state_class = false,
+                         sensor::StateClass state_class = sensor::STATE_CLASS_NONE, int8_t accuracy_decimals = -1) {
+    this->configure_entity_(name, 0,
+                            pack_entity_fields(device_class_idx, uom_idx, icon_idx, false, disabled_by_default,
+                                               entity_category));
+    if (has_state_class)
+      this->set_state_class(state_class);
+    if (accuracy_decimals >= 0)
+      this->set_accuracy_decimals(accuracy_decimals);
+  }
+};
+
+class Satellite1RadarDynamicBinarySensor : public binary_sensor::BinarySensor {
+ public:
+  void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
+                         bool disabled_by_default = false, uint8_t device_class_idx = 0, uint8_t icon_idx = 0) {
+    this->configure_entity_(name, 0,
+                            pack_entity_fields(device_class_idx, 0, icon_idx, false, disabled_by_default,
+                                               entity_category));
+  }
+};
+
+class Satellite1RadarDynamicTextSensor : public text_sensor::TextSensor {
+ public:
+  void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
+                         bool disabled_by_default = false, uint8_t icon_idx = 0) {
+    this->configure_entity_(name, 0,
+                            pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
+  }
+};
+
+class Satellite1RadarSwitch : public switch_::Switch, public Component {
+ public:
+  void setup() override {}
+  void dump_config() override {}
+
+ protected:
+  void write_state(bool state) override { this->publish_state(state); }
+};
+
+class Satellite1RadarTunerSwitch : public switch_::Switch, public Component {
+ public:
+  void setup() override {}
+  void dump_config() override {}
+  void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
+                         bool disabled_by_default = false, uint8_t icon_idx = 0) {
+    this->configure_entity_(name, 0,
+                            pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
+  }
+  void set_write_callback(std::function<void(bool)> callback) { write_callback_ = std::move(callback); }
+
+ protected:
+  void write_state(bool state) override;
+  std::function<void(bool)> write_callback_{};
+};
+
+class Satellite1RadarButton : public button::Button, public Component {
+ public:
+  void setup() override {}
+  void dump_config() override {}
+  void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
+                         bool disabled_by_default = false, uint8_t icon_idx = 0) {
+    this->configure_entity_(name, 0,
+                            pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
+  }
+
+ protected:
+  void press_action() override {}
+};
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/radar_entities.h
+++ b/esphome/components/satellite1_radar/radar_entities.h
@@ -53,9 +53,8 @@ class Satellite1RadarDynamicSensor : public sensor::Sensor {
                          bool disabled_by_default = false, uint8_t device_class_idx = 0, uint8_t uom_idx = 0,
                          uint8_t icon_idx = 0, bool has_state_class = false,
                          sensor::StateClass state_class = sensor::STATE_CLASS_NONE, int8_t accuracy_decimals = -1) {
-    this->configure_entity_(name, 0,
-                            pack_entity_fields(device_class_idx, uom_idx, icon_idx, false, disabled_by_default,
-                                               entity_category));
+    this->configure_entity_(
+        name, 0, pack_entity_fields(device_class_idx, uom_idx, icon_idx, false, disabled_by_default, entity_category));
     if (has_state_class)
       this->set_state_class(state_class);
     if (accuracy_decimals >= 0)
@@ -67,9 +66,8 @@ class Satellite1RadarDynamicBinarySensor : public binary_sensor::BinarySensor {
  public:
   void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
                          bool disabled_by_default = false, uint8_t device_class_idx = 0, uint8_t icon_idx = 0) {
-    this->configure_entity_(name, 0,
-                            pack_entity_fields(device_class_idx, 0, icon_idx, false, disabled_by_default,
-                                               entity_category));
+    this->configure_entity_(
+        name, 0, pack_entity_fields(device_class_idx, 0, icon_idx, false, disabled_by_default, entity_category));
   }
 };
 
@@ -77,8 +75,7 @@ class Satellite1RadarDynamicTextSensor : public text_sensor::TextSensor {
  public:
   void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
                          bool disabled_by_default = false, uint8_t icon_idx = 0) {
-    this->configure_entity_(name, 0,
-                            pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
+    this->configure_entity_(name, 0, pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
   }
 };
 
@@ -97,8 +94,7 @@ class Satellite1RadarTunerSwitch : public switch_::Switch, public Component {
   void dump_config() override {}
   void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
                          bool disabled_by_default = false, uint8_t icon_idx = 0) {
-    this->configure_entity_(name, 0,
-                            pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
+    this->configure_entity_(name, 0, pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
   }
   void set_write_callback(std::function<void(bool)> callback) { write_callback_ = std::move(callback); }
 
@@ -113,8 +109,7 @@ class Satellite1RadarButton : public button::Button, public Component {
   void dump_config() override {}
   void configure_dynamic(const char *name, EntityCategory entity_category = ENTITY_CATEGORY_NONE,
                          bool disabled_by_default = false, uint8_t icon_idx = 0) {
-    this->configure_entity_(name, 0,
-                            pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
+    this->configure_entity_(name, 0, pack_entity_fields(0, 0, icon_idx, false, disabled_by_default, entity_category));
   }
 
  protected:

--- a/esphome/components/satellite1_radar/radar_tuner_server.cpp
+++ b/esphome/components/satellite1_radar/radar_tuner_server.cpp
@@ -1,4 +1,5 @@
 #include "radar_tuner_server.h"
+#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 #include "esphome/core/preferences.h"
 #include <cJSON.h>
@@ -282,10 +283,10 @@ esp_err_t RadarTunerServer::handle_ld2450_get_config_(httpd_req_t *req) {
   int pos = 0;
   pos += snprintf(
       buf + pos, sizeof(buf) - pos,
-      "{\"detection_range\":%u,\"stability\":%u,\"timeout\":%u,\"bluetooth\":%s,\"multi_target\":%s,\"zones\":[",
+      "{\"detection_range\":%u,\"stability\":%u,\"timeout\":%u,\"bluetooth\":%s,\"multi_target\":%s,\"reboot_required\":%s,\"zones\":[",
       static_cast<unsigned int>(cfg.detection_range_cm), static_cast<unsigned int>(cfg.stability),
       static_cast<unsigned int>(cfg.timeout_seconds), cfg.bluetooth_enabled ? "true" : "false",
-      cfg.multi_target_enabled ? "true" : "false");
+      cfg.multi_target_enabled ? "true" : "false", self->ld2450_->is_reboot_required() ? "true" : "false");
 
   for (size_t z = 0; z < LD2450Handler::NUM_ZONES; z++) {
     pos += snprintf(buf + pos, sizeof(buf) - pos, "%s[", z ? "," : "");
@@ -425,7 +426,8 @@ esp_err_t RadarTunerServer::handle_ld2450_patch_config_(httpd_req_t *req) {
     httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Config validation failed");
     return ESP_FAIL;
   }
-  return send_json_ok_(req, "{\"status\":\"ok\"}");
+  return send_json_ok_(req, self->ld2450_->is_reboot_required() ? "{\"status\":\"ok\",\"reboot_required\":true}"
+                                                                  : "{\"status\":\"ok\",\"reboot_required\":false}");
 }
 
 esp_err_t RadarTunerServer::handle_ld2450_live_(httpd_req_t *req) {
@@ -445,6 +447,14 @@ esp_err_t RadarTunerServer::handle_save_(httpd_req_t *req) {
   global_preferences->sync();
   ESP_LOGI(TAG_RT, "Preferences flushed to NVS");
   return send_json_ok_(req, "{\"status\":\"ok\"}");
+}
+
+esp_err_t RadarTunerServer::handle_reboot_(httpd_req_t *req) {
+  global_preferences->sync();
+  ESP_LOGI(TAG_RT, "Reboot requested by tuner UI");
+  send_json_ok_(req, "{\"status\":\"ok\"}");
+  App.safe_reboot();
+  return ESP_OK;
 }
 
 void RadarTunerServer::start() {
@@ -529,6 +539,13 @@ void RadarTunerServer::start() {
   save.handler = handle_save_;
   save.user_ctx = this;
   httpd_register_uri_handler(server_, &save);
+
+  httpd_uri_t reboot = {};
+  reboot.uri = "/api/v1/reboot";
+  reboot.method = HTTP_POST;
+  reboot.handler = handle_reboot_;
+  reboot.user_ctx = this;
+  httpd_register_uri_handler(server_, &reboot);
 
   ESP_LOGI(TAG_RT, "Radar tuner server started on port 80");
 }

--- a/esphome/components/satellite1_radar/radar_tuner_server.cpp
+++ b/esphome/components/satellite1_radar/radar_tuner_server.cpp
@@ -281,12 +281,12 @@ esp_err_t RadarTunerServer::handle_ld2450_get_config_(httpd_req_t *req) {
   const auto &cfg = self->ld2450_->get_backend_config();
   char buf[3072];
   int pos = 0;
-  pos += snprintf(
-      buf + pos, sizeof(buf) - pos,
-      "{\"detection_range\":%u,\"stability\":%u,\"timeout\":%u,\"bluetooth\":%s,\"multi_target\":%s,\"reboot_required\":%s,\"zones\":[",
-      static_cast<unsigned int>(cfg.detection_range_cm), static_cast<unsigned int>(cfg.stability),
-      static_cast<unsigned int>(cfg.timeout_seconds), cfg.bluetooth_enabled ? "true" : "false",
-      cfg.multi_target_enabled ? "true" : "false", self->ld2450_->is_reboot_required() ? "true" : "false");
+  pos += snprintf(buf + pos, sizeof(buf) - pos,
+                  "{\"detection_range\":%u,\"stability\":%u,\"timeout\":%u,\"bluetooth\":%s,\"multi_target\":%s,"
+                  "\"reboot_required\":%s,\"zones\":[",
+                  static_cast<unsigned int>(cfg.detection_range_cm), static_cast<unsigned int>(cfg.stability),
+                  static_cast<unsigned int>(cfg.timeout_seconds), cfg.bluetooth_enabled ? "true" : "false",
+                  cfg.multi_target_enabled ? "true" : "false", self->ld2450_->is_reboot_required() ? "true" : "false");
 
   for (size_t z = 0; z < LD2450Handler::NUM_ZONES; z++) {
     pos += snprintf(buf + pos, sizeof(buf) - pos, "%s[", z ? "," : "");
@@ -427,7 +427,7 @@ esp_err_t RadarTunerServer::handle_ld2450_patch_config_(httpd_req_t *req) {
     return ESP_FAIL;
   }
   return send_json_ok_(req, self->ld2450_->is_reboot_required() ? "{\"status\":\"ok\",\"reboot_required\":true}"
-                                                                  : "{\"status\":\"ok\",\"reboot_required\":false}");
+                                                                : "{\"status\":\"ok\",\"reboot_required\":false}");
 }
 
 esp_err_t RadarTunerServer::handle_ld2450_live_(httpd_req_t *req) {

--- a/esphome/components/satellite1_radar/radar_tuner_server.cpp
+++ b/esphome/components/satellite1_radar/radar_tuner_server.cpp
@@ -1,0 +1,542 @@
+#include "radar_tuner_server.h"
+#include "esphome/core/log.h"
+#include "esphome/core/preferences.h"
+#include <cJSON.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <esp_http_server.h>
+
+namespace esphome {
+namespace satellite1_radar {
+
+static const char *const TAG_RT = "radar_tuner_server";
+
+static void set_common_headers_(httpd_req_t *req) {
+  httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+  httpd_resp_set_hdr(req, "Connection", "close");
+}
+
+static esp_err_t send_json_ok_(httpd_req_t *req, const char *body) {
+  httpd_resp_set_type(req, "application/json");
+  set_common_headers_(req);
+  return httpd_resp_sendstr(req, body);
+}
+
+static bool read_json_body_(httpd_req_t *req, std::string &out) {
+  if (req->content_len <= 0 || req->content_len > 8192)
+    return false;
+  out.resize(static_cast<size_t>(req->content_len));
+  int total_read = 0;
+  while (total_read < req->content_len) {
+    int read_len = httpd_req_recv(req, &out[total_read], req->content_len - total_read);
+    if (read_len <= 0)
+      return false;
+    total_read += read_len;
+  }
+  return true;
+}
+
+static bool parse_bool_field_(cJSON *root, const char *name, bool &out, bool &present) {
+  present = false;
+  cJSON *item = cJSON_GetObjectItemCaseSensitive(root, name);
+  if (item == nullptr)
+    return true;
+  if (!cJSON_IsBool(item))
+    return false;
+  out = cJSON_IsTrue(item);
+  present = true;
+  return true;
+}
+
+static bool parse_uint_field_(cJSON *root, const char *name, uint32_t &out, bool &present) {
+  present = false;
+  cJSON *item = cJSON_GetObjectItemCaseSensitive(root, name);
+  if (item == nullptr)
+    return true;
+  if (!cJSON_IsNumber(item) || item->valuedouble < 0)
+    return false;
+  out = static_cast<uint32_t>(item->valuedouble);
+  present = true;
+  return true;
+}
+
+void RadarTunerServer::update_target(int index, float x, float y) {
+  if (index >= 0 && index < RT_NUM_TARGETS) {
+    targets_[index].x = x;
+    targets_[index].y = y;
+  }
+}
+
+void RadarTunerServer::clear_registrations() {
+  ld2410_ = nullptr;
+  ld2450_ = nullptr;
+  on_ld2410_apply_ = nullptr;
+}
+
+esp_err_t RadarTunerServer::handle_root_(httpd_req_t *req) {
+  auto *self = static_cast<RadarTunerServer *>(req->user_ctx);
+  if (self->html_gz_ == nullptr || self->html_gz_len_ == 0) {
+    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "No HTML content");
+    return ESP_FAIL;
+  }
+  httpd_resp_set_type(req, "text/html");
+  httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
+  httpd_resp_set_hdr(req, "Connection", "close");
+  return httpd_resp_send(req, reinterpret_cast<const char *>(self->html_gz_), self->html_gz_len_);
+}
+
+esp_err_t RadarTunerServer::handle_ld2410_get_config_(httpd_req_t *req) {
+  auto *self = static_cast<RadarTunerServer *>(req->user_ctx);
+  if (self->ld2410_ == nullptr) {
+    httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "LD2410 handler unavailable");
+    return ESP_FAIL;
+  }
+
+  const auto &cfg = self->ld2410_->get_backend_config();
+  char buf[1024];
+  int pos = 0;
+  pos += snprintf(buf + pos, sizeof(buf) - pos,
+                  "{\"timeout\":%u,\"max_move_gate\":%u,\"max_still_gate\":%u,\"distance_resolution\":\"%s\",\"bluetooth\":%s,\"gate_move_thresholds\":[",
+                  static_cast<unsigned int>(cfg.timeout_seconds), static_cast<unsigned int>(cfg.max_move_gate),
+                  static_cast<unsigned int>(cfg.max_still_gate), cfg.distance_resolution ? "0.2m" : "0.75m",
+                  cfg.bluetooth_enabled ? "true" : "false");
+  for (size_t g = 0; g < LD2410Handler::NUM_GATES; g++) {
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "%s%u", g ? "," : "",
+                    static_cast<unsigned int>(cfg.gate_move_threshold[g]));
+  }
+  pos += snprintf(buf + pos, sizeof(buf) - pos, "],\"gate_still_thresholds\":[");
+  for (size_t g = 0; g < LD2410Handler::NUM_GATES; g++) {
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "%s%u", g ? "," : "",
+                    static_cast<unsigned int>(cfg.gate_still_threshold[g]));
+  }
+  pos += snprintf(buf + pos, sizeof(buf) - pos, "]}");
+  return send_json_ok_(req, buf);
+}
+
+esp_err_t RadarTunerServer::handle_ld2410_patch_config_(httpd_req_t *req) {
+  auto *self = static_cast<RadarTunerServer *>(req->user_ctx);
+  if (self->ld2410_ == nullptr) {
+    httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "LD2410 handler unavailable");
+    return ESP_FAIL;
+  }
+
+  std::string body;
+  if (!read_json_body_(req, body)) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid body");
+    return ESP_FAIL;
+  }
+  cJSON *root = cJSON_ParseWithLength(body.c_str(), body.size());
+  if (root == nullptr || !cJSON_IsObject(root)) {
+    if (root != nullptr)
+      cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
+    return ESP_FAIL;
+  }
+
+  auto cfg = self->ld2410_->get_backend_config();
+  uint32_t uval = 0;
+  bool present = false;
+
+  if (!parse_uint_field_(root, "timeout", uval, present) || (present && uval > 65535)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid timeout");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.timeout_seconds = static_cast<uint16_t>(uval);
+
+  if (!parse_uint_field_(root, "max_move_gate", uval, present) || (present && uval > 8)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid max_move_gate");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.max_move_gate = static_cast<uint8_t>(uval);
+
+  if (!parse_uint_field_(root, "max_still_gate", uval, present) || (present && uval > 8)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid max_still_gate");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.max_still_gate = static_cast<uint8_t>(uval);
+
+  bool bool_val = false;
+  if (!parse_bool_field_(root, "bluetooth", bool_val, present)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid bluetooth");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.bluetooth_enabled = bool_val;
+
+  cJSON *distance_resolution = cJSON_GetObjectItemCaseSensitive(root, "distance_resolution");
+  if (distance_resolution != nullptr) {
+    if (!cJSON_IsString(distance_resolution) || distance_resolution->valuestring == nullptr) {
+      cJSON_Delete(root);
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid distance_resolution");
+      return ESP_FAIL;
+    }
+    if (strcmp(distance_resolution->valuestring, "0.2m") == 0) {
+      cfg.distance_resolution = 1;
+    } else if (strcmp(distance_resolution->valuestring, "0.75m") == 0) {
+      cfg.distance_resolution = 0;
+    } else {
+      cJSON_Delete(root);
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid distance_resolution value");
+      return ESP_FAIL;
+    }
+  }
+
+  cJSON *move_thresholds = cJSON_GetObjectItemCaseSensitive(root, "gate_move_thresholds");
+  if (move_thresholds != nullptr) {
+    if (!cJSON_IsArray(move_thresholds) || cJSON_GetArraySize(move_thresholds) != static_cast<int>(LD2410Handler::NUM_GATES)) {
+      cJSON_Delete(root);
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid gate_move_thresholds");
+      return ESP_FAIL;
+    }
+    for (size_t g = 0; g < LD2410Handler::NUM_GATES; g++) {
+      cJSON *item = cJSON_GetArrayItem(move_thresholds, static_cast<int>(g));
+      if (!cJSON_IsNumber(item) || item->valuedouble < 0 || item->valuedouble > 100) {
+        cJSON_Delete(root);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid move threshold value");
+        return ESP_FAIL;
+      }
+      cfg.gate_move_threshold[g] = static_cast<uint8_t>(item->valuedouble);
+    }
+  }
+
+  cJSON *still_thresholds = cJSON_GetObjectItemCaseSensitive(root, "gate_still_thresholds");
+  if (still_thresholds != nullptr) {
+    if (!cJSON_IsArray(still_thresholds) || cJSON_GetArraySize(still_thresholds) != static_cast<int>(LD2410Handler::NUM_GATES)) {
+      cJSON_Delete(root);
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid gate_still_thresholds");
+      return ESP_FAIL;
+    }
+    for (size_t g = 0; g < LD2410Handler::NUM_GATES; g++) {
+      cJSON *item = cJSON_GetArrayItem(still_thresholds, static_cast<int>(g));
+      if (!cJSON_IsNumber(item) || item->valuedouble < 0 || item->valuedouble > 100) {
+        cJSON_Delete(root);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid still threshold value");
+        return ESP_FAIL;
+      }
+      cfg.gate_still_threshold[g] = static_cast<uint8_t>(item->valuedouble);
+    }
+  }
+
+  cJSON_Delete(root);
+  if (!self->ld2410_->set_backend_config(cfg)) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Config validation failed");
+    return ESP_FAIL;
+  }
+  return send_json_ok_(req, "{\"status\":\"ok\"}");
+}
+
+esp_err_t RadarTunerServer::handle_ld2410_apply_(httpd_req_t *req) {
+  auto *self = static_cast<RadarTunerServer *>(req->user_ctx);
+  if (self->on_ld2410_apply_ != nullptr)
+    self->on_ld2410_apply_();
+  return send_json_ok_(req, "{\"status\":\"ok\"}");
+}
+
+esp_err_t RadarTunerServer::handle_ld2410_live_(httpd_req_t *req) {
+  auto *self = static_cast<RadarTunerServer *>(req->user_ctx);
+  if (self->ld2410_ == nullptr) {
+    httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "LD2410 handler unavailable");
+    return ESP_FAIL;
+  }
+  char buf[512];
+  int pos = 0;
+  pos += snprintf(buf + pos, sizeof(buf) - pos, "{\"gates\":{\"move\":[");
+  for (int g = 0; g < RT_NUM_GATES; g++) {
+    float val = self->ld2410_->get_gate_move_energy(static_cast<size_t>(g));
+    if (std::isnan(val))
+      val = 0;
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "%s%.0f", g ? "," : "", val);
+  }
+  pos += snprintf(buf + pos, sizeof(buf) - pos, "],\"still\":[");
+  for (int g = 0; g < RT_NUM_GATES; g++) {
+    float val = self->ld2410_->get_gate_still_energy(static_cast<size_t>(g));
+    if (std::isnan(val))
+      val = 0;
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "%s%.0f", g ? "," : "", val);
+  }
+  pos += snprintf(buf + pos, sizeof(buf) - pos, "]}}");
+  return send_json_ok_(req, buf);
+}
+
+esp_err_t RadarTunerServer::handle_ld2450_get_config_(httpd_req_t *req) {
+  auto *self = static_cast<RadarTunerServer *>(req->user_ctx);
+  if (self->ld2450_ == nullptr) {
+    httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "LD2450 handler unavailable");
+    return ESP_FAIL;
+  }
+
+  const auto &cfg = self->ld2450_->get_backend_config();
+  char buf[3072];
+  int pos = 0;
+  pos += snprintf(buf + pos, sizeof(buf) - pos,
+                  "{\"detection_range\":%u,\"stability\":%u,\"timeout\":%u,\"bluetooth\":%s,\"multi_target\":%s,\"zones\":[",
+                  static_cast<unsigned int>(cfg.detection_range_cm), static_cast<unsigned int>(cfg.stability),
+                  static_cast<unsigned int>(cfg.timeout_seconds), cfg.bluetooth_enabled ? "true" : "false",
+                  cfg.multi_target_enabled ? "true" : "false");
+
+  for (size_t z = 0; z < LD2450Handler::NUM_ZONES; z++) {
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "%s[", z ? "," : "");
+    for (size_t p = 0; p < cfg.zones[z].points_count; p++) {
+      pos += snprintf(buf + pos, sizeof(buf) - pos, "%s{\"x\":%d,\"y\":%d}", p ? "," : "",
+                      static_cast<int>(cfg.zones[z].points[p].x), static_cast<int>(cfg.zones[z].points[p].y));
+    }
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "]");
+  }
+  pos += snprintf(buf + pos, sizeof(buf) - pos, "],\"exclusion\":[");
+  for (size_t p = 0; p < cfg.exclusion.points_count; p++) {
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "%s{\"x\":%d,\"y\":%d}", p ? "," : "",
+                    static_cast<int>(cfg.exclusion.points[p].x), static_cast<int>(cfg.exclusion.points[p].y));
+  }
+  pos += snprintf(buf + pos, sizeof(buf) - pos, "]}");
+  return send_json_ok_(req, buf);
+}
+
+static bool parse_polygon_points_(cJSON *array, LD2450Handler::Polygon &polygon) {
+  if (!cJSON_IsArray(array))
+    return false;
+  int count = cJSON_GetArraySize(array);
+  if (count < 0 || count > static_cast<int>(LD2450Handler::MAX_ZONE_POINTS))
+    return false;
+  polygon.points_count = static_cast<uint8_t>(count);
+  for (int i = 0; i < count; i++) {
+    cJSON *point = cJSON_GetArrayItem(array, i);
+    if (!cJSON_IsObject(point))
+      return false;
+    cJSON *x = cJSON_GetObjectItemCaseSensitive(point, "x");
+    cJSON *y = cJSON_GetObjectItemCaseSensitive(point, "y");
+    if (!cJSON_IsNumber(x) || !cJSON_IsNumber(y))
+      return false;
+    polygon.points[i].x = static_cast<int16_t>(x->valueint);
+    polygon.points[i].y = static_cast<int16_t>(y->valueint);
+  }
+  for (size_t i = static_cast<size_t>(count); i < LD2450Handler::MAX_ZONE_POINTS; i++) {
+    polygon.points[i].x = 0;
+    polygon.points[i].y = 0;
+  }
+  return true;
+}
+
+esp_err_t RadarTunerServer::handle_ld2450_patch_config_(httpd_req_t *req) {
+  auto *self = static_cast<RadarTunerServer *>(req->user_ctx);
+  if (self->ld2450_ == nullptr) {
+    httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "LD2450 handler unavailable");
+    return ESP_FAIL;
+  }
+
+  std::string body;
+  if (!read_json_body_(req, body)) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid body");
+    return ESP_FAIL;
+  }
+  cJSON *root = cJSON_ParseWithLength(body.c_str(), body.size());
+  if (root == nullptr || !cJSON_IsObject(root)) {
+    if (root != nullptr)
+      cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
+    return ESP_FAIL;
+  }
+
+  auto cfg = self->ld2450_->get_backend_config();
+  uint32_t uval = 0;
+  bool present = false;
+
+  if (!parse_uint_field_(root, "detection_range", uval, present) || (present && uval > 600)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid detection_range");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.detection_range_cm = static_cast<uint16_t>(uval);
+
+  if (!parse_uint_field_(root, "stability", uval, present) || (present && uval > 10)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid stability");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.stability = static_cast<uint8_t>(uval);
+
+  if (!parse_uint_field_(root, "timeout", uval, present) || (present && uval > 65535)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid timeout");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.timeout_seconds = static_cast<uint16_t>(uval);
+
+  bool bool_val = false;
+  if (!parse_bool_field_(root, "bluetooth", bool_val, present)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid bluetooth");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.bluetooth_enabled = bool_val;
+
+  if (!parse_bool_field_(root, "multi_target", bool_val, present)) {
+    cJSON_Delete(root);
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid multi_target");
+    return ESP_FAIL;
+  }
+  if (present)
+    cfg.multi_target_enabled = bool_val;
+
+  cJSON *zones = cJSON_GetObjectItemCaseSensitive(root, "zones");
+  if (zones != nullptr) {
+    if (!cJSON_IsArray(zones) || cJSON_GetArraySize(zones) != static_cast<int>(LD2450Handler::NUM_ZONES)) {
+      cJSON_Delete(root);
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid zones");
+      return ESP_FAIL;
+    }
+    for (size_t z = 0; z < LD2450Handler::NUM_ZONES; z++) {
+      cJSON *zone_points = cJSON_GetArrayItem(zones, static_cast<int>(z));
+      if (!parse_polygon_points_(zone_points, cfg.zones[z])) {
+        cJSON_Delete(root);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid zone points");
+        return ESP_FAIL;
+      }
+    }
+  }
+
+  cJSON *exclusion = cJSON_GetObjectItemCaseSensitive(root, "exclusion");
+  if (exclusion != nullptr) {
+    if (!parse_polygon_points_(exclusion, cfg.exclusion)) {
+      cJSON_Delete(root);
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid exclusion points");
+      return ESP_FAIL;
+    }
+  }
+
+  cJSON_Delete(root);
+  if (!self->ld2450_->set_backend_config(cfg)) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Config validation failed");
+    return ESP_FAIL;
+  }
+  return send_json_ok_(req, "{\"status\":\"ok\"}");
+}
+
+esp_err_t RadarTunerServer::handle_ld2450_live_(httpd_req_t *req) {
+  auto *self = static_cast<RadarTunerServer *>(req->user_ctx);
+  char buf[256];
+  snprintf(buf, sizeof(buf),
+           "{\"targets\":["
+           "{\"x\":%.1f,\"y\":%.1f},"
+           "{\"x\":%.1f,\"y\":%.1f},"
+           "{\"x\":%.1f,\"y\":%.1f}]}",
+           self->targets_[0].x, self->targets_[0].y, self->targets_[1].x, self->targets_[1].y, self->targets_[2].x,
+           self->targets_[2].y);
+  return send_json_ok_(req, buf);
+}
+
+esp_err_t RadarTunerServer::handle_save_(httpd_req_t *req) {
+  global_preferences->sync();
+  ESP_LOGI(TAG_RT, "Preferences flushed to NVS");
+  return send_json_ok_(req, "{\"status\":\"ok\"}");
+}
+
+void RadarTunerServer::start() {
+  if (server_ != nullptr)
+    return;
+
+  httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+  config.server_port = 80;
+  config.max_uri_handlers = 12;
+  config.max_open_sockets = 2;
+  config.backlog_conn = 5;
+  config.stack_size = 8192;
+  config.lru_purge_enable = true;
+  config.uri_match_fn = httpd_uri_match_wildcard;
+
+  esp_err_t err = httpd_start(&server_, &config);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG_RT, "Failed to start httpd: %s", esp_err_to_name(err));
+    server_ = nullptr;
+    return;
+  }
+
+  httpd_uri_t root = {};
+  root.uri = "/";
+  root.method = HTTP_GET;
+  root.handler = handle_root_;
+  root.user_ctx = this;
+  httpd_register_uri_handler(server_, &root);
+
+  httpd_uri_t ld2410_cfg_get = {};
+  ld2410_cfg_get.uri = "/api/v1/ld2410/config";
+  ld2410_cfg_get.method = HTTP_GET;
+  ld2410_cfg_get.handler = handle_ld2410_get_config_;
+  ld2410_cfg_get.user_ctx = this;
+  httpd_register_uri_handler(server_, &ld2410_cfg_get);
+
+  httpd_uri_t ld2410_cfg_patch = {};
+  ld2410_cfg_patch.uri = "/api/v1/ld2410/config";
+  ld2410_cfg_patch.method = HTTP_PATCH;
+  ld2410_cfg_patch.handler = handle_ld2410_patch_config_;
+  ld2410_cfg_patch.user_ctx = this;
+  httpd_register_uri_handler(server_, &ld2410_cfg_patch);
+
+  httpd_uri_t ld2410_apply = {};
+  ld2410_apply.uri = "/api/v1/ld2410/apply";
+  ld2410_apply.method = HTTP_POST;
+  ld2410_apply.handler = handle_ld2410_apply_;
+  ld2410_apply.user_ctx = this;
+  httpd_register_uri_handler(server_, &ld2410_apply);
+
+  httpd_uri_t ld2410_live = {};
+  ld2410_live.uri = "/api/v1/ld2410/live";
+  ld2410_live.method = HTTP_GET;
+  ld2410_live.handler = handle_ld2410_live_;
+  ld2410_live.user_ctx = this;
+  httpd_register_uri_handler(server_, &ld2410_live);
+
+  httpd_uri_t ld2450_cfg_get = {};
+  ld2450_cfg_get.uri = "/api/v1/ld2450/config";
+  ld2450_cfg_get.method = HTTP_GET;
+  ld2450_cfg_get.handler = handle_ld2450_get_config_;
+  ld2450_cfg_get.user_ctx = this;
+  httpd_register_uri_handler(server_, &ld2450_cfg_get);
+
+  httpd_uri_t ld2450_cfg_patch = {};
+  ld2450_cfg_patch.uri = "/api/v1/ld2450/config";
+  ld2450_cfg_patch.method = HTTP_PATCH;
+  ld2450_cfg_patch.handler = handle_ld2450_patch_config_;
+  ld2450_cfg_patch.user_ctx = this;
+  httpd_register_uri_handler(server_, &ld2450_cfg_patch);
+
+  httpd_uri_t ld2450_live = {};
+  ld2450_live.uri = "/api/v1/ld2450/live";
+  ld2450_live.method = HTTP_GET;
+  ld2450_live.handler = handle_ld2450_live_;
+  ld2450_live.user_ctx = this;
+  httpd_register_uri_handler(server_, &ld2450_live);
+
+  httpd_uri_t save = {};
+  save.uri = "/api/v1/save";
+  save.method = HTTP_POST;
+  save.handler = handle_save_;
+  save.user_ctx = this;
+  httpd_register_uri_handler(server_, &save);
+
+  ESP_LOGI(TAG_RT, "Radar tuner server started on port 80");
+}
+
+void RadarTunerServer::stop() {
+  if (server_ == nullptr)
+    return;
+
+  httpd_stop(server_);
+  server_ = nullptr;
+  ESP_LOGI(TAG_RT, "Radar tuner server stopped");
+}
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/radar_tuner_server.cpp
+++ b/esphome/components/satellite1_radar/radar_tuner_server.cpp
@@ -98,7 +98,8 @@ esp_err_t RadarTunerServer::handle_ld2410_get_config_(httpd_req_t *req) {
   char buf[1024];
   int pos = 0;
   pos += snprintf(buf + pos, sizeof(buf) - pos,
-                  "{\"timeout\":%u,\"max_move_gate\":%u,\"max_still_gate\":%u,\"distance_resolution\":\"%s\",\"bluetooth\":%s,\"gate_move_thresholds\":[",
+                  "{\"timeout\":%u,\"max_move_gate\":%u,\"max_still_gate\":%u,\"distance_resolution\":\"%s\","
+                  "\"bluetooth\":%s,\"gate_move_thresholds\":[",
                   static_cast<unsigned int>(cfg.timeout_seconds), static_cast<unsigned int>(cfg.max_move_gate),
                   static_cast<unsigned int>(cfg.max_still_gate), cfg.distance_resolution ? "0.2m" : "0.75m",
                   cfg.bluetooth_enabled ? "true" : "false");
@@ -192,7 +193,8 @@ esp_err_t RadarTunerServer::handle_ld2410_patch_config_(httpd_req_t *req) {
 
   cJSON *move_thresholds = cJSON_GetObjectItemCaseSensitive(root, "gate_move_thresholds");
   if (move_thresholds != nullptr) {
-    if (!cJSON_IsArray(move_thresholds) || cJSON_GetArraySize(move_thresholds) != static_cast<int>(LD2410Handler::NUM_GATES)) {
+    if (!cJSON_IsArray(move_thresholds) ||
+        cJSON_GetArraySize(move_thresholds) != static_cast<int>(LD2410Handler::NUM_GATES)) {
       cJSON_Delete(root);
       httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid gate_move_thresholds");
       return ESP_FAIL;
@@ -210,7 +212,8 @@ esp_err_t RadarTunerServer::handle_ld2410_patch_config_(httpd_req_t *req) {
 
   cJSON *still_thresholds = cJSON_GetObjectItemCaseSensitive(root, "gate_still_thresholds");
   if (still_thresholds != nullptr) {
-    if (!cJSON_IsArray(still_thresholds) || cJSON_GetArraySize(still_thresholds) != static_cast<int>(LD2410Handler::NUM_GATES)) {
+    if (!cJSON_IsArray(still_thresholds) ||
+        cJSON_GetArraySize(still_thresholds) != static_cast<int>(LD2410Handler::NUM_GATES)) {
       cJSON_Delete(root);
       httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid gate_still_thresholds");
       return ESP_FAIL;
@@ -277,11 +280,12 @@ esp_err_t RadarTunerServer::handle_ld2450_get_config_(httpd_req_t *req) {
   const auto &cfg = self->ld2450_->get_backend_config();
   char buf[3072];
   int pos = 0;
-  pos += snprintf(buf + pos, sizeof(buf) - pos,
-                  "{\"detection_range\":%u,\"stability\":%u,\"timeout\":%u,\"bluetooth\":%s,\"multi_target\":%s,\"zones\":[",
-                  static_cast<unsigned int>(cfg.detection_range_cm), static_cast<unsigned int>(cfg.stability),
-                  static_cast<unsigned int>(cfg.timeout_seconds), cfg.bluetooth_enabled ? "true" : "false",
-                  cfg.multi_target_enabled ? "true" : "false");
+  pos += snprintf(
+      buf + pos, sizeof(buf) - pos,
+      "{\"detection_range\":%u,\"stability\":%u,\"timeout\":%u,\"bluetooth\":%s,\"multi_target\":%s,\"zones\":[",
+      static_cast<unsigned int>(cfg.detection_range_cm), static_cast<unsigned int>(cfg.stability),
+      static_cast<unsigned int>(cfg.timeout_seconds), cfg.bluetooth_enabled ? "true" : "false",
+      cfg.multi_target_enabled ? "true" : "false");
 
   for (size_t z = 0; z < LD2450Handler::NUM_ZONES; z++) {
     pos += snprintf(buf + pos, sizeof(buf) - pos, "%s[", z ? "," : "");

--- a/esphome/components/satellite1_radar/radar_tuner_server.h
+++ b/esphome/components/satellite1_radar/radar_tuner_server.h
@@ -55,6 +55,7 @@ class RadarTunerServer {
   static esp_err_t handle_ld2450_patch_config_(httpd_req_t *req);
   static esp_err_t handle_ld2450_live_(httpd_req_t *req);
   static esp_err_t handle_save_(httpd_req_t *req);
+  static esp_err_t handle_reboot_(httpd_req_t *req);
 };
 
 }  // namespace satellite1_radar

--- a/esphome/components/satellite1_radar/radar_tuner_server.h
+++ b/esphome/components/satellite1_radar/radar_tuner_server.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <esp_http_server.h>
+#include <string>
+#include <functional>
+#include "ld2410_handler.h"
+#include "ld2450_handler.h"
+
+namespace esphome {
+namespace satellite1_radar {
+
+static const int RT_NUM_TARGETS = 3;
+static const int RT_NUM_GATES = 9;
+
+class RadarTunerServer {
+ public:
+  void start();
+  void stop();
+  bool is_running() const { return server_ != nullptr; }
+
+  void set_html_content(const uint8_t *data, unsigned int len) {
+    html_gz_ = data;
+    html_gz_len_ = len;
+  }
+
+  void set_ld2410_handler(LD2410Handler *handler) { ld2410_ = handler; }
+  void set_ld2450_handler(LD2450Handler *handler) { ld2450_ = handler; }
+  void set_ld2410_apply_callback(std::function<void()> cb) { on_ld2410_apply_ = std::move(cb); }
+
+  void update_target(int index, float x, float y);
+
+  void clear_registrations();
+
+ private:
+  httpd_handle_t server_{nullptr};
+  LD2410Handler *ld2410_{nullptr};
+  LD2450Handler *ld2450_{nullptr};
+
+  const uint8_t *html_gz_{nullptr};
+  unsigned int html_gz_len_{0};
+  std::function<void()> on_ld2410_apply_;
+
+  struct TargetData {
+    float x{0};
+    float y{0};
+  };
+  TargetData targets_[RT_NUM_TARGETS]{};
+
+  static esp_err_t handle_root_(httpd_req_t *req);
+  static esp_err_t handle_ld2410_get_config_(httpd_req_t *req);
+  static esp_err_t handle_ld2410_patch_config_(httpd_req_t *req);
+  static esp_err_t handle_ld2410_apply_(httpd_req_t *req);
+  static esp_err_t handle_ld2410_live_(httpd_req_t *req);
+  static esp_err_t handle_ld2450_get_config_(httpd_req_t *req);
+  static esp_err_t handle_ld2450_patch_config_(httpd_req_t *req);
+  static esp_err_t handle_ld2450_live_(httpd_req_t *req);
+  static esp_err_t handle_save_(httpd_req_t *req);
+};
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/satellite1_radar.cpp
+++ b/esphome/components/satellite1_radar/satellite1_radar.cpp
@@ -13,6 +13,7 @@ static constexpr size_t MAX_DETECT_DRAIN_BYTES = 256;
 
 static const uint8_t LD2410_FRAME_HEADER[] = {0xF4, 0xF3, 0xF2, 0xF1};
 static const uint8_t LD2450_FRAME_HEADER[] = {0xAA, 0xFF, 0x03, 0x00};
+static const uint8_t LD24XX_DISABLE_CONFIG[] = {0xFD, 0xFC, 0xFB, 0xFA, 0x02, 0x00, 0xFE, 0x00, 0x04, 0x03, 0x02, 0x01};
 
 static void drain_uart_bytes_(uart::UARTDevice *uart, size_t max_bytes) {
   size_t drained = 0;
@@ -27,6 +28,8 @@ void Satellite1Radar::setup() {
   ESP_LOGI(TAG, "Starting mmWave radar auto-detection (%.1fs timeout)...", DETECT_TIMEOUT_MS / 1000.0f);
   if (this->radar_type_text_sensor_ != nullptr)
     this->radar_type_text_sensor_->publish_state("UNKNOWN");
+  this->pre_detect_recovery_pending_ = true;
+  this->pre_detect_recovery_sent_ms_ = 0;
   this->detection_started_ = true;
   this->detection_complete_ = false;
   this->detected_type_ = RadarType::UNKNOWN;
@@ -55,6 +58,24 @@ void Satellite1Radar::loop() {
 void Satellite1Radar::process_detection_() {
   if (!this->detection_started_ || this->detection_complete_) {
     return;
+  }
+
+  if (this->pre_detect_recovery_pending_) {
+    if (this->pre_detect_recovery_sent_ms_ == 0) {
+      drain_uart_bytes_(this, MAX_DETECT_DRAIN_BYTES);
+      this->write_array(LD24XX_DISABLE_CONFIG, sizeof(LD24XX_DISABLE_CONFIG));
+      this->flush();
+      this->pre_detect_recovery_sent_ms_ = millis();
+      ESP_LOGD(TAG, "Sent pre-detect disable-config recovery frame");
+      return;
+    }
+
+    if (millis() - this->pre_detect_recovery_sent_ms_ < PRE_DETECT_RECOVERY_SETTLE_MS) {
+      return;
+    }
+
+    drain_uart_bytes_(this, MAX_DETECT_DRAIN_BYTES);
+    this->pre_detect_recovery_pending_ = false;
   }
 
   size_t bytes_processed = 0;

--- a/esphome/components/satellite1_radar/satellite1_radar.cpp
+++ b/esphome/components/satellite1_radar/satellite1_radar.cpp
@@ -175,8 +175,8 @@ void Satellite1Radar::finalize_detection_(RadarType type) {
     ld2450_->set_device_class_indices(this->device_class_meta_);
     ld2450_->set_unit_indices(this->unit_meta_);
     ld2450_->set_icon_indices(this->icon_meta_);
-    ld2450_->create_and_register_entities();
     ld2450_->setup();
+    ld2450_->create_and_register_entities();
   }
 }
 

--- a/esphome/components/satellite1_radar/satellite1_radar.cpp
+++ b/esphome/components/satellite1_radar/satellite1_radar.cpp
@@ -43,12 +43,12 @@ void Satellite1Radar::loop() {
 
   // Normal operation after detection
   if (detected_type_ == RadarType::LD2410 && ld2410_ != nullptr) {
-    ld2410_->loop(this);
+    ld2410_->loop();
     if (this->write_config_pending_.exchange(false)) {
       ld2410_->apply_backend_config();
     }
   } else if (detected_type_ == RadarType::LD2450 && ld2450_ != nullptr) {
-    ld2450_->loop(this);
+    ld2450_->loop();
   }
 }
 
@@ -141,21 +141,21 @@ void Satellite1Radar::finalize_detection_(RadarType type) {
   }
 
   if (type == RadarType::LD2410) {
-    ld2410_ = std::unique_ptr<LD2410Handler>(new LD2410Handler());
+    ld2410_ = std::unique_ptr<LD2410Handler>(new LD2410Handler(*this));
     ld2450_.reset();
     ld2410_->set_device_class_indices(this->device_class_meta_);
     ld2410_->set_unit_indices(this->unit_meta_);
     ld2410_->set_icon_indices(this->icon_meta_);
     ld2410_->create_and_register_entities();
-    ld2410_->setup(this);
+    ld2410_->setup();
   } else if (type == RadarType::LD2450) {
-    ld2450_ = std::unique_ptr<LD2450Handler>(new LD2450Handler());
+    ld2450_ = std::unique_ptr<LD2450Handler>(new LD2450Handler(*this));
     ld2410_.reset();
     ld2450_->set_device_class_indices(this->device_class_meta_);
     ld2450_->set_unit_indices(this->unit_meta_);
     ld2450_->set_icon_indices(this->icon_meta_);
     ld2450_->create_and_register_entities();
-    ld2450_->setup(this);
+    ld2450_->setup();
   }
 }
 

--- a/esphome/components/satellite1_radar/satellite1_radar.cpp
+++ b/esphome/components/satellite1_radar/satellite1_radar.cpp
@@ -1,0 +1,219 @@
+#include "satellite1_radar.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include <cstring>
+
+namespace esphome {
+namespace satellite1_radar {
+
+static const char *const TAG = "satellite1_radar";
+static constexpr size_t MAX_DETECT_BYTES_PER_LOOP = 128;
+static constexpr size_t MAX_DETECT_DRAIN_BYTES = 256;
+
+static const uint8_t LD2410_FRAME_HEADER[] = {0xF4, 0xF3, 0xF2, 0xF1};
+static const uint8_t LD2450_FRAME_HEADER[] = {0xAA, 0xFF, 0x03, 0x00};
+
+static void drain_uart_bytes_(uart::UARTDevice *uart, size_t max_bytes) {
+  size_t drained = 0;
+  while (uart->available() && drained < max_bytes) {
+    uint8_t discard;
+    uart->read_byte(&discard);
+    drained++;
+  }
+}
+
+void Satellite1Radar::setup() {
+  ESP_LOGI(TAG, "Starting mmWave radar auto-detection (%.1fs timeout)...", DETECT_TIMEOUT_MS / 1000.0f);
+  if (this->radar_type_text_sensor_ != nullptr)
+    this->radar_type_text_sensor_->publish_state("UNKNOWN");
+  this->detection_started_ = true;
+  this->detection_complete_ = false;
+  this->detected_type_ = RadarType::UNKNOWN;
+  this->detect_start_ms_ = millis();
+  this->detect_ring_pos_ = 0;
+  memset(this->detect_ring_buf_, 0, sizeof(this->detect_ring_buf_));
+}
+
+void Satellite1Radar::loop() {
+  if (!this->detection_complete_) {
+    this->process_detection_();
+    return;
+  }
+
+  // Normal operation after detection
+  if (detected_type_ == RadarType::LD2410 && ld2410_ != nullptr) {
+    ld2410_->loop(this);
+    if (this->write_config_pending_.exchange(false)) {
+      ld2410_->apply_backend_config(this);
+    }
+  } else if (detected_type_ == RadarType::LD2450 && ld2450_ != nullptr) {
+    ld2450_->loop(this);
+  }
+}
+
+void Satellite1Radar::process_detection_() {
+  if (!this->detection_started_ || this->detection_complete_) {
+    return;
+  }
+
+  size_t bytes_processed = 0;
+  while (this->available() && bytes_processed < MAX_DETECT_BYTES_PER_LOOP) {
+    uint8_t byte;
+    if (!this->read_byte(&byte))
+      break;
+    bytes_processed++;
+
+    this->detect_ring_buf_[this->detect_ring_pos_ % 4] = byte;
+    this->detect_ring_pos_++;
+
+    if (this->detect_ring_pos_ < 4)
+      continue;
+
+    uint8_t seq[4];
+    for (int i = 0; i < 4; i++) {
+      seq[i] = this->detect_ring_buf_[(this->detect_ring_pos_ - 4 + static_cast<size_t>(i)) % 4];
+    }
+
+    if (memcmp(seq, LD2410_FRAME_HEADER, 4) == 0) {
+      ESP_LOGI(TAG, "Detected LD2410 radar (frame header 0xF4F3F2F1)");
+      drain_uart_bytes_(this, MAX_DETECT_DRAIN_BYTES);
+      this->finalize_detection_(RadarType::LD2410);
+      return;
+    }
+
+    if (memcmp(seq, LD2450_FRAME_HEADER, 4) == 0) {
+      ESP_LOGI(TAG, "Detected LD2450 radar (frame header 0xAAFF0300)");
+      drain_uart_bytes_(this, MAX_DETECT_DRAIN_BYTES);
+      this->finalize_detection_(RadarType::LD2450);
+      return;
+    }
+  }
+
+  if (millis() - this->detect_start_ms_ >= DETECT_TIMEOUT_MS) {
+    ESP_LOGI(TAG, "No mmWave radar detected within timeout");
+    this->finalize_detection_(RadarType::NONE);
+  }
+}
+
+void Satellite1Radar::create_common_entities_() {
+  const bool radar_present = (this->detected_type_ == RadarType::LD2410 || this->detected_type_ == RadarType::LD2450);
+
+  if (radar_present && this->runtime_tuner_switch_ == nullptr) {
+    this->runtime_tuner_switch_.reset(new Satellite1RadarTunerSwitch());
+    this->runtime_tuner_switch_->set_write_callback([this](bool state) {
+      if (state)
+        this->start_tuner();
+      else
+        this->stop_tuner();
+    });
+    this->runtime_tuner_switch_->configure_dynamic("Radar Tuner WebUI", ENTITY_CATEGORY_DIAGNOSTIC, false,
+                                                   this->icon_meta_.tune_vertical);
+    App.register_switch(this->runtime_tuner_switch_.get());
+    this->runtime_tuner_switch_->publish_state(false);
+  }
+}
+
+void Satellite1Radar::finalize_detection_(RadarType type) {
+  this->detected_type_ = type;
+  this->detection_complete_ = true;
+
+  this->create_common_entities_();
+
+  if (radar_type_text_sensor_ != nullptr) {
+    switch (type) {
+      case RadarType::LD2410:
+        radar_type_text_sensor_->publish_state("LD2410");
+        break;
+      case RadarType::LD2450:
+        radar_type_text_sensor_->publish_state("LD2450");
+        break;
+      default:
+        radar_type_text_sensor_->publish_state("None");
+        break;
+    }
+  }
+
+  if (type == RadarType::NONE) {
+    ESP_LOGI(TAG, "No radar detected, disabling loop");
+    this->disable_loop();
+    return;
+  }
+
+  if (type == RadarType::LD2410) {
+    ld2410_ = std::unique_ptr<LD2410Handler>(new LD2410Handler());
+    ld2450_.reset();
+    ld2410_->set_device_class_indices(this->device_class_meta_);
+    ld2410_->set_unit_indices(this->unit_meta_);
+    ld2410_->set_icon_indices(this->icon_meta_);
+    ld2410_->create_and_register_entities();
+    ld2410_->setup(this);
+  } else if (type == RadarType::LD2450) {
+    ld2450_ = std::unique_ptr<LD2450Handler>(new LD2450Handler());
+    ld2410_.reset();
+    ld2450_->set_device_class_indices(this->device_class_meta_);
+    ld2450_->set_unit_indices(this->unit_meta_);
+    ld2450_->set_icon_indices(this->icon_meta_);
+    ld2450_->create_and_register_entities();
+    ld2450_->setup(this);
+  }
+}
+
+void Satellite1Radar::dump_config() {
+  ESP_LOGCONFIG(TAG, "Satellite1 Radar:");
+  if (!detection_complete_) {
+    ESP_LOGCONFIG(TAG, "  Detection: in progress...");
+    return;
+  }
+  switch (detected_type_) {
+    case RadarType::LD2410:
+      ESP_LOGCONFIG(TAG, "  Detected sensor: LD2410");
+      break;
+    case RadarType::LD2450:
+      ESP_LOGCONFIG(TAG, "  Detected sensor: LD2450");
+      break;
+    case RadarType::NONE:
+      ESP_LOGCONFIG(TAG, "  Detected sensor: None");
+      break;
+    default:
+      ESP_LOGCONFIG(TAG, "  Detected sensor: Unknown");
+      break;
+  }
+}
+
+void Satellite1Radar::start_tuner() {
+  tuner_server_.clear_registrations();
+
+  if (detected_type_ == RadarType::LD2450) {
+    tuner_server_.set_html_content(ld2450_html_gz_, ld2450_html_gz_len_);
+    tuner_server_.set_ld2450_handler(ld2450_.get());
+
+    if (ld2450_ != nullptr) {
+      ld2450_->on_target_update = [this](int target, float x, float y) { tuner_server_.update_target(target, x, y); };
+    }
+
+  } else if (detected_type_ == RadarType::LD2410) {
+    tuner_server_.set_html_content(ld2410_html_gz_, ld2410_html_gz_len_);
+    tuner_server_.set_ld2410_handler(ld2410_.get());
+    tuner_server_.set_ld2410_apply_callback([this]() { this->write_config_pending_.store(true); });
+
+    if (ld2410_ != nullptr)
+      ld2410_->enable_engineering_mode(this);
+  }
+
+  tuner_server_.start();
+}
+
+void Satellite1Radar::stop_tuner() {
+  if (detected_type_ == RadarType::LD2450) {
+    if (ld2450_ != nullptr)
+      ld2450_->on_target_update = nullptr;
+  } else if (detected_type_ == RadarType::LD2410) {
+    if (ld2410_ != nullptr)
+      ld2410_->disable_engineering_mode(this);
+  }
+  tuner_server_.stop();
+}
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/satellite1_radar.cpp
+++ b/esphome/components/satellite1_radar/satellite1_radar.cpp
@@ -45,7 +45,7 @@ void Satellite1Radar::loop() {
   if (detected_type_ == RadarType::LD2410 && ld2410_ != nullptr) {
     ld2410_->loop(this);
     if (this->write_config_pending_.exchange(false)) {
-      ld2410_->apply_backend_config(this);
+      ld2410_->apply_backend_config();
     }
   } else if (detected_type_ == RadarType::LD2450 && ld2450_ != nullptr) {
     ld2450_->loop(this);
@@ -198,7 +198,7 @@ void Satellite1Radar::start_tuner() {
     tuner_server_.set_ld2410_apply_callback([this]() { this->write_config_pending_.store(true); });
 
     if (ld2410_ != nullptr)
-      ld2410_->enable_engineering_mode(this);
+      ld2410_->enable_engineering_mode();
   }
 
   tuner_server_.start();
@@ -210,7 +210,7 @@ void Satellite1Radar::stop_tuner() {
       ld2450_->on_target_update = nullptr;
   } else if (detected_type_ == RadarType::LD2410) {
     if (ld2410_ != nullptr)
-      ld2410_->disable_engineering_mode(this);
+      ld2410_->disable_engineering_mode();
   }
   tuner_server_.stop();
 }

--- a/esphome/components/satellite1_radar/satellite1_radar.h
+++ b/esphome/components/satellite1_radar/satellite1_radar.h
@@ -75,7 +75,10 @@ class Satellite1Radar : public Component, public uart::UARTDevice {
   RadarType detected_type_{RadarType::UNKNOWN};
   bool detection_started_{false};
   bool detection_complete_{false};
+  bool pre_detect_recovery_pending_{false};
+  uint32_t pre_detect_recovery_sent_ms_{0};
   uint32_t detect_start_ms_{0};
+  static const uint32_t PRE_DETECT_RECOVERY_SETTLE_MS = 20;
   uint8_t detect_ring_buf_[4]{};
   size_t detect_ring_pos_{0};
   DeviceClassMeta device_class_meta_{};

--- a/esphome/components/satellite1_radar/satellite1_radar.h
+++ b/esphome/components/satellite1_radar/satellite1_radar.h
@@ -62,12 +62,12 @@ class Satellite1Radar : public Component, public uart::UARTDevice {
   void set_icon_indices(uint8_t radar, uint8_t chip, uint8_t signal, uint8_t motion_sensor, uint8_t account_multiple,
                         uint8_t account, uint8_t account_arrow_right, uint8_t tune_vertical, uint8_t factory,
                         uint8_t restart, uint8_t database_refresh) {
-    this->icon_meta_ = {radar,          chip,           signal,         motion_sensor, account_multiple,
-                        account,        account_arrow_right, tune_vertical,  factory,       restart,
-                        database_refresh};
+    this->icon_meta_ = {
+        radar,         chip,    signal,  motion_sensor,   account_multiple, account, account_arrow_right,
+        tune_vertical, factory, restart, database_refresh};
   }
 
-  protected:
+ protected:
   void process_detection_();
   void finalize_detection_(RadarType type);
   void create_common_entities_();

--- a/esphome/components/satellite1_radar/satellite1_radar.h
+++ b/esphome/components/satellite1_radar/satellite1_radar.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/button/button.h"
+#include <cstddef>
+#include <atomic>
+#include <memory>
+
+#include "radar_entities.h"
+#include "ld2410_handler.h"
+#include "ld2450_handler.h"
+#include "radar_tuner_server.h"
+
+namespace esphome {
+namespace satellite1_radar {
+
+enum class RadarType : uint8_t {
+  UNKNOWN = 0,
+  NONE,
+  LD2410,
+  LD2450,
+};
+
+static const uint32_t DETECT_TIMEOUT_MS = 3000;
+
+class Satellite1Radar : public Component, public uart::UARTDevice {
+ public:
+  float get_setup_priority() const override { return setup_priority::DATA; }
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  bool can_proceed() override { return this->detection_complete_ || this->is_failed(); }
+
+  RadarType get_detected_type() const { return detected_type_; }
+  bool is_detection_complete() const { return detection_complete_; }
+  void set_radar_type_text_sensor(text_sensor::TextSensor *sensor) { this->radar_type_text_sensor_ = sensor; }
+
+  // --- Radar tuner server ---
+  RadarTunerServer &get_tuner_server() { return tuner_server_; }
+  void start_tuner();
+  void stop_tuner();
+  void set_ld2410_html(const uint8_t *data, size_t len) {
+    ld2410_html_gz_ = data;
+    ld2410_html_gz_len_ = len;
+  }
+  void set_ld2450_html(const uint8_t *data, size_t len) {
+    ld2450_html_gz_ = data;
+    ld2450_html_gz_len_ = len;
+  }
+
+  void set_device_class_indices(uint8_t distance, uint8_t illuminance, uint8_t occupancy, uint8_t motion) {
+    this->device_class_meta_ = {distance, illuminance, occupancy, motion};
+  }
+
+  void set_unit_indices(uint8_t centimeter, uint8_t percent) { this->unit_meta_ = {centimeter, percent}; }
+
+  void set_icon_indices(uint8_t radar, uint8_t chip, uint8_t signal, uint8_t motion_sensor, uint8_t account_multiple,
+                        uint8_t account, uint8_t account_arrow_right, uint8_t tune_vertical, uint8_t factory,
+                        uint8_t restart, uint8_t database_refresh) {
+    this->icon_meta_ = {radar,          chip,           signal,         motion_sensor, account_multiple,
+                        account,        account_arrow_right, tune_vertical,  factory,       restart,
+                        database_refresh};
+  }
+
+  protected:
+  void process_detection_();
+  void finalize_detection_(RadarType type);
+  void create_common_entities_();
+
+  RadarType detected_type_{RadarType::UNKNOWN};
+  bool detection_started_{false};
+  bool detection_complete_{false};
+  uint32_t detect_start_ms_{0};
+  uint8_t detect_ring_buf_[4]{};
+  size_t detect_ring_pos_{0};
+  DeviceClassMeta device_class_meta_{};
+  UnitMeta unit_meta_{};
+  IconMeta icon_meta_{};
+
+  text_sensor::TextSensor *radar_type_text_sensor_{nullptr};
+
+  std::unique_ptr<Satellite1RadarTunerSwitch> runtime_tuner_switch_{};
+
+  // Protocol handlers (allocated only for detected radar type)
+  std::unique_ptr<LD2410Handler> ld2410_{};
+  std::unique_ptr<LD2450Handler> ld2450_{};
+
+  RadarTunerServer tuner_server_{};
+  std::atomic_bool write_config_pending_{false};
+  const uint8_t *ld2410_html_gz_{nullptr};
+  size_t ld2410_html_gz_len_{0};
+  const uint8_t *ld2450_html_gz_{nullptr};
+  size_t ld2450_html_gz_len_{0};
+};
+
+}  // namespace satellite1_radar
+}  // namespace esphome

--- a/esphome/components/satellite1_radar/text_sensor.py
+++ b/esphome/components/satellite1_radar/text_sensor.py
@@ -1,0 +1,23 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+
+from . import CONF_SATELLITE1_RADAR_ID, Satellite1Radar
+
+DEPENDENCIES = ["satellite1_radar"]
+
+CONFIG_SCHEMA = text_sensor.text_sensor_schema(
+    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    icon="mdi:radar",
+).extend(
+    {
+        cv.GenerateID(CONF_SATELLITE1_RADAR_ID): cv.use_id(Satellite1Radar),
+    }
+)
+
+
+async def to_code(config):
+    var = await text_sensor.new_text_sensor(config)
+    parent = await cg.get_variable(config[CONF_SATELLITE1_RADAR_ID])
+    cg.add(parent.set_radar_type_text_sensor(var))

--- a/esphome/components/satellite1_radar/tuner_ui/radar_tuner_ld2410.html
+++ b/esphome/components/satellite1_radar/tuner_ui/radar_tuner_ld2410.html
@@ -1,0 +1,495 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Satellite1 Radar Tuner — LD2410</title>
+<style>
+:root{--bg:#0a0d12;--panel:#10131a;--border:#1e2330;--text:#d0d4dc;--dim:#6b7280;--accent:#3b82f6;--green:#22c55e;--red:#ef4444;--yellow:#eab308;--orange:#f97316}
+[data-theme="light"]{--bg:#f5f6f8;--panel:#ffffff;--border:#d1d5db;--text:#1f2937;--dim:#6b7280;--accent:#2563eb;--green:#16a34a;--red:#dc2626;--yellow:#ca8a04;--orange:#ea580c}
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:flex;flex-direction:column;height:100vh}
+header{background:var(--panel);border-bottom:1px solid var(--border);padding:10px 16px;display:flex;align-items:center;gap:12px}
+header h1{font-size:16px;font-weight:600}
+.status{width:8px;height:8px;border-radius:50%;background:var(--red)}
+.status.ok{background:var(--green)}
+.wrap{display:flex;flex:1;overflow:hidden}
+.canvas-wrap{flex:1;position:relative;overflow:hidden}
+canvas{display:block;width:100%;height:100%}
+.panel{width:280px;background:var(--panel);border-left:1px solid var(--border);padding:16px;overflow-y:auto;display:flex;flex-direction:column;gap:12px}
+.panel label{font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.5px}
+.panel input,.panel select{background:var(--bg);border:1px solid var(--border);color:var(--text);padding:6px 8px;border-radius:4px;width:100%;font-size:13px}
+.btn{padding:6px 12px;border:none;border-radius:4px;cursor:pointer;font-size:13px;font-weight:500;transition:opacity .15s}
+.btn:hover{opacity:.85}
+.btn-primary{background:var(--accent);color:#fff}
+.btn-danger{background:var(--red);color:#fff}
+.btn-success{background:var(--green);color:#fff}
+.group{display:flex;flex-direction:column;gap:6px}
+.row{display:flex;gap:6px}
+.hint{font-size:11px;color:var(--dim);line-height:1.4}
+.instructions{font-size:11px;color:var(--dim);line-height:1.5;border:1px solid var(--border);border-radius:4px;padding:8px 10px;background:var(--bg)}
+.tooltip{position:relative;display:inline-block;cursor:help;margin-left:4px;width:14px;height:14px;border-radius:50%;background:var(--border);color:var(--dim);font-size:10px;text-align:center;line-height:14px}
+.tooltip .tt{visibility:hidden;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:6px 8px;font-size:11px;line-height:1.4;position:absolute;z-index:10;bottom:120%;left:50%;transform:translateX(-50%);width:220px;text-transform:none;letter-spacing:0;font-weight:400}
+.tooltip:hover .tt{visibility:visible}
+.toggle{position:relative;display:inline-block;width:40px;height:22px}
+.toggle input{opacity:0;width:0;height:0}
+.slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:var(--border);border-radius:22px;transition:.2s}
+.slider::before{content:"";position:absolute;height:16px;width:16px;left:3px;bottom:3px;background:var(--dim);border-radius:50%;transition:.2s}
+.toggle input:checked+.slider{background:var(--accent)}
+.toggle input:checked+.slider::before{transform:translateX(18px);background:#fff}
+.gate-btns{display:flex;flex-wrap:wrap;gap:4px}
+.gate-btn{padding:4px 0;width:28px;text-align:center;border:1px solid var(--border);border-radius:4px;background:var(--bg);color:var(--dim);font-size:11px;font-weight:500;cursor:pointer;transition:all .15s}
+.gate-btn:hover{border-color:var(--accent);color:var(--text)}
+.gate-btn.active{background:var(--accent);border-color:var(--accent);color:#fff}
+.theme-toggle{margin-left:auto;background:none;border:none;cursor:pointer;padding:4px;border-radius:4px;color:var(--dim);display:flex;align-items:center}
+.theme-toggle:hover{background:var(--border)}
+.theme-toggle svg{width:18px;height:18px;fill:currentColor}
+@media(max-width:700px){.wrap{flex-direction:column}.panel{width:100%;max-height:40vh;border-left:none;border-top:1px solid var(--border)}}
+</style>
+</head>
+<body>
+<header>
+<div class="status" id="statusDot"></div>
+<h1>Satellite1 Radar Tuner — LD2410</h1>
+<button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" title="Toggle light/dark mode"><svg id="themeIcon" viewBox="0 0 24 24"><path d="M21.75 12.02c-.06 5.27-4.38 9.53-9.65 9.48-4.3-.04-8.03-2.92-9.18-6.96-.12-.42.15-.82.58-.9 1.04-.17 2.05-.54 2.97-1.09 2.72-1.63 4.35-4.38 4.53-7.3.02-.33.05-.67.05-1.01 0-.52-.06-1.02-.16-1.52-.09-.43.19-.85.63-.89 5.43-.42 10.28 3.8 10.23 9.19z"/></svg></button>
+</header>
+<div class="wrap">
+<div class="canvas-wrap"><canvas id="cv"></canvas></div>
+<div class="panel">
+<div class="group">
+<p class="instructions">
+Select a gate below or click its column in the chart.<br>
+Drag any dashed threshold line up or down to adjust it visually, then press <b style="color:var(--text)">Save All</b> to write changes to the radar.
+</p>
+</div>
+<div class="group" id="gatePanel">
+<label>Select Gate</label>
+<div class="gate-btns" id="gateBtns"></div>
+<div id="threshRow" style="display:none;margin-top:6px">
+<label style="font-size:11px;margin-bottom:2px">Selected: <span id="gateLabel" style="color:var(--accent);text-transform:none">--</span></label>
+<div class="row">
+<div style="flex:1">
+<label style="font-size:11px">Move Thresh</label>
+<input type="number" id="moveThreshInput" min="0" max="100" step="1">
+</div>
+<div style="flex:1">
+<label style="font-size:11px">Still Thresh</label>
+<input type="number" id="stillThreshInput" min="0" max="100" step="1">
+</div>
+</div>
+<div class="row" style="margin-top:4px">
+<button class="btn btn-primary" style="flex:1" onclick="applyThreshold()">Apply Gate</button>
+</div>
+</div>
+</div>
+<hr style="border:none;border-top:1px solid var(--border)">
+<div class="group">
+<label>Timeout (seconds)<span class="tooltip">?<span class="tt">Duration in seconds the sensor continues to report presence after the last target disappears.</span></span></label>
+<div class="row">
+<input type="number" id="timeoutInput" min="0" max="65535" step="1" value="0">
+<button class="btn btn-primary" onclick="saveTimeout()">Set</button>
+</div>
+</div>
+<div class="group">
+<label>Max Moving Gate<span class="tooltip">?<span class="tt">Farthest gate that detects moving targets (0-8). Gates beyond this are ignored for motion detection.</span></span></label>
+<div class="row">
+<input type="number" id="maxMoveGate" min="0" max="8" step="1" value="8">
+<button class="btn btn-primary" onclick="saveMaxMoveGate()">Set</button>
+</div>
+</div>
+<div class="group">
+<label>Max Still Gate<span class="tooltip">?<span class="tt">Farthest gate that detects still targets (0-8). Gates beyond this are ignored for stationary detection.</span></span></label>
+<div class="row">
+<input type="number" id="maxStillGate" min="0" max="8" step="1" value="8">
+<button class="btn btn-primary" onclick="saveMaxStillGate()">Set</button>
+</div>
+</div>
+<div class="group">
+<label>Bluetooth<span class="tooltip">?<span class="tt">Enable or disable the radar module's Bluetooth radio.</span></span></label>
+<div class="row" style="align-items:center">
+<label class="toggle"><input type="checkbox" id="btToggle" onchange="saveBluetooth()"><span class="slider"></span></label>
+<span id="btLabel" style="font-size:12px;color:var(--dim)">OFF</span>
+</div>
+</div>
+<div class="group">
+<label>Distance Resolution<span class="tooltip">?<span class="tt">Controls the distance granularity per gate. At 0.75m each of the 9 gates covers 0.75 m (max range &asymp; 6 m). At 0.2m each gate covers 0.2 m (max range &asymp; 1.6 m) for finer close-range detection.</span></span></label>
+<div class="row">
+<select id="distRes" style="flex:1">
+<option value="0.75m">0.75 m (default)</option>
+<option value="0.2m">0.2 m (fine)</option>
+</select>
+<button class="btn btn-primary" onclick="saveDistRes()">Set</button>
+</div>
+</div>
+<div class="group">
+<button class="btn btn-success" style="width:100%" onclick="saveAll()">Save All</button>
+</div>
+<div class="group">
+<p class="hint">
+<b style="color:rgba(59,130,246,0.9)">Blue</b> = Moving energy &nbsp;
+<b style="color:rgba(34,197,94,0.9)">Green</b> = Still energy<br>
+<b style="color:#6b7280">Dashed</b> = Threshold (drag to adjust)
+</p>
+</div>
+</div>
+</div>
+<script>
+const MOON_PATH='M21.75 12.02c-.06 5.27-4.38 9.53-9.65 9.48-4.3-.04-8.03-2.92-9.18-6.96-.12-.42.15-.82.58-.9 1.04-.17 2.05-.54 2.97-1.09 2.72-1.63 4.35-4.38 4.53-7.3.02-.33.05-.67.05-1.01 0-.52-.06-1.02-.16-1.52-.09-.43.19-.85.63-.89 5.43-.42 10.28 3.8 10.23 9.19z';
+const SUN_PATH='M12 2a1 1 0 011 1v1a1 1 0 01-2 0V3a1 1 0 011-1zm0 15a5 5 0 100-10 5 5 0 000 10zm0 3a1 1 0 011 1v1a1 1 0 01-2 0v-1a1 1 0 011-1zm9-9a1 1 0 010 2h-1a1 1 0 010-2h1zM4 11a1 1 0 010 2H3a1 1 0 010-2h1zm15.07-6.36a1 1 0 010 1.41l-.71.71a1 1 0 01-1.41-1.41l.7-.71a1 1 0 011.42 0zM7.05 17.66a1 1 0 010 1.41l-.7.71a1 1 0 01-1.42-1.41l.71-.71a1 1 0 011.41 0zM4.93 4.64a1 1 0 011.41 0l.71.71a1 1 0 01-1.41 1.41l-.71-.7a1 1 0 010-1.42zm12.02 13.02a1 1 0 011.41 0l.71.71a1 1 0 01-1.41 1.41l-.71-.7a1 1 0 010-1.42z';
+function isLight(){return document.documentElement.getAttribute('data-theme')==='light'}
+function toggleTheme(){
+  const next=isLight()?'dark':'light';
+  document.documentElement.setAttribute('data-theme',next);
+  localStorage.setItem('radar-tuner-theme',next);
+  updateThemeIcon();draw();
+}
+function updateThemeIcon(){
+  document.getElementById('themeIcon').innerHTML='<path d="'+(isLight()?SUN_PATH:MOON_PATH)+'"/>';
+}
+(function(){var s=localStorage.getItem('radar-tuner-theme');if(s)document.documentElement.setAttribute('data-theme',s);updateThemeIcon()})();
+
+const BASE=window.location.origin;
+const cv=document.getElementById('cv');
+const ctx=cv.getContext('2d');
+const GATES=9;
+
+function chartColors(){
+  if(isLight())return{dim:'#6b7280',accent:'#2563eb',grid:'#d1d5db',selBg:'rgba(37,99,235,0.08)',waitText:'#9ca3af'};
+  return{dim:'#6b7280',accent:'#3b82f6',grid:'#1a1e28',selBg:'rgba(59,130,246,0.08)',waitText:'#4b5563'};
+}
+const C_MOVE='59,130,246';
+const C_STILL='34,197,94';
+
+let moveEnergy=new Array(GATES).fill(0);
+let stillEnergy=new Array(GATES).fill(0);
+let dispMove=new Array(GATES).fill(0);
+let dispStill=new Array(GATES).fill(0);
+let moveThresh=new Array(GATES).fill(50);
+let stillThresh=new Array(GATES).fill(50);
+let selGate=-1;
+let connected=false;
+let everReceivedData=false;
+let W,H;
+const FETCH_OPTS={headers:{'Connection':'close'}};
+function wait(ms){return new Promise(r=>setTimeout(r,ms))}
+
+// Drag state
+let isDragging=false;
+let dragGate=-1;
+let dragType='';
+let dragStartY=0;
+let dragMoved=false;
+
+function resize(){
+  const r=cv.parentElement.getBoundingClientRect();
+  cv.width=r.width*devicePixelRatio;
+  cv.height=r.height*devicePixelRatio;
+  W=cv.width;H=cv.height;
+}
+window.addEventListener('resize',resize);
+
+function getLayout(){
+  const dpr=devicePixelRatio;
+  const pad={top:30*dpr,bottom:40*dpr,left:50*dpr,right:20*dpr};
+  const cw=W-pad.left-pad.right;
+  const ch=H-pad.top-pad.bottom;
+  const gw=cw/GATES;
+  const barW=gw*0.35;
+  return {dpr,pad,cw,ch,gw,barW};
+}
+
+function draw(){
+  if(!W||!H)return;
+  const cc=chartColors();
+  ctx.clearRect(0,0,W,H);
+  const {dpr,pad,cw,ch,gw,barW}=getLayout();
+
+  ctx.fillStyle=cc.dim;ctx.font=`${10*dpr}px sans-serif`;ctx.textAlign='right';ctx.textBaseline='middle';
+  for(let p=0;p<=100;p+=25){
+    const y=pad.top+ch*(1-p/100);
+    ctx.fillText(p+'%',pad.left-8*dpr,y);
+    ctx.strokeStyle=cc.grid;ctx.lineWidth=1;
+    ctx.beginPath();ctx.moveTo(pad.left,y);ctx.lineTo(W-pad.right,y);ctx.stroke();
+  }
+
+  ctx.fillStyle=cc.dim;ctx.font=`${11*dpr}px sans-serif`;ctx.textAlign='center';
+  ctx.fillText('GATE ENERGY & THRESHOLDS',W/2,16*dpr);
+
+  for(let g=0;g<GATES;g++){
+    const gx=pad.left+g*gw;
+    const cx_=gx+gw/2;
+
+    if(g===selGate){
+      ctx.fillStyle=cc.selBg;
+      ctx.fillRect(gx+2,pad.top,gw-4,ch);
+    }
+
+    const mh=ch*dispMove[g]/100;
+    const mActive=dispMove[g]>moveThresh[g];
+    ctx.fillStyle=mActive?`rgba(${C_MOVE},0.9)`:`rgba(${C_MOVE},0.35)`;
+    ctx.fillRect(cx_-barW-1,pad.top+ch-mh,barW,mh);
+
+    const sh_=ch*dispStill[g]/100;
+    const sActive=dispStill[g]>stillThresh[g];
+    ctx.fillStyle=sActive?`rgba(${C_STILL},0.9)`:`rgba(${C_STILL},0.35)`;
+    ctx.fillRect(cx_+1,pad.top+ch-sh_,barW,sh_);
+
+    const mty=pad.top+ch*(1-moveThresh[g]/100);
+    ctx.strokeStyle=`rgba(${C_MOVE},0.7)`;ctx.lineWidth=2*dpr;ctx.setLineDash([4*dpr,3*dpr]);
+    ctx.beginPath();ctx.moveTo(gx+4,mty);ctx.lineTo(cx_-1,mty);ctx.stroke();
+    ctx.setLineDash([]);
+
+    const sty=pad.top+ch*(1-stillThresh[g]/100);
+    ctx.strokeStyle=`rgba(${C_STILL},0.7)`;ctx.lineWidth=2*dpr;ctx.setLineDash([4*dpr,3*dpr]);
+    ctx.beginPath();ctx.moveTo(cx_+1,sty);ctx.lineTo(gx+gw-4,sty);ctx.stroke();
+    ctx.setLineDash([]);
+
+    if(isDragging&&dragGate===g){
+      const val=dragType==='move'?moveThresh[g]:stillThresh[g];
+      const ty=dragType==='move'?mty:sty;
+      ctx.fillStyle=`rgba(${dragType==='move'?C_MOVE:C_STILL},0.9)`;
+      ctx.font=`bold ${10*dpr}px sans-serif`;ctx.textAlign='center';
+      ctx.fillText(Math.round(val)+'',cx_,ty-8*dpr);
+    }
+
+    ctx.fillStyle=g===selGate?cc.accent:cc.dim;
+    ctx.font=`${g===selGate?'bold ':''}${11*dpr}px sans-serif`;ctx.textAlign='center';
+    ctx.fillText('G'+g,cx_,H-pad.bottom+16*dpr);
+  }
+
+  if(!everReceivedData){
+    ctx.fillStyle=cc.waitText;
+    ctx.font=`${13*dpr}px sans-serif`;ctx.textAlign='center';ctx.textBaseline='middle';
+    ctx.fillText('Waiting for radar engineering data\u2026',W/2,pad.top+ch/2);
+    ctx.font=`${10*dpr}px sans-serif`;
+    ctx.fillText('Engineering mode is being enabled on the sensor.',W/2,pad.top+ch/2+18*dpr);
+  }
+}
+
+// Animation loop
+function animate(){
+  let needsRedraw=false;
+  for(let g=0;g<GATES;g++){
+    const dm=moveEnergy[g]-dispMove[g];
+    const ds=stillEnergy[g]-dispStill[g];
+    if(Math.abs(dm)>0.2){dispMove[g]+=dm*0.15;needsRedraw=true}else if(dm!==0){dispMove[g]=moveEnergy[g];needsRedraw=true}
+    if(Math.abs(ds)>0.2){dispStill[g]+=ds*0.15;needsRedraw=true}else if(ds!==0){dispStill[g]=stillEnergy[g];needsRedraw=true}
+  }
+  if(needsRedraw||isDragging)draw();
+  requestAnimationFrame(animate);
+}
+
+// Hit-test: is point near a threshold line?
+function hitTestThreshold(canvasX,canvasY){
+  const {dpr,pad,cw,ch,gw,barW}=getLayout();
+  const hitDist=8*dpr;
+  for(let g=0;g<GATES;g++){
+    const gx=pad.left+g*gw;
+    const cx_=gx+gw/2;
+    const mty=pad.top+ch*(1-moveThresh[g]/100);
+    if(canvasX>=gx&&canvasX<=cx_&&Math.abs(canvasY-mty)<hitDist)return{gate:g,type:'move'};
+    const sty=pad.top+ch*(1-stillThresh[g]/100);
+    if(canvasX>=cx_&&canvasX<=gx+gw&&Math.abs(canvasY-sty)<hitDist)return{gate:g,type:'still'};
+  }
+  return null;
+}
+
+function canvasCoords(e){
+  const dpr=devicePixelRatio;
+  const rect=cv.getBoundingClientRect();
+  const t=e.touches?e.touches[0]||e.changedTouches[0]:e;
+  return{x:(t.clientX-rect.left)*dpr,y:(t.clientY-rect.top)*dpr};
+}
+
+function yToThreshVal(canvasY){
+  const {pad,ch}=getLayout();
+  const pct=(1-(canvasY-pad.top)/ch)*100;
+  return Math.max(0,Math.min(100,Math.round(pct)));
+}
+
+function onPointerDown(e){
+  const {x,y}=canvasCoords(e);
+  const hit=hitTestThreshold(x,y);
+  dragStartY=y;
+  dragMoved=false;
+  if(hit){
+    isDragging=true;
+    dragGate=hit.gate;
+    dragType=hit.type;
+    cv.style.cursor='ns-resize';
+    e.preventDefault();
+  }
+}
+
+function onPointerMove(e){
+  const {x,y}=canvasCoords(e);
+  if(isDragging){
+    dragMoved=true;
+    const val=yToThreshVal(y);
+    if(dragType==='move')moveThresh[dragGate]=val;
+    else stillThresh[dragGate]=val;
+    if(selGate===dragGate)syncThreshInputs();
+    draw();
+    e.preventDefault();
+    return;
+  }
+  const hit=hitTestThreshold(x,y);
+  cv.style.cursor=hit?'ns-resize':'default';
+}
+
+function onPointerUp(e){
+  if(isDragging){
+    const g=dragGate;
+    isDragging=false;
+    cv.style.cursor='default';
+    if(dragMoved){
+      // threshold values stay local until user applies/saves
+    }
+    selectGate(g);
+    e.preventDefault();
+    return;
+  }
+  if(!dragMoved){
+    const {x}=canvasCoords(e);
+    const {pad,gw}=getLayout();
+    const g=Math.floor((x-pad.left)/gw);
+    if(g>=0&&g<GATES)selectGate(g);
+  }
+}
+
+cv.addEventListener('mousedown',onPointerDown);
+cv.addEventListener('mousemove',onPointerMove);
+cv.addEventListener('mouseup',onPointerUp);
+cv.addEventListener('mouseleave',()=>{if(!isDragging)cv.style.cursor='default'});
+cv.addEventListener('touchstart',onPointerDown,{passive:false});
+cv.addEventListener('touchmove',onPointerMove,{passive:false});
+cv.addEventListener('touchend',onPointerUp,{passive:false});
+
+function selectGate(g){
+  selGate=g;
+  document.getElementById('gateLabel').textContent='Gate '+g;
+  document.getElementById('threshRow').style.display='block';
+  syncThreshInputs();
+  document.querySelectorAll('.gate-btn').forEach((b,i)=>b.classList.toggle('active',i===g));
+  draw();
+}
+
+function syncThreshInputs(){
+  if(selGate<0)return;
+  document.getElementById('moveThreshInput').value=Math.round(moveThresh[selGate]);
+  document.getElementById('stillThreshInput').value=Math.round(stillThresh[selGate]);
+}
+
+// Build gate selector buttons
+(function(){
+  const c=document.getElementById('gateBtns');
+  for(let g=0;g<GATES;g++){
+    const b=document.createElement('button');
+    b.className='gate-btn';b.textContent='G'+g;
+    b.addEventListener('click',()=>selectGate(g));
+    c.appendChild(b);
+  }
+})();
+
+async function apiGet(path){const r=await fetch(BASE+path,FETCH_OPTS);if(!r.ok)throw new Error(r.statusText);return r.json()}
+async function apiPatch(path,payload){
+  const r=await fetch(BASE+path,{method:'PATCH',headers:{'Content-Type':'application/json','Connection':'close'},body:JSON.stringify(payload)});
+  if(!r.ok)throw new Error(r.statusText);
+  return r.json();
+}
+async function flushPrefs(){await fetch(BASE+'/api/v1/save',{method:'POST',...FETCH_OPTS})}
+async function applyConfig(){await fetch(BASE+'/api/v1/ld2410/apply',{method:'POST',...FETCH_OPTS})}
+
+async function loadConfig(){
+  const cfg=await apiGet('/api/v1/ld2410/config');
+  document.getElementById('timeoutInput').value=Math.round(cfg.timeout||0);
+  document.getElementById('maxMoveGate').value=Math.round(cfg.max_move_gate||8);
+  document.getElementById('maxStillGate').value=Math.round(cfg.max_still_gate||8);
+  const on=cfg.bluetooth===true;
+  document.getElementById('btToggle').checked=on;
+  document.getElementById('btLabel').textContent=on?'ON':'OFF';
+  if(cfg.distance_resolution)document.getElementById('distRes').value=cfg.distance_resolution;
+  for(let g=0;g<GATES;g++){
+    moveThresh[g]=(cfg.gate_move_thresholds&&cfg.gate_move_thresholds[g])||0;
+    stillThresh[g]=(cfg.gate_still_thresholds&&cfg.gate_still_thresholds[g])||0;
+  }
+}
+
+async function pollGates(){
+  try{
+    const r=await fetch(BASE+'/api/v1/ld2410/live',FETCH_OPTS);
+    if(!r.ok)throw new Error();
+    const d=await r.json();
+    let anyNonZero=false;
+    for(let g=0;g<GATES;g++){
+      moveEnergy[g]=(d.gates&&d.gates.move&&d.gates.move[g])||0;
+      stillEnergy[g]=(d.gates&&d.gates.still&&d.gates.still[g])||0;
+      if(moveEnergy[g]>0||stillEnergy[g]>0)anyNonZero=true;
+    }
+    if(anyNonZero)everReceivedData=true;
+    if(!connected){connected=true;document.getElementById('statusDot').classList.add('ok')}
+  }catch(e){
+    if(connected){connected=false;document.getElementById('statusDot').classList.remove('ok')}
+  }
+}
+
+async function saveTimeout(){
+  const v=parseInt(document.getElementById('timeoutInput').value)||0;
+  await apiPatch('/api/v1/ld2410/config',{timeout:v});await applyConfig();await flushPrefs();
+}
+async function saveMaxMoveGate(){
+  const v=parseInt(document.getElementById('maxMoveGate').value)||0;
+  await apiPatch('/api/v1/ld2410/config',{max_move_gate:v});await applyConfig();await flushPrefs();
+}
+async function saveMaxStillGate(){
+  const v=parseInt(document.getElementById('maxStillGate').value)||0;
+  await apiPatch('/api/v1/ld2410/config',{max_still_gate:v});await applyConfig();await flushPrefs();
+}
+async function saveBluetooth(){
+  const on=document.getElementById('btToggle').checked;
+  document.getElementById('btLabel').textContent=on?'ON':'OFF';
+  await apiPatch('/api/v1/ld2410/config',{bluetooth:on});
+}
+async function saveDistRes(){
+  const v=document.getElementById('distRes').value;
+  await apiPatch('/api/v1/ld2410/config',{distance_resolution:v});
+  await applyConfig();await flushPrefs();
+}
+async function applyThreshold(){
+  if(selGate<0)return;
+  const mt=parseInt(document.getElementById('moveThreshInput').value)||0;
+  const st=parseInt(document.getElementById('stillThreshInput').value)||0;
+  moveThresh[selGate]=mt;stillThresh[selGate]=st;
+  const move=moveThresh.map(v=>Math.round(v));
+  const still=stillThresh.map(v=>Math.round(v));
+  await apiPatch('/api/v1/ld2410/config',{gate_move_thresholds:move,gate_still_thresholds:still});
+  await applyConfig();await flushPrefs();
+  draw();
+}
+async function saveAll(){
+  await apiPatch('/api/v1/ld2410/config',{
+    timeout:parseInt(document.getElementById('timeoutInput').value)||0,
+    max_move_gate:parseInt(document.getElementById('maxMoveGate').value)||0,
+    max_still_gate:parseInt(document.getElementById('maxStillGate').value)||0,
+    distance_resolution:document.getElementById('distRes').value,
+    bluetooth:document.getElementById('btToggle').checked,
+    gate_move_thresholds:moveThresh.map(v=>Math.round(v)),
+    gate_still_thresholds:stillThresh.map(v=>Math.round(v))
+  });
+  await applyConfig();await flushPrefs();
+}
+
+async function init(){
+  try{
+    await loadConfig();
+    connected=true;document.getElementById('statusDot').classList.add('ok');
+  }catch(e){connected=false}
+  draw();
+  setInterval(pollGates,500);
+}
+resize();
+requestAnimationFrame(animate);
+init();
+</script>
+</body>
+</html>

--- a/esphome/components/satellite1_radar/tuner_ui/radar_tuner_ld2450.html
+++ b/esphome/components/satellite1_radar/tuner_ui/radar_tuner_ld2450.html
@@ -51,6 +51,9 @@ canvas{display:block;width:100%;height:100%;cursor:crosshair}
 .panel.ui-disabled *{cursor:not-allowed!important}
 .offline-note{display:none;font-size:12px;color:var(--orange)}
 .offline-note.show{display:block}
+.zone-validity{font-size:11px;line-height:1.4}
+.zone-validity .ok{color:var(--green)}
+.zone-validity .warn{color:var(--orange)}
 @media(max-width:700px){.wrap{flex-direction:column}.panel{width:100%;max-height:40vh;border-left:none;border-top:1px solid var(--border)}}
 </style>
 </head>
@@ -121,6 +124,8 @@ canvas{display:block;width:100%;height:100%;cursor:crosshair}
 <button class="btn btn-danger" onclick="clearCurrentZone()">Clear Zone</button>
 </div>
 <button class="btn btn-primary" style="width:100%" onclick="saveAllZones()">Save All Zones</button>
+<p class="hint">A zone needs at least 3 points to be valid and create a zone sensor after reboot.</p>
+<div class="zone-validity" id="zoneValidity"></div>
 </div>
 <div class="group">
 <p class="hint">
@@ -255,6 +260,7 @@ function draw(){
   }
   ctx.restore();
   updateCoords();
+  updateZoneValidity();
 }
 
 function updateCoords(){
@@ -263,6 +269,17 @@ function updateCoords(){
   if(!pts.length){el.innerHTML='<p class="hint">No points yet</p>';return}
   let h='<label>Points ('+pts.length+'/'+MAX_PTS+')</label>';
   pts.forEach((p,i)=>{h+=`<div style="font-size:11px;color:var(--dim)">P${i+1}: (${Math.round(p.x)}, ${Math.round(p.y)})</div>`});
+  el.innerHTML=h;
+}
+
+function updateZoneValidity(){
+  const el=document.getElementById('zoneValidity');
+  let h='';
+  for(let z=0;z<3;z++){
+    const n=zones[z].length;
+    if(n>=3)h+=`<div class="ok">Zone ${z+1}: defined (${n} points)</div>`;
+    else h+=`<div class="warn">Zone ${z+1}: incomplete (${n}/3+ points)</div>`;
+  }
   el.innerHTML=h;
 }
 
@@ -424,10 +441,12 @@ async function saveZone(z){
   if(!connected)return;
   if(z<3){
     const zonesPayload=[zones[0],zones[1],zones[2]].map(arr=>arr.map(p=>({x:Math.round(p.x),y:Math.round(p.y)})));
-    await apiPatch('/api/v1/ld2450/config',{zones:zonesPayload});
+    const res=await apiPatch('/api/v1/ld2450/config',{zones:zonesPayload});
+    setRebootRequired(res.reboot_required===true);
   }else{
     const exclusion=zones[3].map(p=>({x:Math.round(p.x),y:Math.round(p.y)}));
-    await apiPatch('/api/v1/ld2450/config',{exclusion});
+    const res=await apiPatch('/api/v1/ld2450/config',{exclusion});
+    setRebootRequired(res.reboot_required===true);
   }
 }
 

--- a/esphome/components/satellite1_radar/tuner_ui/radar_tuner_ld2450.html
+++ b/esphome/components/satellite1_radar/tuner_ui/radar_tuner_ld2450.html
@@ -1,0 +1,455 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Satellite1 Radar Tuner — LD2450</title>
+<style>
+:root{--bg:#0a0d12;--panel:#10131a;--border:#1e2330;--text:#d0d4dc;--dim:#6b7280;--accent:#3b82f6;--green:#22c55e;--red:#ef4444;--yellow:#eab308;--orange:#f97316}
+[data-theme="light"]{--bg:#f5f6f8;--panel:#ffffff;--border:#d1d5db;--text:#1f2937;--dim:#6b7280;--accent:#2563eb;--green:#16a34a;--red:#dc2626;--yellow:#ca8a04;--orange:#ea580c}
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:flex;flex-direction:column;height:100vh}
+header{background:var(--panel);border-bottom:1px solid var(--border);padding:10px 16px;display:flex;align-items:center;gap:12px}
+header h1{font-size:16px;font-weight:600}
+.status{width:8px;height:8px;border-radius:50%;background:var(--red)}
+.status.ok{background:var(--green)}
+.wrap{display:flex;flex:1;overflow:hidden}
+.canvas-wrap{flex:1;position:relative;overflow:hidden}
+canvas{display:block;width:100%;height:100%;cursor:crosshair}
+.panel{width:260px;background:var(--panel);border-left:1px solid var(--border);padding:16px;overflow-y:auto;display:flex;flex-direction:column;gap:12px}
+.panel label{font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.5px}
+.panel input{background:var(--bg);border:1px solid var(--border);color:var(--text);padding:6px 8px;border-radius:4px;width:100%;font-size:13px}
+.btn{padding:6px 12px;border:none;border-radius:4px;cursor:pointer;font-size:13px;font-weight:500;transition:opacity .15s}
+.btn:hover{opacity:.85}
+.btn-primary{background:var(--accent);color:#fff}
+.btn-danger{background:var(--red);color:#fff}
+.btn-success{background:var(--green);color:#fff}
+.btn-outline{background:transparent;border:1px solid var(--border);color:var(--text)}
+.btn-outline.active{border-color:var(--accent);color:var(--accent)}
+.zone-btns{display:flex;gap:4px;flex-wrap:wrap}
+.zone-btns .btn{flex:1;min-width:0;font-size:11px;padding:5px 4px}
+.group{display:flex;flex-direction:column;gap:6px}
+.row{display:flex;gap:6px}
+.hint{font-size:11px;color:var(--dim);line-height:1.4}
+.tooltip{position:relative;display:inline-block;cursor:help;margin-left:4px;width:14px;height:14px;border-radius:50%;background:var(--border);color:var(--dim);font-size:10px;text-align:center;line-height:14px}
+.tooltip .tt{visibility:hidden;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:6px 8px;font-size:11px;line-height:1.4;position:absolute;z-index:10;top:120%;bottom:auto;left:50%;transform:translateX(-50%);width:220px;text-transform:none;letter-spacing:0;font-weight:400}
+.tooltip:hover .tt{visibility:visible}
+.toggle{position:relative;display:inline-block;width:40px;height:22px}
+.toggle input{opacity:0;width:0;height:0}
+.slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:var(--border);border-radius:22px;transition:.2s}
+.slider::before{content:"";position:absolute;height:16px;width:16px;left:3px;bottom:3px;background:var(--dim);border-radius:50%;transition:.2s}
+.toggle input:checked+.slider{background:var(--accent)}
+.toggle input:checked+.slider::before{transform:translateX(18px);background:#fff}
+.theme-toggle{margin-left:auto;background:none;border:none;cursor:pointer;padding:4px;border-radius:4px;color:var(--dim);display:flex;align-items:center}
+.theme-toggle:hover{background:var(--border)}
+.theme-toggle svg{width:18px;height:18px;fill:currentColor}
+@media(max-width:700px){.wrap{flex-direction:column}.panel{width:100%;max-height:40vh;border-left:none;border-top:1px solid var(--border)}}
+</style>
+</head>
+<body>
+<header>
+<div class="status" id="statusDot"></div>
+<h1>Satellite1 Radar Tuner — LD2450</h1>
+<button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" title="Toggle light/dark mode"><svg id="themeIcon" viewBox="0 0 24 24"><path d="M21.75 12.02c-.06 5.27-4.38 9.53-9.65 9.48-4.3-.04-8.03-2.92-9.18-6.96-.12-.42.15-.82.58-.9 1.04-.17 2.05-.54 2.97-1.09 2.72-1.63 4.35-4.38 4.53-7.3.02-.33.05-.67.05-1.01 0-.52-.06-1.02-.16-1.52-.09-.43.19-.85.63-.89 5.43-.42 10.28 3.8 10.23 9.19z"/></svg></button>
+</header>
+<div class="wrap">
+<div class="canvas-wrap"><canvas id="cv"></canvas></div>
+<div class="panel">
+<div class="group">
+<label>Max Detection Range (cm)<span class="tooltip">?<span class="tt">Maximum detection range for the LD2450 sensor. The hardware maximum is 600 cm (6 meters). Targets beyond this range are ignored.</span></span></label>
+<div class="row">
+<input type="number" id="rangeInput" min="0" max="600" step="1" value="0">
+<button class="btn btn-primary" onclick="saveRange()">Set</button>
+</div>
+</div>
+<div class="group">
+<label>Timeout (seconds)<span class="tooltip">?<span class="tt">Duration in seconds the sensor continues to report presence after the last target disappears. Helps prevent rapid on/off toggling.</span></span></label>
+<div class="row">
+<input type="number" id="timeoutInput" min="0" max="65535" step="1" value="0">
+<button class="btn btn-primary" onclick="saveTimeout()">Set</button>
+</div>
+</div>
+<div class="group">
+<label>Stability<span class="tooltip">?<span class="tt">Controls how stable target count and zone state readings are. Higher values require more consecutive radar frames to agree before updating, reducing flicker but adding response delay. 0 = raw (no filtering), 10 = maximum stability (~1s delay).</span></span></label>
+<div class="row" style="align-items:center">
+<input type="range" id="stabilitySlider" min="0" max="10" step="1" value="5" style="flex:1" oninput="document.getElementById('stabilityVal').textContent=this.value">
+<span id="stabilityVal" style="min-width:20px;text-align:center;font-size:13px;color:var(--text)">5</span>
+<button class="btn btn-primary" onclick="saveStability()">Set</button>
+</div>
+</div>
+<div class="group">
+<label>Multi-Target Tracking<span class="tooltip">?<span class="tt">When enabled, the LD2450 tracks up to 3 targets simultaneously. When disabled, only a single target is tracked. Multi-target mode is recommended for zone-based detection.</span></span></label>
+<div class="row" style="align-items:center">
+<label class="toggle"><input type="checkbox" id="multiTargetToggle" onchange="saveMultiTarget()"><span class="slider"></span></label>
+<span id="multiTargetLabel" style="font-size:12px;color:var(--dim)">OFF</span>
+</div>
+</div>
+<div class="group">
+<label>Bluetooth<span class="tooltip">?<span class="tt">Enable or disable the radar module's Bluetooth radio.</span></span></label>
+<div class="row" style="align-items:center">
+<label class="toggle"><input type="checkbox" id="btToggle" onchange="saveBluetooth()"><span class="slider"></span></label>
+<span id="btLabel" style="font-size:12px;color:var(--dim)">OFF</span>
+</div>
+</div>
+<div class="group">
+<label>Active Zone</label>
+<div class="zone-btns">
+<button class="btn btn-outline active" onclick="selectZone(0)">Zone 1</button>
+<button class="btn btn-outline" onclick="selectZone(1)">Zone 2</button>
+<button class="btn btn-outline" onclick="selectZone(2)">Zone 3</button>
+<button class="btn btn-outline" onclick="selectZone(3)" style="color:var(--red)">Exclusion</button>
+</div>
+</div>
+<div class="group">
+<label>Zone Actions</label>
+<div class="row">
+<button class="btn btn-success" onclick="saveCurrentZone()">Save Zone</button>
+<button class="btn btn-danger" onclick="clearCurrentZone()">Clear Zone</button>
+</div>
+<button class="btn btn-primary" style="width:100%" onclick="saveAllZones()">Save All Zones</button>
+</div>
+<div class="group">
+<p class="hint">
+<b>Click</b> canvas to add point (max 8)<br>
+<b>Drag</b> vertex to move it<br>
+<b>Right-click</b> vertex to delete<br>
+<b>Drag inside</b> polygon to move all
+</p>
+</div>
+<div class="group" id="coordsDisplay"></div>
+</div>
+</div>
+<script>
+const MOON_PATH='M21.75 12.02c-.06 5.27-4.38 9.53-9.65 9.48-4.3-.04-8.03-2.92-9.18-6.96-.12-.42.15-.82.58-.9 1.04-.17 2.05-.54 2.97-1.09 2.72-1.63 4.35-4.38 4.53-7.3.02-.33.05-.67.05-1.01 0-.52-.06-1.02-.16-1.52-.09-.43.19-.85.63-.89 5.43-.42 10.28 3.8 10.23 9.19z';
+const SUN_PATH='M12 2a1 1 0 011 1v1a1 1 0 01-2 0V3a1 1 0 011-1zm0 15a5 5 0 100-10 5 5 0 000 10zm0 3a1 1 0 011 1v1a1 1 0 01-2 0v-1a1 1 0 011-1zm9-9a1 1 0 010 2h-1a1 1 0 010-2h1zM4 11a1 1 0 010 2H3a1 1 0 010-2h1zm15.07-6.36a1 1 0 010 1.41l-.71.71a1 1 0 01-1.41-1.41l.7-.71a1 1 0 011.42 0zM7.05 17.66a1 1 0 010 1.41l-.7.71a1 1 0 01-1.42-1.41l.71-.71a1 1 0 011.41 0zM4.93 4.64a1 1 0 011.41 0l.71.71a1 1 0 01-1.41 1.41l-.71-.7a1 1 0 010-1.42zm12.02 13.02a1 1 0 011.41 0l.71.71a1 1 0 01-1.41 1.41l-.71-.7a1 1 0 010-1.42z';
+function isLight(){return document.documentElement.getAttribute('data-theme')==='light'}
+function themeColors(){
+  if(isLight())return{grid:'#d1d5db',fov:'#9ca3af',dim:'#6b7280',target:'#1f2937',targetLabel:'rgba(31,41,55,0.6)'};
+  return{grid:'#1a1e28',fov:'#2a2e38',dim:'#6b7280',target:'#fff',targetLabel:'rgba(255,255,255,0.6)'};
+}
+function toggleTheme(){
+  const next=isLight()?'dark':'light';
+  document.documentElement.setAttribute('data-theme',next);
+  localStorage.setItem('radar-tuner-theme',next);
+  updateThemeIcon();draw();
+}
+function updateThemeIcon(){
+  document.getElementById('themeIcon').innerHTML='<path d="'+(isLight()?SUN_PATH:MOON_PATH)+'"/>';
+}
+(function(){var s=localStorage.getItem('radar-tuner-theme');if(s)document.documentElement.setAttribute('data-theme',s);updateThemeIcon()})();
+
+const BASE=window.location.origin;
+const cv=document.getElementById('cv');
+const ctx=cv.getContext('2d');
+const ZONES=4;
+const MAX_PTS=8;
+const FOV_DEG=120;
+const COLORS=['rgba(34,197,94,','rgba(59,130,246,','rgba(234,179,8,','rgba(239,68,68,'];
+let zones=Array.from({length:ZONES},()=>[]);
+let activeZone=0;
+let dragIdx=-1,dragZone=-1,dragAll=false,dragStart=null,dragOrigPts=null;
+let targets=[{x:0,y:0},{x:0,y:0},{x:0,y:0}];
+let detRange=0;
+let timeout=0;
+let connected=false;
+let W,H,cx,cy,scale;
+
+function resize(){
+  const r=cv.parentElement.getBoundingClientRect();
+  cv.width=r.width*devicePixelRatio;
+  cv.height=r.height*devicePixelRatio;
+  W=cv.width;H=cv.height;
+  cx=W/2;cy=20*devicePixelRatio;
+  scale=Math.min(W,H)*0.0013;
+  draw();
+}
+window.addEventListener('resize',resize);
+
+function cmToCanvas(x,y){return[cx+x*scale,cy+y*scale]}
+function canvasToCm(px,py){return[(px-cx)/scale,(py-cy)/scale]}
+
+function draw(){
+  const tc=themeColors();
+  ctx.clearRect(0,0,W,H);
+  ctx.save();
+  ctx.strokeStyle=tc.grid;ctx.lineWidth=1;
+  for(let d=100;d<=600;d+=100){
+    const r=d*scale;
+    ctx.beginPath();ctx.arc(cx,cy,r,0,Math.PI);ctx.stroke();
+  }
+  const fovRad=FOV_DEG*Math.PI/360;
+  ctx.strokeStyle=tc.fov;ctx.lineWidth=2;
+  ctx.beginPath();
+  ctx.moveTo(cx,cy);
+  const fl=600*scale;
+  ctx.lineTo(cx-fl*Math.sin(fovRad),cy+fl*Math.cos(fovRad));
+  ctx.moveTo(cx,cy);
+  ctx.lineTo(cx+fl*Math.sin(fovRad),cy+fl*Math.cos(fovRad));
+  ctx.stroke();
+  if(detRange>0){
+    const rr=detRange*scale;
+    ctx.strokeStyle='rgba(59,130,246,0.5)';ctx.lineWidth=2;ctx.setLineDash([6,4]);
+    ctx.beginPath();ctx.arc(cx,cy,rr,Math.PI/2-fovRad,Math.PI/2+fovRad);ctx.stroke();
+    ctx.setLineDash([]);
+  }
+  ctx.fillStyle=tc.dim;ctx.font=`${11*devicePixelRatio}px sans-serif`;ctx.textAlign='center';
+  ctx.fillText('SENSOR',cx,cy-10*devicePixelRatio);
+  // Zones
+  for(let z=0;z<ZONES;z++){
+    const pts=zones[z];if(pts.length<1)continue;
+    const c=COLORS[z];
+    if(pts.length>=3){
+      ctx.fillStyle=c+(z===activeZone?'0.15)':'0.08)');
+      ctx.strokeStyle=c+(z===activeZone?'0.8)':'0.4)');
+      ctx.lineWidth=z===activeZone?2:1;
+      ctx.beginPath();
+      const[fx,fy]=cmToCanvas(pts[0].x,pts[0].y);
+      ctx.moveTo(fx,fy);
+      for(let i=1;i<pts.length;i++){const[px,py]=cmToCanvas(pts[i].x,pts[i].y);ctx.lineTo(px,py)}
+      ctx.closePath();ctx.fill();ctx.stroke();
+    }else if(pts.length===2){
+      ctx.strokeStyle=c+'0.6)';ctx.lineWidth=1;ctx.beginPath();
+      const[ax,ay]=cmToCanvas(pts[0].x,pts[0].y);
+      const[bx,by]=cmToCanvas(pts[1].x,pts[1].y);
+      ctx.moveTo(ax,ay);ctx.lineTo(bx,by);ctx.stroke();
+    }
+    // Vertices
+    for(let i=0;i<pts.length;i++){
+      const[px,py]=cmToCanvas(pts[i].x,pts[i].y);
+      const sz=(z===activeZone?6:4)*devicePixelRatio;
+      ctx.fillStyle=c+'1)';
+      ctx.fillRect(px-sz/2,py-sz/2,sz,sz);
+    }
+  }
+  for(let t=0;t<3;t++){
+    const tx=targets[t].x,ty=targets[t].y;
+    if(tx===0&&ty===0)continue;
+    const[px,py]=cmToCanvas(tx,ty);
+    ctx.fillStyle=tc.target;ctx.beginPath();ctx.arc(px,py,4*devicePixelRatio,0,Math.PI*2);ctx.fill();
+    ctx.fillStyle=tc.targetLabel;ctx.font=`${10*devicePixelRatio}px sans-serif`;ctx.textAlign='left';
+    ctx.fillText(`T${t+1}`,px+6*devicePixelRatio,py-4*devicePixelRatio);
+  }
+  ctx.restore();
+  updateCoords();
+}
+
+function updateCoords(){
+  const el=document.getElementById('coordsDisplay');
+  const pts=zones[activeZone];
+  if(!pts.length){el.innerHTML='<p class="hint">No points yet</p>';return}
+  let h='<label>Points ('+pts.length+'/'+MAX_PTS+')</label>';
+  pts.forEach((p,i)=>{h+=`<div style="font-size:11px;color:var(--dim)">P${i+1}: (${Math.round(p.x)}, ${Math.round(p.y)})</div>`});
+  el.innerHTML=h;
+}
+
+function selectZone(z){
+  activeZone=z;
+  document.querySelectorAll('.zone-btns .btn').forEach((b,i)=>{
+    b.classList.toggle('active',i===z);
+  });
+  draw();
+}
+
+function hitVertex(mx,my,radius){
+  const r=radius||10*devicePixelRatio;
+  for(let z=0;z<ZONES;z++){
+    for(let i=0;i<zones[z].length;i++){
+      const[px,py]=cmToCanvas(zones[z][i].x,zones[z][i].y);
+      if(Math.hypot(mx-px,my-py)<r)return{zone:z,idx:i};
+    }
+  }
+  return null;
+}
+
+function pointInPolygon(pts,x,y){
+  let inside=false;
+  for(let i=0,j=pts.length-1;i<pts.length;j=i++){
+    const xi=pts[i].x,yi=pts[i].y,xj=pts[j].x,yj=pts[j].y;
+    if(((yi>y)!==(yj>y))&&(x<(xj-xi)*(y-yi)/(yj-yi)+xi))inside=!inside;
+  }
+  return inside;
+}
+
+cv.addEventListener('mousedown',e=>{
+  if(e.button===2)return;
+  const rect=cv.getBoundingClientRect();
+  const mx=(e.clientX-rect.left)*devicePixelRatio;
+  const my=(e.clientY-rect.top)*devicePixelRatio;
+  const hit=hitVertex(mx,my);
+  if(hit){
+    dragIdx=hit.idx;dragZone=hit.zone;
+    if(hit.zone!==activeZone)selectZone(hit.zone);
+    return;
+  }
+  // Check drag-all for active zone
+  const[cmx,cmy]=canvasToCm(mx,my);
+  if(zones[activeZone].length>=3&&pointInPolygon(zones[activeZone],cmx,cmy)){
+    dragAll=true;
+    dragStart={x:cmx,y:cmy};
+    dragOrigPts=zones[activeZone].map(p=>({...p}));
+    return;
+  }
+  // Add point
+  if(zones[activeZone].length<MAX_PTS){
+    zones[activeZone].push({x:Math.round(cmx),y:Math.round(cmy)});
+    draw();
+  }
+});
+
+cv.addEventListener('mousemove',e=>{
+  const rect=cv.getBoundingClientRect();
+  const mx=(e.clientX-rect.left)*devicePixelRatio;
+  const my=(e.clientY-rect.top)*devicePixelRatio;
+  if(dragIdx>=0){
+    const[cmx,cmy]=canvasToCm(mx,my);
+    zones[dragZone][dragIdx]={x:Math.round(cmx),y:Math.round(cmy)};
+    draw();
+  }else if(dragAll&&dragStart){
+    const[cmx,cmy]=canvasToCm(mx,my);
+    const dx=cmx-dragStart.x,dy=cmy-dragStart.y;
+    zones[activeZone]=dragOrigPts.map(p=>({x:Math.round(p.x+dx),y:Math.round(p.y+dy)}));
+    draw();
+  }
+});
+
+cv.addEventListener('mouseup',()=>{dragIdx=-1;dragZone=-1;dragAll=false;dragStart=null;dragOrigPts=null});
+cv.addEventListener('mouseleave',()=>{dragIdx=-1;dragZone=-1;dragAll=false;dragStart=null;dragOrigPts=null});
+
+cv.addEventListener('contextmenu',e=>{
+  e.preventDefault();
+  const rect=cv.getBoundingClientRect();
+  const mx=(e.clientX-rect.left)*devicePixelRatio;
+  const my=(e.clientY-rect.top)*devicePixelRatio;
+  const hit=hitVertex(mx,my);
+  if(hit){
+    zones[hit.zone].splice(hit.idx,1);
+    draw();
+  }
+});
+
+// Touch support
+cv.addEventListener('touchstart',e=>{
+  e.preventDefault();
+  const t=e.touches[0];
+  cv.dispatchEvent(new MouseEvent('mousedown',{clientX:t.clientX,clientY:t.clientY,button:0}));
+},{passive:false});
+cv.addEventListener('touchmove',e=>{
+  e.preventDefault();
+  const t=e.touches[0];
+  cv.dispatchEvent(new MouseEvent('mousemove',{clientX:t.clientX,clientY:t.clientY}));
+},{passive:false});
+cv.addEventListener('touchend',()=>{cv.dispatchEvent(new MouseEvent('mouseup',{}))});
+
+// API
+const FETCH_OPTS={headers:{'Connection':'close'}};
+async function apiGet(path){
+  const r=await fetch(BASE+path,FETCH_OPTS);
+  if(!r.ok)throw new Error(r.statusText);
+  return r.json();
+}
+async function apiPatch(path,payload){
+  const r=await fetch(BASE+path,{method:'PATCH',headers:{'Content-Type':'application/json','Connection':'close'},body:JSON.stringify(payload)});
+  if(!r.ok)throw new Error(r.statusText);
+  return r.json();
+}
+let saving=false;
+async function flushPrefs(){await fetch(BASE+'/api/v1/save',{method:'POST',...FETCH_OPTS})}
+
+async function loadAll(){
+  const cfg=await apiGet('/api/v1/ld2450/config');
+  for(let z=0;z<3;z++)zones[z]=cfg.zones&&cfg.zones[z]?cfg.zones[z].map(p=>({x:p.x,y:p.y})):[];
+  zones[3]=cfg.exclusion?cfg.exclusion.map(p=>({x:p.x,y:p.y})):[];
+  detRange=cfg.detection_range||0;
+  document.getElementById('rangeInput').value=Math.round(detRange);
+  timeout=cfg.timeout||0;
+  document.getElementById('timeoutInput').value=Math.round(timeout);
+  const sv=Math.round(cfg.stability||5);
+  document.getElementById('stabilitySlider').value=sv;
+  document.getElementById('stabilityVal').textContent=sv;
+  const mtOn=cfg.multi_target===true;
+  document.getElementById('multiTargetToggle').checked=mtOn;
+  document.getElementById('multiTargetLabel').textContent=mtOn?'ON':'OFF';
+  const btOn=cfg.bluetooth===true;
+  document.getElementById('btToggle').checked=btOn;
+  document.getElementById('btLabel').textContent=btOn?'ON':'OFF';
+  draw();
+}
+
+async function saveZone(z){
+  if(z<3){
+    const zonesPayload=[zones[0],zones[1],zones[2]].map(arr=>arr.map(p=>({x:Math.round(p.x),y:Math.round(p.y)})));
+    await apiPatch('/api/v1/ld2450/config',{zones:zonesPayload});
+  }else{
+    const exclusion=zones[3].map(p=>({x:Math.round(p.x),y:Math.round(p.y)}));
+    await apiPatch('/api/v1/ld2450/config',{exclusion});
+  }
+}
+
+async function saveCurrentZone(){saving=true;try{await saveZone(activeZone);await flushPrefs()}finally{saving=false}}
+async function saveAllZones(){saving=true;try{for(let z=0;z<ZONES;z++)await saveZone(z);await flushPrefs()}finally{saving=false}}
+function clearCurrentZone(){zones[activeZone]=[];draw()}
+async function saveRange(){
+  const v=parseInt(document.getElementById('rangeInput').value)||0;
+  detRange=v;await apiPatch('/api/v1/ld2450/config',{detection_range:v});await flushPrefs();draw();
+}
+async function saveTimeout(){
+  const v=parseInt(document.getElementById('timeoutInput').value)||0;
+  timeout=v;await apiPatch('/api/v1/ld2450/config',{timeout:v});await flushPrefs();
+}
+async function saveStability(){
+  const v=parseInt(document.getElementById('stabilitySlider').value)||0;
+  await apiPatch('/api/v1/ld2450/config',{stability:v});await flushPrefs();
+}
+async function saveMultiTarget(){
+  const on=document.getElementById('multiTargetToggle').checked;
+  document.getElementById('multiTargetLabel').textContent=on?'ON':'OFF';
+  await apiPatch('/api/v1/ld2450/config',{multi_target:on});
+}
+async function saveBluetooth(){
+  const on=document.getElementById('btToggle').checked;
+  document.getElementById('btLabel').textContent=on?'ON':'OFF';
+  await apiPatch('/api/v1/ld2450/config',{bluetooth:on});
+}
+
+// Polling for live target data
+let pollTimer=null;
+
+async function pollTargets(){
+  if(saving)return;
+  try{
+    const r=await fetch(BASE+'/api/v1/ld2450/live',FETCH_OPTS);
+    if(!r.ok)throw new Error();
+    const d=await r.json();
+    for(let i=0;i<3;i++){
+      targets[i].x=d.targets[i].x;
+      targets[i].y=d.targets[i].y;
+    }
+    if(!connected){
+      connected=true;
+      document.getElementById('statusDot').classList.add('ok');
+    }
+    draw();
+  }catch(e){
+    if(connected){
+      connected=false;
+      document.getElementById('statusDot').classList.remove('ok');
+    }
+  }
+}
+
+async function init(){
+  try{
+    await loadAll();
+    connected=true;
+    document.getElementById('statusDot').classList.add('ok');
+  }catch(e){
+    connected=false;
+  }
+  pollTimer=setInterval(pollTargets,500);
+}
+
+resize();
+init();
+</script>
+</body>
+</html>

--- a/esphome/components/satellite1_radar/tuner_ui/radar_tuner_ld2450.html
+++ b/esphome/components/satellite1_radar/tuner_ui/radar_tuner_ld2450.html
@@ -43,6 +43,14 @@ canvas{display:block;width:100%;height:100%;cursor:crosshair}
 .theme-toggle{margin-left:auto;background:none;border:none;cursor:pointer;padding:4px;border-radius:4px;color:var(--dim);display:flex;align-items:center}
 .theme-toggle:hover{background:var(--border)}
 .theme-toggle svg{width:18px;height:18px;fill:currentColor}
+.notice{display:none;border:1px solid var(--orange);background:color-mix(in srgb,var(--orange) 12%,transparent);border-radius:6px;padding:10px;gap:8px;flex-direction:column}
+.notice.show{display:flex}
+.notice p{font-size:12px;line-height:1.4;color:var(--text)}
+.ui-disabled{opacity:.45;pointer-events:none;filter:saturate(.6)}
+.panel.ui-disabled{opacity:.5;filter:saturate(.65)}
+.panel.ui-disabled *{cursor:not-allowed!important}
+.offline-note{display:none;font-size:12px;color:var(--orange)}
+.offline-note.show{display:block}
 @media(max-width:700px){.wrap{flex-direction:column}.panel{width:100%;max-height:40vh;border-left:none;border-top:1px solid var(--border)}}
 </style>
 </head>
@@ -55,6 +63,7 @@ canvas{display:block;width:100%;height:100%;cursor:crosshair}
 <div class="wrap">
 <div class="canvas-wrap"><canvas id="cv"></canvas></div>
 <div class="panel">
+<p class="offline-note" id="offlineNote">Device offline - controls are disabled.</p>
 <div class="group">
 <label>Max Detection Range (cm)<span class="tooltip">?<span class="tt">Maximum detection range for the LD2450 sensor. The hardware maximum is 600 cm (6 meters). Targets beyond this range are ignored.</span></span></label>
 <div class="row">
@@ -83,6 +92,11 @@ canvas{display:block;width:100%;height:100%;cursor:crosshair}
 <label class="toggle"><input type="checkbox" id="multiTargetToggle" onchange="saveMultiTarget()"><span class="slider"></span></label>
 <span id="multiTargetLabel" style="font-size:12px;color:var(--dim)">OFF</span>
 </div>
+</div>
+<div class="notice" id="rebootNotice">
+<p><b>Reboot required.</b> Configuration changes are saved, but require a device reboot to take effect in Home Assistant.</p>
+<p>Note: after reboot, the mmWave config UI will be disabled until it is enabled again from Home Assistant.</p>
+<button class="btn btn-danger" onclick="requestReboot()">Reboot Device</button>
 </div>
 <div class="group">
 <label>Bluetooth<span class="tooltip">?<span class="tt">Enable or disable the radar module's Bluetooth radio.</span></span></label>
@@ -152,7 +166,17 @@ let targets=[{x:0,y:0},{x:0,y:0},{x:0,y:0}];
 let detRange=0;
 let timeout=0;
 let connected=false;
+let rebootRequired=false;
 let W,H,cx,cy,scale;
+
+function setUiEnabled(enabled){
+  const panel=document.querySelector('.panel');
+  panel.classList.toggle('ui-disabled',!enabled);
+  const interactive=document.querySelectorAll('.panel .btn,.panel input');
+  interactive.forEach(el=>{el.disabled=!enabled});
+  document.getElementById('offlineNote').classList.toggle('show',!enabled);
+  document.getElementById('cv').classList.toggle('ui-disabled',!enabled);
+}
 
 function resize(){
   const r=cv.parentElement.getBoundingClientRect();
@@ -243,6 +267,7 @@ function updateCoords(){
 }
 
 function selectZone(z){
+  if(!connected)return;
   activeZone=z;
   document.querySelectorAll('.zone-btns .btn').forEach((b,i)=>{
     b.classList.toggle('active',i===z);
@@ -271,6 +296,7 @@ function pointInPolygon(pts,x,y){
 }
 
 cv.addEventListener('mousedown',e=>{
+  if(!connected)return;
   if(e.button===2)return;
   const rect=cv.getBoundingClientRect();
   const mx=(e.clientX-rect.left)*devicePixelRatio;
@@ -297,6 +323,7 @@ cv.addEventListener('mousedown',e=>{
 });
 
 cv.addEventListener('mousemove',e=>{
+  if(!connected)return;
   const rect=cv.getBoundingClientRect();
   const mx=(e.clientX-rect.left)*devicePixelRatio;
   const my=(e.clientY-rect.top)*devicePixelRatio;
@@ -316,6 +343,7 @@ cv.addEventListener('mouseup',()=>{dragIdx=-1;dragZone=-1;dragAll=false;dragStar
 cv.addEventListener('mouseleave',()=>{dragIdx=-1;dragZone=-1;dragAll=false;dragStart=null;dragOrigPts=null});
 
 cv.addEventListener('contextmenu',e=>{
+  if(!connected)return;
   e.preventDefault();
   const rect=cv.getBoundingClientRect();
   const mx=(e.clientX-rect.left)*devicePixelRatio;
@@ -329,11 +357,13 @@ cv.addEventListener('contextmenu',e=>{
 
 // Touch support
 cv.addEventListener('touchstart',e=>{
+  if(!connected)return;
   e.preventDefault();
   const t=e.touches[0];
   cv.dispatchEvent(new MouseEvent('mousedown',{clientX:t.clientX,clientY:t.clientY,button:0}));
 },{passive:false});
 cv.addEventListener('touchmove',e=>{
+  if(!connected)return;
   e.preventDefault();
   const t=e.touches[0];
   cv.dispatchEvent(new MouseEvent('mousemove',{clientX:t.clientX,clientY:t.clientY}));
@@ -354,6 +384,10 @@ async function apiPatch(path,payload){
 }
 let saving=false;
 async function flushPrefs(){await fetch(BASE+'/api/v1/save',{method:'POST',...FETCH_OPTS})}
+function setRebootRequired(required){
+  rebootRequired=required===true;
+  document.getElementById('rebootNotice').classList.toggle('show',rebootRequired);
+}
 
 async function loadAll(){
   const cfg=await apiGet('/api/v1/ld2450/config');
@@ -372,10 +406,22 @@ async function loadAll(){
   const btOn=cfg.bluetooth===true;
   document.getElementById('btToggle').checked=btOn;
   document.getElementById('btLabel').textContent=btOn?'ON':'OFF';
+  setRebootRequired(cfg.reboot_required===true);
   draw();
 }
 
+async function requestReboot(){
+  if(!connected)return;
+  document.getElementById('rebootNotice').classList.remove('show');
+  const status=document.getElementById('statusDot');
+  status.classList.remove('ok');
+  connected=false;
+  setUiEnabled(false);
+  await fetch(BASE+'/api/v1/reboot',{method:'POST',...FETCH_OPTS});
+}
+
 async function saveZone(z){
+  if(!connected)return;
   if(z<3){
     const zonesPayload=[zones[0],zones[1],zones[2]].map(arr=>arr.map(p=>({x:Math.round(p.x),y:Math.round(p.y)})));
     await apiPatch('/api/v1/ld2450/config',{zones:zonesPayload});
@@ -387,25 +433,32 @@ async function saveZone(z){
 
 async function saveCurrentZone(){saving=true;try{await saveZone(activeZone);await flushPrefs()}finally{saving=false}}
 async function saveAllZones(){saving=true;try{for(let z=0;z<ZONES;z++)await saveZone(z);await flushPrefs()}finally{saving=false}}
-function clearCurrentZone(){zones[activeZone]=[];draw()}
+function clearCurrentZone(){if(!connected)return;zones[activeZone]=[];draw()}
 async function saveRange(){
+  if(!connected)return;
   const v=parseInt(document.getElementById('rangeInput').value)||0;
   detRange=v;await apiPatch('/api/v1/ld2450/config',{detection_range:v});await flushPrefs();draw();
 }
 async function saveTimeout(){
+  if(!connected)return;
   const v=parseInt(document.getElementById('timeoutInput').value)||0;
   timeout=v;await apiPatch('/api/v1/ld2450/config',{timeout:v});await flushPrefs();
 }
 async function saveStability(){
+  if(!connected)return;
   const v=parseInt(document.getElementById('stabilitySlider').value)||0;
   await apiPatch('/api/v1/ld2450/config',{stability:v});await flushPrefs();
 }
 async function saveMultiTarget(){
+  if(!connected)return;
   const on=document.getElementById('multiTargetToggle').checked;
   document.getElementById('multiTargetLabel').textContent=on?'ON':'OFF';
-  await apiPatch('/api/v1/ld2450/config',{multi_target:on});
+  const res=await apiPatch('/api/v1/ld2450/config',{multi_target:on});
+  await flushPrefs();
+  setRebootRequired(res.reboot_required===true);
 }
 async function saveBluetooth(){
+  if(!connected)return;
   const on=document.getElementById('btToggle').checked;
   document.getElementById('btLabel').textContent=on?'ON':'OFF';
   await apiPatch('/api/v1/ld2450/config',{bluetooth:on});
@@ -427,12 +480,15 @@ async function pollTargets(){
     if(!connected){
       connected=true;
       document.getElementById('statusDot').classList.add('ok');
+      setUiEnabled(true);
+      try{await loadAll()}catch(_e){}
     }
     draw();
   }catch(e){
     if(connected){
       connected=false;
       document.getElementById('statusDot').classList.remove('ok');
+      setUiEnabled(false);
     }
   }
 }
@@ -442,8 +498,10 @@ async function init(){
     await loadAll();
     connected=true;
     document.getElementById('statusDot').classList.add('ok');
+    setUiEnabled(true);
   }catch(e){
     connected=false;
+    setUiEnabled(false);
   }
   pollTimer=setInterval(pollTargets,500);
 }


### PR DESCRIPTION
### Summary
- Introduces satellite1_radar as a re-implementation/replacement of the upstream ld2410 and ld2450 components.
- Adds runtime radar auto-detection so one firmware can adapt to the connected mmWave hardware.
- Eliminates the operational need to ship separate firmware variants for LD2410, LD2450, or no mmWave.
- Backwards compatibility by keeping the ld2410 & ld2450 yaml configurations and firmware builds.