### PR TITLE
Sendspin: move cfg import to satellite1.base.yaml

### DIFF
--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -90,6 +90,7 @@ packages:
   timer: !include common/timer.yaml
   led_ring: !include common/led_ring.yaml
   mmwave: !include common/mmwave.yaml
+  sendspin: !include common/sendspin.yaml
 
   ## OPTIONAL COMPONENTS
   # debug: !include common/debug.yaml

--- a/config/satellite1.dashboard.yaml
+++ b/config/satellite1.dashboard.yaml
@@ -20,7 +20,6 @@ packages:
       # Main config files, don't remove
       - config/satellite1.base.yaml
       - config/common/dashboard_build.yaml
-      - config/common/sendspin.yaml
       - path: config/common/components.external.yaml
         vars:
           ext_comp_repo_url: *repo_url

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -48,7 +48,6 @@ packages:
                 - memory_flasher.write_embedded_image:
 
   home-assistant-voice: !include satellite1.base.yaml
-  sendspin: !include common/sendspin.yaml
 
 esphome:
   project:


### PR DESCRIPTION
For users who already took control of their devices in the dashboard builder the current setup requires modifing the device config to add the sendspin import line.

This PR moves the import to satellite1.base.yaml which get's updated from the upstream version, hence now additional modification needed by the user.