### PR TITLE
ci: dispatch docs update on published releases

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -136,14 +136,3 @@ jobs:
 
             ${{ needs.build-changelog.outputs.changelog }}
           tag_name: ${{ needs.prepare.outputs.next_tag }}
-
-      - name: Update Documentation
-        if: ${{ !contains(needs.prepare.outputs.next_tag, '-beta') && !contains(needs.prepare.outputs.next_tag, '-alpha') }}
-        run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PAT_TOKEN }}" \
-            https://api.github.com/repos/FutureProofHomes/Documentation/actions/workflows/update-binaries-esp32.yaml/dispatches \
-            -d '{"ref":"main", "inputs": {"esphome_release_tag": "${{ needs.prepare.outputs.next_tag }}"}}'
-        env:
-          SECOND_REPO_PAT: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/release_published_dispatch_docs.yaml
+++ b/.github/workflows/release_published_dispatch_docs.yaml
@@ -1,0 +1,24 @@
+name: Dispatch Documentation Update On Release Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch-docs-update:
+    name: Dispatch docs update
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-alpha') && (!contains(github.event.release.tag_name, '-') || contains(github.event.release.tag_name, '-beta')) }}
+    steps:
+      - name: Show release context
+        run: |
+          echo "Published tag: ${{ github.event.release.tag_name }}"
+          echo "Prerelease flag: ${{ github.event.release.prerelease }}"
+
+      - name: Dispatch Documentation workflow
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT_TOKEN }}" \
+            https://api.github.com/repos/FutureProofHomes/Documentation/actions/workflows/update-binaries-esp32.yaml/dispatches \
+            -d '{"ref":"main", "inputs": {"esphome_release_tag": "${{ github.event.release.tag_name }}"}}'


### PR DESCRIPTION
## Summary
This PR moves the Documentation repository dispatch out of the tag-build workflow and triggers it only after a GitHub release is actually published.
## Why
- Prevents downstream artifact sync from happening when a release is still in draft.
- Aligns Documentation updates with the real public release event.
- Keeps manual review/edit of draft release notes as a required gate.
## What Changed
- Removed Documentation dispatch from .github/workflows/build_release.yaml.
- Added .github/workflows/release_published_dispatch_docs.yaml:
  - Trigger: release event with types: [published]
  - Dispatches Documentation workflow only for:
    - stable tags (vX.Y.Z)
    - beta tags (vX.Y.Z-beta.N)
  - Explicitly skips alpha tags (vX.Y.Z-alpha.N)
## Resulting Behavior
- Tag push (v*) still creates/updates draft release assets in this repo.
- Documentation repo is not triggered at tag time.
- Documentation repo is triggered only when the release is published in GitHub.