### PR TITLE
core_board: restore WiFi/LWIP/SPIRAM tuning dropped in sendspin migration

### DIFF
--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -25,6 +25,36 @@ esp32:
       CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC: "y"
       CONFIG_MBEDTLS_SSL_PROTO_TLS1_3: "y"  # TLS1.3 support isn't enabled by default in IDF 5.1.5
 
+      # Network + memory tuning that exists on `develop` but was dropped during
+      # the sendspin migration (c9e0f999). Without it the ESP32-S3 falls back to
+      # tiny default LWIP/WiFi buffers, causing unstable Wi-Fi and unreliable OTA
+      # on the Satellite1. Restores the network keys only; does not touch the
+      # cache / MBEDTLS options added in the 2026.5 migration.
+      # SPIRAM placement for wifi+lwip
+      CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: "y"
+      # LWIP
+      CONFIG_LWIP_IRAM_OPTIMIZATION: "y"
+      CONFIG_LWIP_TCPIP_TASK_PRIO: "18"
+      CONFIG_LWIP_TCPIP_TASK_AFFINITY_CPU0: "y"
+      CONFIG_LWIP_TCP_SND_BUF_DEFAULT: "65535"
+      CONFIG_LWIP_TCP_WND_DEFAULT: "65535"
+      CONFIG_LWIP_TCPIP_RECVMBOX_SIZE: "64"
+      CONFIG_LWIP_TCP_RECVMBOX_SIZE: "64"
+      CONFIG_LWIP_UDP_RECVMBOX_SIZE: "64"
+      CONFIG_LWIP_TCP_RTO_TIME: "500"
+      CONFIG_LWIP_TCP_SACK_OUT: "y"
+      CONFIG_LWIP_TCP_OOSEQ_MAX_PBUFS: "8"
+      # WiFi
+      CONFIG_ESP_WIFI_AMPDU_RX_ENABLED: "y"
+      CONFIG_ESP_WIFI_RX_BA_WIN: "32"
+      CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM: "16"
+      CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM: "128"
+      CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM: "64"
+      CONFIG_ESP_WIFI_AMPDU_TX_ENABLED: "y"
+      CONFIG_ESP_WIFI_TX_BA_WIN: "32"
+      # MDNS
+      CONFIG_MDNS_MEMORY_ALLOC_SPIRAM: "y"
+
 psram:
   mode: octal
   speed: 80MHz


### PR DESCRIPTION
Note: additional code co-authored w/Claude while getting my Sat1 working w/ esphome 2026.5

The sendspin migration (c9e0f999) rewrote config/common/core_board.yaml and dropped the WiFi/LWIP/SPIRAM network-and-memory sdkconfig tuning that is still present on `develop`. Without these options the ESP32-S3 uses tiny default LWIP/WiFi buffers, which on the Satellite1 manifests as unstable Wi-Fi and unreliable OTA (full image uploads then times out on the checksum response; device intermittently drops off the network).

Restore the network-relevant keys only (LWIP TCP buffers/mboxes/SACK, WiFi AMPDU + RX/TX buffers, SPIRAM placement for wifi+lwip, mDNS in SPIRAM). This does not re-introduce the board-preset / cache options that the 2026.5 migration intentionally changed.

Verified on ESPHome 2026.5.1 (Satellite1 + LD2450): with this restored

* Wi-Fi is stable;
* OTA completes reliably (without it, OTA repeatedly fails at the checksum step)
* LD2450 works correctly; 
* new Radar Tuner feature works

<img width="355" height="760" alt="image" src="https://github.com/user-attachments/assets/ef7089f8-9551-4bf0-903b-433a7a5456fa" />
<img width="1715" height="976" alt="image" src="https://github.com/user-attachments/assets/79c9dd39-4245-417d-bc9c-587019fc85d1" />
