### PR TITLE
ci: Move to tag-driven draft releases and improve changelog quality

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,39 @@
+{
+  "template": "## What's New\n\n#{{CHANGELOG}}",
+  "pr_template": "- #{{TITLE}} (#{{NUMBER}})",
+  "empty_template": "- No customer-facing changes.",
+  "categories": [
+    {
+      "title": "## Features",
+      "labels": ["feature", "enhancement"]
+    },
+    {
+      "title": "## Improvements",
+      "labels": ["improvement", "performance", "hardware"]
+    },
+    {
+      "title": "## Fixes",
+      "labels": ["fix", "bug"]
+    },
+    {
+      "title": "## Breaking Changes / Migration Notes",
+      "labels": ["breaking", "migration"]
+    },
+    {
+      "title": "## Internal",
+      "labels": ["internal"]
+    }
+  ],
+  "exclude_labels": [
+    "skip-changelog",
+    "chore",
+    "ci",
+    "refactor",
+    "dependencies",
+    "sync"
+  ],
+  "sort": {
+    "order": "ASC",
+    "on_property": "mergedAt"
+  }
+}

--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -4,21 +4,47 @@ on:
   push:
     branches:
       - develop
+      - staging
+      - main
+  pull_request:
+    branches:
+      - staging
+      - main
   workflow_dispatch:
 
 env:
   DEFAULT_PYTHON: "3.9"
 
 jobs:
