### PR TITLE
components.external: set refresh rate to 300s

### DIFF
--- a/config/common/components.external.yaml
+++ b/config/common/components.external.yaml
@@ -7,6 +7,7 @@ external_components:
       type: git
       url: ${ext_comp_repo_url}
       ref: ${ext_comp_repo_ref}
+    refresh: 300s
     components:
       - fusb302b
       - i2s_audio


### PR DESCRIPTION
makes sure that external components get updated for the dashboard esphome builder.