### PR TITLE
fix: Sendspin for dashboard builds

### DIFF
--- a/config/common/components.external.yaml
+++ b/config/common/components.external.yaml
@@ -7,7 +7,7 @@ external_components:
       type: git
       url: ${ext_comp_repo_url}
       ref: ${ext_comp_repo_ref}
-    refresh: 300s
+    refresh: 1s
     components:
       - fusb302b
       - i2s_audio

--- a/config/common/sendspin.yaml
+++ b/config/common/sendspin.yaml
@@ -8,6 +8,8 @@ external_components:
     components: [const, media_source, sendspin]
     refresh: 300s
 
+http_request:
+
 sendspin:
   id: sendspin_hub
   task_stack_in_psram: true
@@ -19,3 +21,9 @@ media_source:
 media_player:
   - platform: sendspin
     id: sendspin_group_media_player
+
+  - platform: speaker_source
+    id: !extend external_media_player
+    media_pipeline:
+      sources:
+        - sendspin_media_source

--- a/config/satellite1.dashboard.yaml
+++ b/config/satellite1.dashboard.yaml
@@ -14,7 +14,7 @@ esphome:
 packages:
   FutureProofHomes.Satellite1:
     url: &repo_url "https://github.com/futureproofhomes/satellite1-esphome"
-    ref: &repo_ref "develop"
+    ref: &repo_ref "staging"
     refresh: 1s
     files:
       # Main config files, don't remove

--- a/config/satellite1.dashboard.yaml
+++ b/config/satellite1.dashboard.yaml
@@ -14,23 +14,17 @@ esphome:
 packages:
   FutureProofHomes.Satellite1:
     url: &repo_url "https://github.com/futureproofhomes/satellite1-esphome"
-    ref: &repo_ref "staging"
+    ref: &repo_ref "develop"
     refresh: 1s
     files:
       # Main config files, don't remove
       - config/satellite1.base.yaml
       - config/common/dashboard_build.yaml
+      - config/common/sendspin.yaml
       - path: config/common/components.external.yaml
         vars:
           ext_comp_repo_url: *repo_url
           ext_comp_repo_ref: *repo_ref
-
-      # yamllint disable rule:comments-indentation
-      # OPTIONALLY, uncomment if you have the smaller LD2410 mmWave sensor connected to your HAT.
-      # - config/common/mmwave_ld2410.yaml
-
-      ## OPTIONALLY, uncomment if you have the larger LD2450 mmWave sensor connected to your HAT.
-      # - config/common/mmwave_ld2450.yaml
 
       ## OPTIONALLY, uncomment if want extra memory, wifi and xmos control of the device.
       # - config/common/debug.yaml
@@ -57,11 +51,6 @@ logger:
 # wifi:
 #   ssid: !secret wifi_ssid
 #   password: !secret wifi_password
-
-## OPTIONALLY, uncomment the following lines to customize the Snapcast server to connect to.
-# snapcast:
-#   id: snapcast_client
-#   server_ip: 192.168.178.101
 
 ## OPTIONALLY, uncomment the following lines to set a custom micro wake word model
 # micro_wake_word:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -67,8 +67,6 @@ esp32_improv:
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
 
-http_request:
-
 ota:
   - platform: http_request
     id: ota_http_request
@@ -116,13 +114,6 @@ external_components:
       ref: ff8ce89556748509d7ee8724e12d9d43d3c8c1e8
     refresh: 300s
     components: [http_request]
-
-media_player:
-  - platform: speaker_source
-    id: !extend external_media_player
-    media_pipeline:
-      sources:
-        - sendspin_media_source
 
 logger:
   deassert_rts_dtr: true


### PR DESCRIPTION
Several fixes for building the firmware with Senspin support from the esphome builder dashboard.