### PR TITLE
CI: Add changelog category for dashboard builder users

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -20,6 +20,10 @@
       "labels": ["breaking", "migration"]
     },
     {
+      "title": "## Dashboard Builder",
+      "labels": ["dashboard-builder"]
+    },
+    {
       "title": "## Internal",
       "labels": ["internal"]
     }


### PR DESCRIPTION
- Add a new changelog category for changes that impact users building their own firmware via the ESPHome Dashboard Builder.
