### PR TITLE
fix: Removed resampler from external imports

### DIFF
--- a/config/common/components.external.yaml
+++ b/config/common/components.external.yaml
@@ -12,7 +12,6 @@ external_components:
       - i2s_audio
       - memory_flasher
       - pcm5122
-      - resampler
       - satellite1
       - tas2780
 


### PR DESCRIPTION
The customized resampler component has been removed from this repo but is still referenced in components.external.yaml which prevents dashboard builds to compile successfully.

This PR fixes this.