### PR TITLE
ci: add dashboard import smoke compile on develop

### DIFF
--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -68,6 +68,19 @@ jobs:
           echo "Configured package/external component refs:"
           grep -nE '(^\s*ref:|ext_comp_repo_ref:)' dashboard-smoke/satellite1.dashboard.yaml
 
+      - name: Rewrite dashboard package ref to current branch
+        run: |
+          branch="${{ github.ref_name }}"
+          if [ -z "$branch" ]; then
+            echo "Failed to resolve current branch"
+            exit 1
+          fi
+
+          sed -i -E "s|^(\s*ref:\s*&repo_ref\s*\").*(\")$|\1${branch}\2|" dashboard-smoke/satellite1.dashboard.yaml
+
+          echo "Dashboard package ref rewritten to: $branch"
+          grep -nE '^\s*ref:\s*&repo_ref' dashboard-smoke/satellite1.dashboard.yaml
+
       - name: Build dashboard import config
         uses: esphome/build-action@v7.0.0
         with:

--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -53,7 +53,7 @@ jobs:
     name: Build dashboard import smoke test
     needs:
       - resolve-esphome-version
-    if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
+    if: ${{ (github.event_name == 'push' && github.ref_name == 'develop') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download dashboard import config from current commit

--- a/.github/workflows/build_latest.yaml
+++ b/.github/workflows/build_latest.yaml
@@ -49,6 +49,31 @@ jobs:
       release-url:
       release-version:
 
+  build-dashboard-import-smoke:
+    name: Build dashboard import smoke test
+    needs:
+      - resolve-esphome-version
+    if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dashboard import config from current commit
+        run: |
+          mkdir -p dashboard-smoke
+          url="https://raw.githubusercontent.com/FutureProofHomes/Satellite1-ESPHome/${{ github.sha }}/config/satellite1.dashboard.yaml"
+          curl -fsSL "$url" -o dashboard-smoke/satellite1.dashboard.yaml
+
+      - name: Show dashboard import refs
+        run: |
+          echo "Dashboard config source commit: ${{ github.sha }}"
+          echo "Configured package/external component refs:"
+          grep -nE '(^\s*ref:|ext_comp_repo_ref:)' dashboard-smoke/satellite1.dashboard.yaml
+
+      - name: Build dashboard import config
+        uses: esphome/build-action@v7.0.0
+        with:
+          yaml-file: dashboard-smoke/satellite1.dashboard.yaml
+          version: ${{ needs.resolve-esphome-version.outputs.esphome-version }}
+
 
   create_artifact_matrix:
     name: Create artifact matrix


### PR DESCRIPTION
Compile config/satellite1.dashboard.yaml from raw GitHub on develop pushes to validate the dashboard import path in a clean context. Log the resolved package and external component refs for easier troubleshooting.