+  resolve-esphome-version:
+    name: Resolve ESPHome version
+    runs-on: ubuntu-latest
+    outputs:
+      esphome-version: ${{ steps.resolve.outputs.esphome_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read ESPHome version from requirements.txt
+        id: resolve
+        run: |
+          version=$(grep -E '^esphome==' requirements.txt | cut -d'=' -f3)
+          if [ -z "$version" ]; then
+            echo "Failed to resolve ESPHome version from requirements.txt"
+            exit 1
+          fi
+          echo "esphome_version=$version" >> "$GITHUB_OUTPUT"
 
   build-firmware:
+    needs:
+      - resolve-esphome-version
     uses: ./.github/workflows/build.yaml
     with:
       files: |
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2026.3.3
+      esphome-version: ${{ needs.resolve-esphome-version.outputs.esphome-version }}
       release-summary: develop-branch
       release-url:
       release-version:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -2,15 +2,9 @@ name: Build-and-Release-Satellite-Firmware
 
 on:
   push:
-    branches:
-      - main
-      - staging
-  
+    tags:
+      - v*
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag for the release (optional). If not provided, it will be auto-generated.'
-        required: false
 
 env:
   DEFAULT_PYTHON: "3.9"
@@ -23,52 +17,45 @@ jobs:
     outputs:
       commit_id: ${{ steps.dump.outputs.commit }}
       previous_tag: ${{ steps.dump.outputs.previous_tag }}
-      next_tag: ${{ steps.set_release_tag.outputs.release_tag }}
+      next_tag: ${{ steps.tag.outputs.release_tag }}
+      esphome_version: ${{ steps.esphome.outputs.esphome_version }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
-      
-      - name: Set Manual Tag (if provided)
-        id: set_tag
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
-        run: echo "manual_tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
 
-      - name: Bump version
-        # if manual tag is provided, use it
-        if: ${{ !steps.set_tag.outputs.manual_tag }}
-        uses: anothrNick/github-tag-action@1.70.0
-        id: bump
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # To create a major bump add #major to commit message
-          DEFAULT_BUMP: 'patch'
-          WITH_V: true
-          PRERELEASE: ${{ github.ref_name != 'main' }}
-          PRERELEASE_SUFFIX: ${{ github.ref_name == 'staging' && 'beta' || 'alpha' }}
-          DRY_RUN: true # Prevent action from pushing the tag.
-          INITIAL_VERSION: 0.0.0
-
-      - name: Set tag for release
-        if: ${{ steps.set_tag.outputs.manual_tag || steps.bump.outputs.tag }}
-        id: set_release_tag
+      - name: Resolve release tag
+        id: tag
         run: |
-            if [ -z "${{ steps.set_tag.outputs.manual_tag }}" ]; then
-              echo "release_tag=${{ steps.bump.outputs.tag }}" >> $GITHUB_OUTPUT
-            else
-              echo "release_tag=${{ steps.set_tag.outputs.manual_tag }}" >> $GITHUB_OUTPUT
-            fi
+          tag="${{ github.ref_name }}"
+          if [ -z "$tag" ]; then
+            echo "Release tag is empty"
+            exit 1
+          fi
+          if ! printf '%s' "$tag" | grep -Eq '^v'; then
+            echo "Release workflows must run on a tag ref that starts with v"
+            exit 1
+          fi
+          echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Read ESPHome version from requirements.txt
+        id: esphome
+        run: |
+          version=$(grep -E '^esphome==' requirements.txt | cut -d'=' -f3)
+          if [ -z "$version" ]; then
+            echo "Failed to resolve ESPHome version from requirements.txt"
+            exit 1
+          fi
+          echo "esphome_version=$version" >> "$GITHUB_OUTPUT"
 
       - id: dump
         name: Set outputs
         run: |
-          echo "gh_env=${{ github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'beta' || 'alpha' }}" >> $GITHUB_OUTPUT
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "long_version=${{ steps.set_release_tag.outputs.release_tag }}_$(date +%Y-%m-%d)_$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "label_version=$(echo "${{ steps.set_release_tag.outputs.release_tag }}" | sed 's/\./dot/g' | sed 's/-/dash/g')" >> $GITHUB_OUTPUT
-          echo "previous_tag=$(git describe --abbrev=0 --tags)" >> $GITHUB_OUTPUT
+          previous_tag=$(git tag --sort=-version:refname | grep '^v' | grep -Fxv "${{ steps.tag.outputs.release_tag }}" | sed -n '1p')
+          echo "previous_tag=$previous_tag" >> "$GITHUB_OUTPUT"
 
   build-firmware:
     name: Build Firmware
@@ -80,11 +67,11 @@ jobs:
         config/satellite1.yaml
         config/satellite1.ld2410.yaml
         config/satellite1.ld2450.yaml
-      esphome-version: 2026.3.3
+      esphome-version: ${{ needs.prepare.outputs.esphome_version }}
       release-version: ${{ needs.prepare.outputs.next_tag }}
 
-  push-tag:
-    name: Push tag to repository and build changelog.
+  build-changelog:
+    name: Build changelog
     needs:
       - prepare
       - build-firmware
@@ -97,54 +84,27 @@ jobs:
         with:
               fetch-depth: 0
               ref: ${{ github.ref }}
-      
-      - name: Create Manual Tag (if provided and does not exist)
-        id: crate_manual_tag
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
+
+      - name: Ensure tag exists remotely
         run: |
-          tag="${{ github.event.inputs.tag }}"
-
-          # Fetch tags from remote
           git fetch --tags
-
-          if git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "Tag '$tag' already exists."
-          else
-            echo "Creating tag '$tag'"
-            git config user.name "github-actions"
-            git config user.email "github-actions@github.com"
-            git tag "$tag"
-            git push origin "$tag"
+          if ! git rev-parse "refs/tags/${{ needs.prepare.outputs.next_tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ needs.prepare.outputs.next_tag }} does not exist."
+            exit 1
           fi
-
-          echo "manual_tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Bump version and push tag
-        if: ${{ !github.event.inputs.tag }}
-        uses: anothrNick/github-tag-action@1.70.0
-        id: bump
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # To create a major bump add #major to commit message
-          DEFAULT_BUMP: 'patch'
-          WITH_V: true
-          PRERELEASE: ${{ github.ref_name != 'main' }}
-          PRERELEASE_SUFFIX: ${{ github.ref_name == 'staging' && 'beta' || 'alpha' }}
-          DRY_RUN: false # Set the tag to the commit.
-          INITIAL_VERSION: 0.0.0
 
       - name: Release Changelog Builder
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           fromTag: ${{ needs.prepare.outputs.previous_tag }}
+          toTag: ${{ needs.prepare.outputs.next_tag }}
+          configuration: .github/changelog-configuration.json
 
   create_release:
     name: Create Release
-    # only build release for staging and main branches
-    # if: github.ref_name == 'main' || github.ref_name == 'staging'
     needs:
-      - push-tag
+      - build-changelog
       - prepare
     runs-on: ubuntu-latest
     steps:
@@ -166,13 +126,19 @@ jobs:
           files: |
             build/*.bin
             build/*.elf
-          generate_release_notes: true
-          append_body: true
-          body: ${{ needs.push-tag.outputs.changelog }}
+          draft: true
+          prerelease: ${{ contains(needs.prepare.outputs.next_tag, '-beta') || contains(needs.prepare.outputs.next_tag, '-alpha') }}
+          generate_release_notes: false
+          body: |
+            ## Build Info
+            - ESPHome Version: ${{ needs.prepare.outputs.esphome_version }}
+            - Commit: `${{ needs.prepare.outputs.commit_id }}`
+
+            ${{ needs.build-changelog.outputs.changelog }}
           tag_name: ${{ needs.prepare.outputs.next_tag }}
 
       - name: Update Documentation
-        if: ${{ github.ref_name == 'main' || github.ref_name == 'staging' }}
+        if: ${{ !contains(needs.prepare.outputs.next_tag, '-beta') && !contains(needs.prepare.outputs.next_tag, '-alpha') }}
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \

--- a/docs/pr-review-merge-and-release-workflow.md
+++ b/docs/pr-review-merge-and-release-workflow.md
@@ -1,0 +1,135 @@
+# PR, Promotion, and Release Workflow
+
+This repository uses two workflows:
+
+- `build_latest`: validation builds on pushes and PRs.
+- `build_release`: tag-driven release builds that create draft GitHub releases.
+
+## 1) PRs into `develop` (feature and fix intake)
+
+This is the primary point where release categorization is defined.
+
+### Goals
+
+- Keep changes reviewable and scoped.
+- Set release category labels once on the original PR.
+- Use clear PR titles so release notes are customer-readable.
+
+### Branch naming best practice
+
+- Use short, purpose-first names.
+- Examples: `fix/snapcast-reconnect-race`, `feature/radar-autodetect`, `improvement/wifi-buffer-tuning`.
+
+### PR title best practice
+
+- Write titles in customer-facing language.
+- Good: `Fix snapcast reconnect race that could stall playback`
+- Good: `Add LD2450 auto-detect fallback for startup recovery`
+- Avoid: `wip`, `misc changes`, `cleanup`.
+
+### Required labels on PRs to `develop`
+
+Add at least one release category label:
+
+- `feature` or `enhancement`
+- `improvement` or `performance` or `hardware`
+- `fix` or `bug`
+- `breaking` or `migration`
+- `internal` (for non-customer-facing changes)
+
+Optional label:
+
+- `skip-changelog` for CI/admin/sync-only work that should not appear in customer notes.
+
+### Merge best practice for `develop`
+
+- Wait for `build_latest` checks to pass.
+- Prefer merge behavior that preserves commit-to-PR traceability.
+- Avoid unnecessary history rewrites on release-path commits.
+
+Why this matters: release notes are generated later from tag commit ranges, and the changelog action resolves commit SHAs back to their original PR labels.
+
+## 2) Promotion PRs (`develop -> staging` and `staging -> main`)
+
+Promotion PRs should not duplicate feature categorization.
+
+- Categories come from the original PRs merged into `develop`.
+- Promotion PRs are operational wrappers and should be labeled accordingly.
+
+### Promote `develop` to `staging` (beta lane)
+
+- Open PR: `develop -> staging`.
+- Ensure `build_latest` checks are green on the PR.
+- Label as `promotion` or `sync`.
+- Add `skip-changelog` if the PR is only a branch promotion wrapper.
+- Use a clear title such as `Promote develop to staging for beta candidate`.
+
+### Promote `staging` to `main` (production lane)
+
+- Open PR: `staging -> main`.
+- Ensure `build_latest` checks are green on the PR.
+- Label as `promotion` or `sync`.
+- Add `skip-changelog` when appropriate.
+- Use a clear title such as `Promote staging to main for production candidate`.
+
+### If GitHub says `staging` is out of date with `main`
+
+Create a dedicated sync PR from `main` back into `staging`:
+
+```bash
+git fetch origin
+git checkout -b sync/staging-with-main origin/staging
+git merge --no-ff origin/main
+git push -u origin sync/staging-with-main
+```
+
+Then open PR `sync/staging-with-main -> staging` and merge with `[skip ci]` when allowed by branch protection.
+
+## 3) Release flow (tag-driven)
+
+Releases are triggered by tags, not by PR labels.
+
+### Beta release from `staging`
+
+1. Confirm latest `build_latest` on `staging` is green.
+2. Tag the exact release commit:
+
+```bash
+git fetch origin
+git checkout staging
+git pull
+git tag -a vX.Y.Z-beta.N -m "vX.Y.Z-beta.N"
+git push origin vX.Y.Z-beta.N
+```
+
+3. `build_release` runs from the tag and creates a draft prerelease.
+4. Review/edit notes, then publish.
+
+### Production release from `main`
+
+1. Confirm latest `build_latest` on `main` is green.
+2. Tag the exact release commit:
+
+```bash
+git fetch origin
+git checkout main
+git pull
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+3. `build_release` runs from the tag and creates a draft release.
+4. Review/edit notes, then publish.
+
+## 4) ESPHome version handling
+
+- `requirements.txt` is the single source of truth for ESPHome version.
+- Workflows derive the build version from `requirements.txt`.
+- Release notes include resolved ESPHome version in `Build Info`.
+
+
+## 5) Quick troubleshooting
+
+- Release workflow fails with "must run on a tag ref": run release from a pushed `v*` tag, not a branch.
+- Changelog is noisy: verify original PR labels and apply `skip-changelog` to sync/CI/admin PRs.
+- `staging -> main` says out of date: run a dedicated `main -> staging` sync PR first.


### PR DESCRIPTION
Summary
- Refactor release automation to run on pushed version tags (v*) instead of branch pushes.
- Keep branch CI validation in build_latest, now covering pushes to develop, staging, and main, plus PRs into staging/main.
- Add label-based changelog categorization and a team workflow guide for PR labeling, promotion, and beta/stable releases.
Why
- Prevent accidental beta/stable releases when syncing or promoting branches.
- Improve customer-facing release notes by grouping entries via PR labels and excluding internal noise.
- Keep release publication controlled with draft releases that can be reviewed before publishing.
What Changed
- build_latest
  - Runs on push to develop, staging, main
  - Runs on PRs targeting staging and main
  - Derives ESPHome version from requirements.txt and passes it into the shared build workflow
- build_release
  - Trigger changed to tag-based (push.tags: v*)
  - Removed automatic tag creation/pushing logic
  - Still rebuilds artifacts from the release tag
  - Creates draft GitHub releases
  - Marks prerelease automatically for -beta / -alpha tags
  - Includes build metadata (ESPHome Version, commit SHA) in release body
- Changelog config
  - Added .github/changelog-configuration.json
  - Category mapping via PR labels
  - Excludes internal/sync/CI noise labels
- Docs
  - Added docs/pr-review-merge-and-release-workflow.md
  - Documents best practices for:
    - PRs into develop (labels, naming, titles)
    - Promotion flow to staging/main
    - Tag-driven beta/production release process
Operational Notes
- Releases are now intentional and tag-driven.
- Draft releases are private until published.
- Label discipline on PRs into develop is required for best changelog quality.
