### PR TITLE
i2s-audio: fixes closing the wrong i2s channel

### DIFF
--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -232,11 +232,8 @@ bool I2SAudioIn::stop_i2s_channel_() {
     ESP_LOGE(TAG, "Trying to stop I2S-RX channel, but handle is nullptr.");
     return false;
   }
-  if (this->parent_->rx_handle_ == nullptr) {
-    return false;
-  }
 
-  esp_err_t err = i2s_channel_disable(this->parent_->tx_handle_);
+  esp_err_t err = i2s_channel_disable(this->parent_->rx_handle_);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to disable RX channel: %s", esp_err_to_name(err));
     return false;


### PR DESCRIPTION
Fixed an RX/Tx handle mix-up in i2s_audio channel teardown: the input stop path (I2SAudioIn::stop_i2s_channel_()) was disabling tx_handle_ instead of rx_handle_. 