### PR TITLE
Add wake-word audio UDP streaming for training data capture

### DIFF
--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -1,4 +1,11 @@
 substitutions:
+  # IP address of the machine running the wake-word training-data collector (listens for raw
+  # int16/16kHz/mono PCM over UDP). Override this to point at your recording server.
+  wake_audio_stream_host: "192.168.1.100"
+  wake_audio_stream_port: "6056"
+  # HTTP port of the ingest service's FastAPI app (the /wake_event endpoint).
+  wake_event_http_port: "8000"
+
   # Phases of the Voice Assistant
   # The voice assistant is ready to be triggered by a wake word
   voice_assist_idle_phase_id: '1'
@@ -49,7 +56,22 @@ micro_wake_word:
     channels: 1
     gain_factor: 6
   stop_after_detection: false
+  # Forward the exact audio the wake-word models process to the training-data collector. The stream
+  # component only buffers/sends when its capture switch is on, so this trigger is cheap when idle.
+  on_audio_data:
+    - lambda: id(wake_audio_streamer).push_audio(x);
   on_wake_word_detected:
+    # When capturing training data, tell the ingest service a wake word fired so it can extract a
+    # clip from the UDP audio it is already buffering. Omitting assistant_id lets the service key
+    # the clip by this device's IP, matching how it buffers the UDP audio stream.
+    - if:
+        condition:
+          switch.is_on: wake_audio_capture
+        then:
+          - http_request.post:
+              url: !lambda |-
+                return "http://${wake_audio_stream_host}:${wake_event_http_port}/wake_event?wake_word=" + wake_word;
+              capture_response: false
     # If the wake word is detected when the device is muted (Possible with the software mute switch): Do nothing
     - if:
         condition:
@@ -233,6 +255,15 @@ script:
                 then:
                   - micro_wake_word.disable_model: stop
 
+# Streams the raw wake-word audio over UDP so it can be recorded and labeled as training data
+# (false positive / false negative / background noise / etc.).
+wake_audio_stream:
+  id: wake_audio_streamer
+  ip_address: ${wake_audio_stream_host}
+  port: ${wake_audio_stream_port}
+  buffer_duration: 500ms
+  enabled_on_boot: false
+
 select:
   - platform: template
     id: mww_sensitivity_select
@@ -261,3 +292,20 @@ select:
           id(okay_nabu).set_probability_cutoff(143);    // 0.56 -> 0.751 FAPH on DipCo
           id(hey_jarvis).set_probability_cutoff(212);   // 0.83 -> 1.502 FAPH on DipCo
         }
+
+switch:
+  # Toggle capturing wake-word audio for training data. When on, the raw PCM microWakeWord processes
+  # is streamed over UDP to the configured collector; when off, nothing is buffered or sent.
+  - platform: template
+    id: wake_audio_capture
+    name: "Capture wake-word audio"
+    icon: "mdi:record-rec"
+    entity_category: config
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    on_turn_on:
+      - wake_audio_stream.start:
+          id: wake_audio_streamer
+    on_turn_off:
+      - wake_audio_stream.stop:
+          id: wake_audio_streamer

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -101,10 +101,12 @@ external_components:
       - fusb302b
       - i2s_audio
       - memory_flasher
+      - micro_wake_word
       - pcm5122
       - satellite1
       - satellite1_radar
       - tas2780
+      - wake_audio_stream
 
   - source:
       # https://github.com/esphome/esphome/pull/12429

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -1,0 +1,594 @@
+import hashlib
+import json
+import logging
+from pathlib import Path
+from urllib.parse import urljoin
+
+from esphome import automation, external_files, git
+from esphome.automation import register_action, register_condition
+import esphome.codegen as cg
+from esphome.components import esp32, microphone, ota
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_FILE,
+    CONF_ID,
+    CONF_INTERNAL,
+    CONF_MICROPHONE,
+    CONF_MODEL,
+    CONF_PASSWORD,
+    CONF_PATH,
+    CONF_RAW_DATA_ID,
+    CONF_REF,
+    CONF_REFRESH,
+    CONF_TRIGGER_ID,
+    CONF_TYPE,
+    CONF_URL,
+    CONF_USERNAME,
+    TYPE_GIT,
+    TYPE_LOCAL,
+)
+from esphome.core import CORE, HexInt
+
+_LOGGER = logging.getLogger(__name__)
+
+CODEOWNERS = ["@kahrendt", "@jesserockz"]
+DEPENDENCIES = ["microphone"]
+
+DOMAIN = "micro_wake_word"
+
+
+CONF_FEATURE_STEP_SIZE = "feature_step_size"
+CONF_MODELS = "models"
+CONF_ON_AUDIO_DATA = "on_audio_data"
+CONF_ON_WAKE_WORD_DETECTED = "on_wake_word_detected"
+CONF_PROBABILITY_CUTOFF = "probability_cutoff"
+CONF_SLIDING_WINDOW_AVERAGE_SIZE = "sliding_window_average_size"
+CONF_SLIDING_WINDOW_SIZE = "sliding_window_size"
+CONF_STOP_AFTER_DETECTION = "stop_after_detection"
+CONF_TENSOR_ARENA_SIZE = "tensor_arena_size"
+CONF_VAD = "vad"
+
+TYPE_HTTP = "http"
+
+micro_wake_word_ns = cg.esphome_ns.namespace("micro_wake_word")
+
+MicroWakeWord = micro_wake_word_ns.class_("MicroWakeWord", cg.Component)
+
+DisableModelAction = micro_wake_word_ns.class_("DisableModelAction", automation.Action)
+EnableModelAction = micro_wake_word_ns.class_("EnableModelAction", automation.Action)
+StartAction = micro_wake_word_ns.class_("StartAction", automation.Action)
+StopAction = micro_wake_word_ns.class_("StopAction", automation.Action)
+
+ModelIsEnabledCondition = micro_wake_word_ns.class_(
+    "ModelIsEnabledCondition", automation.Condition
+)
+IsRunningCondition = micro_wake_word_ns.class_(
+    "IsRunningCondition", automation.Condition
+)
+
+WakeWordModel = micro_wake_word_ns.class_("WakeWordModel")
+
+AudioDataTrigger = micro_wake_word_ns.class_(
+    "AudioDataTrigger",
+    automation.Trigger.template(
+        cg.std_vector.template(cg.uint8).operator("ref").operator("const")
+    ),
+)
+
+
+def _validate_json_filename(value):
+    value = cv.string(value)
+    if not value.endswith(".json"):
+        raise cv.Invalid("Manifest filename must end with .json")
+    return value
+
+
+def _process_git_source(config):
+    repo_dir, _ = git.clone_or_update(
+        url=config[CONF_URL],
+        ref=config.get(CONF_REF),
+        refresh=config[CONF_REFRESH],
+        domain=DOMAIN,
+        username=config.get(CONF_USERNAME),
+        password=config.get(CONF_PASSWORD),
+    )
+
+    if not (repo_dir / config[CONF_FILE]).exists():
+        raise cv.Invalid("File does not exist in repository")
+
+    return config
+
+
+CV_GIT_SCHEMA = cv.GIT_SCHEMA
+if isinstance(CV_GIT_SCHEMA, dict):
+    CV_GIT_SCHEMA = cv.Schema(CV_GIT_SCHEMA)
+
+GIT_SCHEMA = cv.All(
+    CV_GIT_SCHEMA.extend(
+        {
+            cv.Required(CONF_FILE): _validate_json_filename,
+            cv.Optional(CONF_REFRESH, default="1d"): cv.All(
+                cv.string, cv.source_refresh
+            ),
+        }
+    ),
+    _process_git_source,
+)
+
+
+KEY_AUTHOR = "author"
+KEY_MICRO = "micro"
+KEY_MINIMUM_ESPHOME_VERSION = "minimum_esphome_version"
+KEY_TRAINED_LANGUAGES = "trained_languages"
+KEY_VERSION = "version"
+KEY_WAKE_WORD = "wake_word"
+KEY_WEBSITE = "website"
+
+MANIFEST_SCHEMA_V1 = cv.Schema(
+    {
+        cv.Required(CONF_TYPE): "micro",
+        cv.Required(KEY_WAKE_WORD): cv.string,
+        cv.Required(KEY_AUTHOR): cv.string,
+        cv.Required(KEY_WEBSITE): cv.url,
+        cv.Required(KEY_VERSION): cv.All(cv.int_, 1),
+        cv.Required(CONF_MODEL): cv.string,
+        cv.Required(KEY_MICRO): cv.Schema(
+            {
+                cv.Required(CONF_PROBABILITY_CUTOFF): cv.float_,
+                cv.Required(CONF_SLIDING_WINDOW_AVERAGE_SIZE): cv.positive_int,
+                cv.Optional(KEY_MINIMUM_ESPHOME_VERSION): cv.All(
+                    cv.version_number, cv.validate_esphome_version
+                ),
+            }
+        ),
+    }
+)
+
+MANIFEST_SCHEMA_V2 = cv.Schema(
+    {
+        cv.Required(CONF_TYPE): "micro",
+        cv.Required(CONF_MODEL): cv.string,
+        cv.Required(KEY_AUTHOR): cv.string,
+        cv.Required(KEY_VERSION): cv.All(cv.int_, 2),
+        cv.Required(KEY_WAKE_WORD): cv.string,
+        cv.Required(KEY_TRAINED_LANGUAGES): cv.ensure_list(cv.string),
+        cv.Optional(KEY_WEBSITE): cv.url,
+        cv.Required(KEY_MICRO): cv.Schema(
+            {
+                cv.Required(CONF_FEATURE_STEP_SIZE): cv.int_range(min=0, max=30),
+                cv.Required(CONF_TENSOR_ARENA_SIZE): cv.int_,
+                cv.Required(CONF_PROBABILITY_CUTOFF): cv.float_,
+                cv.Required(CONF_SLIDING_WINDOW_SIZE): cv.positive_int,
+                cv.Required(KEY_MINIMUM_ESPHOME_VERSION): cv.All(
+                    cv.version_number, cv.validate_esphome_version
+                ),
+            }
+        ),
+    }
+)
+
+
+def _compute_local_file_path(config: dict) -> Path:
+    url = config[CONF_URL]
+    h = hashlib.new("sha256")
+    h.update(url.encode())
+    key = h.hexdigest()[:8]
+    base_dir = external_files.compute_local_file_dir(DOMAIN)
+    return base_dir / key
+
+
+def _convert_manifest_v1_to_v2(v1_manifest):
+    v2_manifest = v1_manifest.copy()
+
+    v2_manifest[KEY_VERSION] = 2
+    v2_manifest[KEY_MICRO][CONF_SLIDING_WINDOW_SIZE] = v1_manifest[KEY_MICRO][
+        CONF_SLIDING_WINDOW_AVERAGE_SIZE
+    ]
+    del v2_manifest[KEY_MICRO][CONF_SLIDING_WINDOW_AVERAGE_SIZE]
+
+    # Original Inception-based V1 manifest models require a minimum of 45672 bytes
+    v2_manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE] = 45672
+    # Original Inception-based V1 manifest models use a 20 ms feature step size
+    v2_manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE] = 20
+    # Original Inception-based V1 manifest models were trained only on TTS English samples
+    v2_manifest[KEY_TRAINED_LANGUAGES] = ["en"]
+
+    return v2_manifest
+
+
+def _validate_manifest_version(manifest_data):
+    if manifest_version := manifest_data.get(KEY_VERSION):
+        if manifest_version == 1:
+            try:
+                MANIFEST_SCHEMA_V1(manifest_data)
+            except cv.Invalid as e:
+                raise cv.Invalid(f"Invalid manifest file: {e}") from e
+        elif manifest_version == 2:
+            try:
+                MANIFEST_SCHEMA_V2(manifest_data)
+            except cv.Invalid as e:
+                raise cv.Invalid(f"Invalid manifest file: {e}") from e
+        else:
+            raise cv.Invalid("Invalid manifest version")
+    else:
+        raise cv.Invalid("Invalid manifest file, missing 'version' key")
+
+
+def _process_http_source(config):
+    url = config[CONF_URL]
+    path = _compute_local_file_path(config)
+
+    json_path = path / "manifest.json"
+
+    json_contents = external_files.download_content(url, json_path)
+
+    manifest_data = json.loads(json_contents)
+    if not isinstance(manifest_data, dict):
+        raise cv.Invalid("Manifest file must contain a JSON object")
+
+    model = manifest_data[CONF_MODEL]
+    model_url = urljoin(url, model)
+
+    model_path = path / model
+
+    external_files.download_content(str(model_url), model_path)
+
+    return config
+
+
+HTTP_SCHEMA = cv.All(
+    {
+        cv.Required(CONF_URL): cv.url,
+    },
+    _process_http_source,
+)
+
+LOCAL_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_PATH): cv.All(_validate_json_filename, cv.file_),
+    }
+)
+
+
+def _validate_source_model_name(value):
+    if not isinstance(value, str):
+        raise cv.Invalid("Model name must be a string")
+
+    if value.endswith(".json"):
+        raise cv.Invalid("Model name must not end with .json")
+
+    return MODEL_SOURCE_SCHEMA(
+        {
+            CONF_TYPE: TYPE_HTTP,
+            CONF_URL: f"https://github.com/esphome/micro-wake-word-models/raw/main/models/v2/{value}.json",
+        }
+    )
+
+
+def _validate_source_shorthand(value):
+    if not isinstance(value, str):
+        raise cv.Invalid("Shorthand only for strings")
+
+    try:  # Test for model name
+        return _validate_source_model_name(value)
+    except cv.Invalid:
+        pass
+
+    try:  # Test for local path
+        return MODEL_SOURCE_SCHEMA({CONF_TYPE: TYPE_LOCAL, CONF_PATH: value})
+    except cv.Invalid:
+        pass
+
+    try:  # Test for http url
+        return MODEL_SOURCE_SCHEMA({CONF_TYPE: TYPE_HTTP, CONF_URL: value})
+    except cv.Invalid:
+        pass
+
+    git_file = git.GitFile.from_shorthand(value)
+
+    conf = {
+        CONF_TYPE: TYPE_GIT,
+        CONF_URL: git_file.git_url,
+        CONF_FILE: git_file.filename,
+    }
+    if git_file.ref:
+        conf[CONF_REF] = git_file.ref
+
+    try:
+        return MODEL_SOURCE_SCHEMA(conf)
+    except cv.Invalid as e:
+        raise cv.Invalid(
+            f"Could not find file '{git_file.filename}' in the repository. Please make sure it exists."
+        ) from e
+
+
+MODEL_SOURCE_SCHEMA = cv.Any(
+    _validate_source_shorthand,
+    cv.typed_schema(
+        {
+            TYPE_GIT: GIT_SCHEMA,
+            TYPE_LOCAL: LOCAL_SCHEMA,
+            TYPE_HTTP: HTTP_SCHEMA,
+        }
+    ),
+    msg="Not a valid model name, local path, http(s) url, or github shorthand",
+)
+
+MODEL_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(WakeWordModel),
+        cv.Optional(CONF_MODEL): MODEL_SOURCE_SCHEMA,
+        cv.Optional(CONF_PROBABILITY_CUTOFF): cv.percentage,
+        cv.Optional(CONF_SLIDING_WINDOW_SIZE): cv.positive_int,
+        cv.Optional(CONF_INTERNAL, default=False): cv.boolean,
+        cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
+    }
+)
+
+# Provides a default VAD model that could be overridden
+VAD_MODEL_SCHEMA = MODEL_SCHEMA.extend(
+    cv.Schema(
+        {
+            cv.Optional(
+                CONF_MODEL,
+                default="vad",
+            ): MODEL_SOURCE_SCHEMA,
+        }
+    )
+)
+
+
+def _maybe_empty_vad_schema(value):
+    # Idea borrowed from uart/__init__.py's ``maybe_empty_debug`` function. Accessed 2 July 2024.
+    # Loads a default VAD model without any parameters overridden.
+    if value is None:
+        value = {}
+    return VAD_MODEL_SCHEMA(value)
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(MicroWakeWord),
+            cv.Optional(
+                CONF_MICROPHONE, default={}
+            ): microphone.microphone_source_schema(
+                min_bits_per_sample=16,
+                max_bits_per_sample=16,
+                min_channels=1,
+                max_channels=1,
+            ),
+            cv.Required(CONF_MODELS): cv.ensure_list(
+                cv.maybe_simple_value(MODEL_SCHEMA, key=CONF_MODEL)
+            ),
+            cv.Optional(CONF_ON_AUDIO_DATA): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(AudioDataTrigger)}
+            ),
+            cv.Optional(CONF_ON_WAKE_WORD_DETECTED): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_VAD): _maybe_empty_vad_schema,
+            cv.Optional(CONF_STOP_AFTER_DETECTION, default=True): cv.boolean,
+            cv.Optional(CONF_MODEL): cv.invalid(
+                f"The {CONF_MODEL} parameter has moved to be a list element under the {CONF_MODELS} parameter."
+            ),
+            cv.Optional(CONF_PROBABILITY_CUTOFF): cv.invalid(
+                f"The {CONF_PROBABILITY_CUTOFF} parameter has moved to be a list element under the {CONF_MODELS} parameter."
+            ),
+            cv.Optional(CONF_SLIDING_WINDOW_AVERAGE_SIZE): cv.invalid(
+                f"The {CONF_SLIDING_WINDOW_AVERAGE_SIZE} parameter has been renamed to {CONF_SLIDING_WINDOW_SIZE} and moved to be a list element under the {CONF_MODELS} parameter."
+            ),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    cv.only_on_esp32,
+)
+
+
+def _load_model_data(manifest_path: Path):
+    with open(manifest_path, encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    _validate_manifest_version(manifest)
+
+    model_path = manifest_path.parent / manifest[CONF_MODEL]
+
+    with open(model_path, "rb") as f:
+        model = f.read()
+
+    if manifest.get(KEY_VERSION) == 1:
+        manifest = _convert_manifest_v1_to_v2(manifest)
+
+    return manifest, model
+
+
+def _model_config_to_manifest_data(model_config):
+    if model_config[CONF_TYPE] == TYPE_GIT:
+        # compute path to model file
+        key = f"{model_config[CONF_URL]}@{model_config.get(CONF_REF)}"
+        base_dir = Path(CORE.data_dir) / DOMAIN
+        h = hashlib.new("sha256")
+        h.update(key.encode())
+        file: Path = base_dir / h.hexdigest()[:8] / model_config[CONF_FILE]
+
+    elif model_config[CONF_TYPE] == TYPE_LOCAL:
+        file = Path(model_config[CONF_PATH])
+
+    elif model_config[CONF_TYPE] == TYPE_HTTP:
+        file = _compute_local_file_path(model_config) / "manifest.json"
+
+    else:
+        raise ValueError(f"Unsupported config type: {model_config[CONF_TYPE]}")
+
+    return _load_model_data(file)
+
+
+def _feature_step_size_validate(config):
+    features_step_size = None
+
+    for model_parameters in config[CONF_MODELS]:
+        model_config = model_parameters.get(CONF_MODEL)
+        manifest, _ = _model_config_to_manifest_data(model_config)
+
+        model_step_size = manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE]
+
+        if features_step_size is None:
+            features_step_size = model_step_size
+        elif features_step_size != model_step_size:
+            raise cv.Invalid("Cannot load models with different features step sizes")
+
+
+FINAL_VALIDATE_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(
+                CONF_MICROPHONE
+            ): microphone.final_validate_microphone_source_schema(
+                "micro_wake_word", sample_rate=16000
+            ),
+        },
+        extra=cv.ALLOW_EXTRA,
+    ),
+    _feature_step_size_validate,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    mic_source = await microphone.microphone_source_to_code(config[CONF_MICROPHONE])
+    cg.add(var.set_microphone_source(mic_source))
+
+    cg.add_define("USE_MICRO_WAKE_WORD")
+    ota.request_ota_state_listeners()
+
+    esp32.add_idf_component(name="espressif/esp-tflite-micro", ref="1.3.3~1")
+    # Pin esp-nn for stable future builds (esp-tflite-micro depends on esp-nn)
+    esp32.add_idf_component(name="espressif/esp-nn", ref="1.1.2")
+
+    cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
+    cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")
+    cg.add_build_flag("-DESP_NN")
+
+    cg.add_library("kahrendt/ESPMicroSpeechFeatures", "1.1.0")
+
+    if vad_model := config.get(CONF_VAD):
+        cg.add_define("USE_MICRO_WAKE_WORD_VAD")
+
+        # Use the general model loading code for the VAD codegen
+        config[CONF_MODELS].append(vad_model)
+
+    for i, model_parameters in enumerate(config[CONF_MODELS]):
+        model_config = model_parameters.get(CONF_MODEL)
+        data = []
+        manifest, data = _model_config_to_manifest_data(model_config)
+
+        rhs = [HexInt(x) for x in data]
+        prog_arr = cg.progmem_array(model_parameters[CONF_RAW_DATA_ID], rhs)
+
+        probability_cutoff = model_parameters.get(
+            CONF_PROBABILITY_CUTOFF, manifest[KEY_MICRO][CONF_PROBABILITY_CUTOFF]
+        )
+        quantized_probability_cutoff = int(probability_cutoff * 255)
+
+        sliding_window_size = model_parameters.get(
+            CONF_SLIDING_WINDOW_SIZE,
+            manifest[KEY_MICRO][CONF_SLIDING_WINDOW_SIZE],
+        )
+
+        if manifest[KEY_WAKE_WORD] == "vad":
+            cg.add(
+                var.add_vad_model(
+                    prog_arr,
+                    quantized_probability_cutoff,
+                    sliding_window_size,
+                    manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE],
+                )
+            )
+        else:
+            # Only enable the first wake word by default. After first boot, the enable state is saved/loaded to the flash
+            default_enabled = i == 0
+            wake_word_model = cg.new_Pvariable(
+                model_parameters[CONF_ID],
+                str(model_parameters[CONF_ID]),
+                prog_arr,
+                quantized_probability_cutoff,
+                sliding_window_size,
+                manifest[KEY_WAKE_WORD],
+                manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE],
+                default_enabled,
+                model_parameters[CONF_INTERNAL],
+            )
+
+            for lang in manifest[KEY_TRAINED_LANGUAGES]:
+                cg.add(wake_word_model.add_trained_language(lang))
+
+            cg.add(var.add_wake_word_model(wake_word_model))
+
+    cg.add(var.set_features_step_size(manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE]))
+    cg.add(var.set_stop_after_detection(config[CONF_STOP_AFTER_DETECTION]))
+
+    for conf in config.get(CONF_ON_AUDIO_DATA, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(
+            trigger,
+            [(cg.std_vector.template(cg.uint8).operator("ref").operator("const"), "x")],
+            conf,
+        )
+
+    if on_wake_word_detection_config := config.get(CONF_ON_WAKE_WORD_DETECTED):
+        await automation.build_automation(
+            var.get_wake_word_detected_trigger(),
+            [(cg.std_string, "wake_word")],
+            on_wake_word_detection_config,
+        )
+
+
+MICRO_WAKE_WORD_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(MicroWakeWord)})
+
+
+@register_action(
+    "micro_wake_word.start",
+    StartAction,
+    MICRO_WAKE_WORD_ACTION_SCHEMA,
+    synchronous=True,
+)
+@register_action(
+    "micro_wake_word.stop", StopAction, MICRO_WAKE_WORD_ACTION_SCHEMA, synchronous=True
+)
+@register_condition(
+    "micro_wake_word.is_running", IsRunningCondition, MICRO_WAKE_WORD_ACTION_SCHEMA
+)
+async def micro_wake_word_action_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.Required(CONF_ID): cv.use_id(WakeWordModel),
+    }
+)
+
+
+@register_action(
+    "micro_wake_word.enable_model",
+    EnableModelAction,
+    MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA,
+    synchronous=True,
+)
+@register_action(
+    "micro_wake_word.disable_model",
+    DisableModelAction,
+    MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA,
+    synchronous=True,
+)
+@register_condition(
+    "micro_wake_word.model_is_enabled",
+    ModelIsEnabledCondition,
+    MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA,
+)
+async def model_action(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, parent)

--- a/esphome/components/micro_wake_word/automation.h
+++ b/esphome/components/micro_wake_word/automation.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "micro_wake_word.h"
+#include "streaming_model.h"
+
+#ifdef USE_ESP32
+namespace esphome {
+namespace micro_wake_word {
+
+template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<MicroWakeWord> {
+ public:
+  void play(const Ts &...x) override { this->parent_->start(); }
+};
+
+template<typename... Ts> class StopAction : public Action<Ts...>, public Parented<MicroWakeWord> {
+ public:
+  void play(const Ts &...x) override { this->parent_->stop(); }
+};
+
+template<typename... Ts> class IsRunningCondition : public Condition<Ts...>, public Parented<MicroWakeWord> {
+ public:
+  bool check(const Ts &...x) override { return this->parent_->is_running(); }
+};
+
+template<typename... Ts> class EnableModelAction : public Action<Ts...> {
+ public:
+  explicit EnableModelAction(WakeWordModel *wake_word_model) : wake_word_model_(wake_word_model) {}
+  void play(const Ts &...x) override { this->wake_word_model_->enable(); }
+
+ protected:
+  WakeWordModel *wake_word_model_;
+};
+
+template<typename... Ts> class DisableModelAction : public Action<Ts...> {
+ public:
+  explicit DisableModelAction(WakeWordModel *wake_word_model) : wake_word_model_(wake_word_model) {}
+  void play(const Ts &...x) override { this->wake_word_model_->disable(); }
+
+ protected:
+  WakeWordModel *wake_word_model_;
+};
+
+template<typename... Ts> class ModelIsEnabledCondition : public Condition<Ts...> {
+ public:
+  explicit ModelIsEnabledCondition(WakeWordModel *wake_word_model) : wake_word_model_(wake_word_model) {}
+  bool check(const Ts &...x) override { return this->wake_word_model_->is_enabled(); }
+
+ protected:
+  WakeWordModel *wake_word_model_;
+};
+
+/// @brief Fires for every chunk of raw audio (int16 PCM, mono, 16 kHz) that microWakeWord processes, so it can
+///        be forwarded off-device (e.g. UDP) and captured as wake-word training data.
+class AudioDataTrigger : public Trigger<const std::vector<uint8_t> &> {
+ public:
+  explicit AudioDataTrigger(MicroWakeWord *parent) {
+    parent->add_audio_data_callback([this](const std::vector<uint8_t> &data) { this->trigger(data); });
+  }
+};
+
+}  // namespace micro_wake_word
+}  // namespace esphome
+#endif

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -1,0 +1,480 @@
+#include "micro_wake_word.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include "esphome/components/audio/audio_transfer_buffer.h"
+
+#ifdef USE_OTA
+#include "esphome/components/ota/ota_backend.h"
+#endif
+
+namespace esphome {
+namespace micro_wake_word {
+
+static const char *const TAG = "micro_wake_word";
+
+static const ssize_t DETECTION_QUEUE_LENGTH = 5;
+
+static const size_t DATA_TIMEOUT_MS = 50;
+
+static const uint32_t RING_BUFFER_DURATION_MS = 120;
+
+static const uint32_t INFERENCE_TASK_STACK_SIZE = 3072;
+static const UBaseType_t INFERENCE_TASK_PRIORITY = 3;
+
+enum EventGroupBits : uint32_t {
+  COMMAND_STOP = (1 << 0),  // Signals the inference task should stop
+
+  TASK_STARTING = (1 << 3),
+  TASK_RUNNING = (1 << 4),
+  TASK_STOPPING = (1 << 5),
+  TASK_STOPPED = (1 << 6),
+
+  ERROR_MEMORY = (1 << 9),
+  ERROR_INFERENCE = (1 << 10),
+
+  WARNING_FULL_RING_BUFFER = (1 << 13),
+
+  ERROR_BITS = ERROR_MEMORY | ERROR_INFERENCE,
+  ALL_BITS = 0xfffff,  // 24 total bits available in an event group
+};
+
+float MicroWakeWord::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
+
+static const LogString *micro_wake_word_state_to_string(State state) {
+  switch (state) {
+    case State::STARTING:
+      return LOG_STR("STARTING");
+    case State::DETECTING_WAKE_WORD:
+      return LOG_STR("DETECTING_WAKE_WORD");
+    case State::STOPPING:
+      return LOG_STR("STOPPING");
+    case State::STOPPED:
+      return LOG_STR("STOPPED");
+    default:
+      return LOG_STR("UNKNOWN");
+  }
+}
+
+void MicroWakeWord::dump_config() {
+  ESP_LOGCONFIG(TAG, "microWakeWord:");
+  ESP_LOGCONFIG(TAG, "  models:");
+  for (auto &model : this->wake_word_models_) {
+    model->log_model_config();
+  }
+#ifdef USE_MICRO_WAKE_WORD_VAD
+  this->vad_model_->log_model_config();
+#endif
+}
+
+void MicroWakeWord::setup() {
+  this->frontend_config_.window.size_ms = FEATURE_DURATION_MS;
+  this->frontend_config_.window.step_size_ms = this->features_step_size_;
+  this->frontend_config_.filterbank.num_channels = PREPROCESSOR_FEATURE_SIZE;
+  this->frontend_config_.filterbank.lower_band_limit = FILTERBANK_LOWER_BAND_LIMIT;
+  this->frontend_config_.filterbank.upper_band_limit = FILTERBANK_UPPER_BAND_LIMIT;
+  this->frontend_config_.noise_reduction.smoothing_bits = NOISE_REDUCTION_SMOOTHING_BITS;
+  this->frontend_config_.noise_reduction.even_smoothing = NOISE_REDUCTION_EVEN_SMOOTHING;
+  this->frontend_config_.noise_reduction.odd_smoothing = NOISE_REDUCTION_ODD_SMOOTHING;
+  this->frontend_config_.noise_reduction.min_signal_remaining = NOISE_REDUCTION_MIN_SIGNAL_REMAINING;
+  this->frontend_config_.pcan_gain_control.enable_pcan = PCAN_GAIN_CONTROL_ENABLE_PCAN;
+  this->frontend_config_.pcan_gain_control.strength = PCAN_GAIN_CONTROL_STRENGTH;
+  this->frontend_config_.pcan_gain_control.offset = PCAN_GAIN_CONTROL_OFFSET;
+  this->frontend_config_.pcan_gain_control.gain_bits = PCAN_GAIN_CONTROL_GAIN_BITS;
+  this->frontend_config_.log_scale.enable_log = LOG_SCALE_ENABLE_LOG;
+  this->frontend_config_.log_scale.scale_shift = LOG_SCALE_SCALE_SHIFT;
+
+  this->event_group_ = xEventGroupCreate();
+  if (this->event_group_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create event group");
+    this->mark_failed();
+    return;
+  }
+
+  this->detection_queue_ = xQueueCreate(DETECTION_QUEUE_LENGTH, sizeof(DetectionEvent));
+  if (this->detection_queue_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create detection event queue");
+    this->mark_failed();
+    return;
+  }
+
+  this->microphone_source_->add_data_callback([this](const std::vector<uint8_t> &data) {
+    if (this->state_ == State::STOPPED) {
+      return;
+    }
+    // Tap the raw audio (int16 PCM, mono, 16 kHz) so it can be captured for wake-word training data. This is
+    // the exact signal the models process, so it also captures audio when no wake word is detected (false
+    // negatives). Only invoke the callbacks when something is listening to avoid copying overhead.
+    if (this->audio_data_callbacks_.size() > 0) {
+      this->audio_data_callbacks_.call(data);
+    }
+    std::shared_ptr<RingBuffer> temp_ring_buffer = this->ring_buffer_.lock();
+    if (this->ring_buffer_.use_count() > 1) {
+      size_t bytes_free = temp_ring_buffer->free();
+
+      if (bytes_free < data.size()) {
+        xEventGroupSetBits(this->event_group_, EventGroupBits::WARNING_FULL_RING_BUFFER);
+        temp_ring_buffer->reset();
+      }
+      temp_ring_buffer->write((void *) data.data(), data.size());
+    }
+  });
+
+#ifdef USE_OTA_STATE_LISTENER
+  ota::get_global_ota_callback()->add_global_state_listener(this);
+#endif
+}
+
+#ifdef USE_OTA_STATE_LISTENER
+void MicroWakeWord::on_ota_global_state(ota::OTAState state, float progress, uint8_t error, ota::OTAComponent *comp) {
+  if (state == ota::OTA_STARTED) {
+    this->suspend_task_();
+  } else if (state == ota::OTA_ERROR) {
+    this->resume_task_();
+  }
+}
+#endif
+
+void MicroWakeWord::inference_task(void *params) {
+  MicroWakeWord *this_mww = (MicroWakeWord *) params;
+
+  xEventGroupSetBits(this_mww->event_group_, EventGroupBits::TASK_STARTING);
+
+  {  // Ensures any C++ objects fall out of scope to deallocate before deleting the task
+
+    const size_t new_bytes_to_process =
+        this_mww->microphone_source_->get_audio_stream_info().ms_to_bytes(this_mww->features_step_size_);
+    std::unique_ptr<audio::AudioSourceTransferBuffer> audio_buffer;
+    int8_t features_buffer[PREPROCESSOR_FEATURE_SIZE];
+
+    if (!(xEventGroupGetBits(this_mww->event_group_) & ERROR_BITS)) {
+      // Allocate audio transfer buffer
+      audio_buffer = audio::AudioSourceTransferBuffer::create(new_bytes_to_process);
+
+      if (audio_buffer == nullptr) {
+        xEventGroupSetBits(this_mww->event_group_, EventGroupBits::ERROR_MEMORY);
+      }
+    }
+
+    if (!(xEventGroupGetBits(this_mww->event_group_) & ERROR_BITS)) {
+      // Allocate ring buffer
+      std::shared_ptr<RingBuffer> temp_ring_buffer = RingBuffer::create(
+          this_mww->microphone_source_->get_audio_stream_info().ms_to_bytes(RING_BUFFER_DURATION_MS));
+      if (temp_ring_buffer.use_count() == 0) {
+        xEventGroupSetBits(this_mww->event_group_, EventGroupBits::ERROR_MEMORY);
+      }
+      audio_buffer->set_source(temp_ring_buffer);
+      this_mww->ring_buffer_ = temp_ring_buffer;
+    }
+
+    if (!(xEventGroupGetBits(this_mww->event_group_) & ERROR_BITS)) {
+      this_mww->microphone_source_->start();
+      xEventGroupSetBits(this_mww->event_group_, EventGroupBits::TASK_RUNNING);
+
+      while (!(xEventGroupGetBits(this_mww->event_group_) & COMMAND_STOP)) {
+        audio_buffer->transfer_data_from_source(pdMS_TO_TICKS(DATA_TIMEOUT_MS));
+
+        if (audio_buffer->available() < new_bytes_to_process) {
+          // Insufficient data to generate new spectrogram features, read more next iteration
+          continue;
+        }
+
+        // Generate new spectrogram features
+        uint32_t processed_samples = this_mww->generate_features_(
+            (int16_t *) audio_buffer->get_buffer_start(), audio_buffer->available() / sizeof(int16_t), features_buffer);
+        audio_buffer->decrease_buffer_length(processed_samples * sizeof(int16_t));
+
+        // Run inference using the new spectorgram features
+        if (!this_mww->update_model_probabilities_(features_buffer)) {
+          xEventGroupSetBits(this_mww->event_group_, EventGroupBits::ERROR_INFERENCE);
+          break;
+        }
+
+        // Process each model's probabilities and possibly send a Detection Event to the queue
+        this_mww->process_probabilities_();
+      }
+    }
+  }
+
+  xEventGroupSetBits(this_mww->event_group_, EventGroupBits::TASK_STOPPING);
+
+  this_mww->unload_models_();
+  this_mww->microphone_source_->stop();
+  FrontendFreeStateContents(&this_mww->frontend_state_);
+
+  xEventGroupSetBits(this_mww->event_group_, EventGroupBits::TASK_STOPPED);
+  while (true) {
+    // Continuously delay until the main loop deletes the task
+    delay(10);
+  }
+}
+
+std::vector<WakeWordModel *> MicroWakeWord::get_wake_words() {
+  std::vector<WakeWordModel *> external_wake_word_models;
+  for (auto *model : this->wake_word_models_) {
+    if (!model->get_internal_only()) {
+      external_wake_word_models.push_back(model);
+    }
+  }
+  return external_wake_word_models;
+}
+
+void MicroWakeWord::add_wake_word_model(WakeWordModel *model) { this->wake_word_models_.push_back(model); }
+
+#ifdef USE_MICRO_WAKE_WORD_VAD
+void MicroWakeWord::add_vad_model(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size,
+                                  size_t tensor_arena_size) {
+  this->vad_model_ = make_unique<VADModel>(model_start, probability_cutoff, sliding_window_size, tensor_arena_size);
+}
+#endif
+
+void MicroWakeWord::suspend_task_() {
+  if (this->inference_task_handle_ != nullptr) {
+    vTaskSuspend(this->inference_task_handle_);
+  }
+}
+
+void MicroWakeWord::resume_task_() {
+  if (this->inference_task_handle_ != nullptr) {
+    vTaskResume(this->inference_task_handle_);
+  }
+}
+
+void MicroWakeWord::loop() {
+  uint32_t event_group_bits = xEventGroupGetBits(this->event_group_);
+
+  if (event_group_bits & EventGroupBits::ERROR_MEMORY) {
+    xEventGroupClearBits(this->event_group_, EventGroupBits::ERROR_MEMORY);
+    ESP_LOGE(TAG, "Encountered an error allocating buffers");
+  }
+
+  if (event_group_bits & EventGroupBits::ERROR_INFERENCE) {
+    xEventGroupClearBits(this->event_group_, EventGroupBits::ERROR_INFERENCE);
+    ESP_LOGE(TAG, "Encountered an error while performing an inference");
+  }
+
+  if (event_group_bits & EventGroupBits::WARNING_FULL_RING_BUFFER) {
+    xEventGroupClearBits(this->event_group_, EventGroupBits::WARNING_FULL_RING_BUFFER);
+    ESP_LOGW(TAG, "Not enough free bytes in ring buffer to store incoming audio data. Resetting the ring buffer. Wake "
+                  "word detection accuracy will temporarily be reduced.");
+  }
+
+  if (event_group_bits & EventGroupBits::TASK_STARTING) {
+    ESP_LOGD(TAG, "Inference task has started, attempting to allocate memory for buffers");
+    xEventGroupClearBits(this->event_group_, EventGroupBits::TASK_STARTING);
+  }
+
+  if (event_group_bits & EventGroupBits::TASK_RUNNING) {
+    ESP_LOGD(TAG, "Inference task is running");
+
+    xEventGroupClearBits(this->event_group_, EventGroupBits::TASK_RUNNING);
+    this->set_state_(State::DETECTING_WAKE_WORD);
+  }
+
+  if (event_group_bits & EventGroupBits::TASK_STOPPING) {
+    ESP_LOGD(TAG, "Inference task is stopping, deallocating buffers");
+    xEventGroupClearBits(this->event_group_, EventGroupBits::TASK_STOPPING);
+  }
+
+  if ((event_group_bits & EventGroupBits::TASK_STOPPED)) {
+    ESP_LOGD(TAG, "Inference task is finished, freeing task resources");
+    vTaskDelete(this->inference_task_handle_);
+    this->inference_task_handle_ = nullptr;
+    xEventGroupClearBits(this->event_group_, ALL_BITS);
+    xQueueReset(this->detection_queue_);
+    this->set_state_(State::STOPPED);
+  }
+
+  if ((this->pending_start_) && (this->state_ == State::STOPPED)) {
+    this->set_state_(State::STARTING);
+    this->pending_start_ = false;
+  }
+
+  if ((this->pending_stop_) && (this->state_ == State::DETECTING_WAKE_WORD)) {
+    this->set_state_(State::STOPPING);
+    this->pending_stop_ = false;
+  }
+
+  switch (this->state_) {
+    case State::STARTING:
+      if ((this->inference_task_handle_ == nullptr) && !this->status_has_error()) {
+        // Setup preprocesor feature generator. If done in the task, it would lock the task to its initial core, as it
+        // uses floating point operations.
+        if (!FrontendPopulateState(&this->frontend_config_, &this->frontend_state_,
+                                   this->microphone_source_->get_audio_stream_info().get_sample_rate())) {
+          this->status_momentary_error("frontend_alloc", 1000);
+          return;
+        }
+
+        xTaskCreate(MicroWakeWord::inference_task, "mww", INFERENCE_TASK_STACK_SIZE, (void *) this,
+                    INFERENCE_TASK_PRIORITY, &this->inference_task_handle_);
+
+        if (this->inference_task_handle_ == nullptr) {
+          FrontendFreeStateContents(&this->frontend_state_);  // Deallocate frontend state
+          this->status_momentary_error("task_start", 1000);
+        }
+      }
+      break;
+    case State::DETECTING_WAKE_WORD: {
+      DetectionEvent detection_event;
+      while (xQueueReceive(this->detection_queue_, &detection_event, 0)) {
+        if (detection_event.blocked_by_vad) {
+          ESP_LOGD(TAG, "Wake word model predicts '%s', but VAD model doesn't.", detection_event.wake_word->c_str());
+        } else {
+          constexpr float uint8_to_float_divisor =
+              255.0f;  // Converting a quantized uint8 probability to floating point
+          ESP_LOGD(TAG, "Detected '%s' with sliding average probability is %.2f and max probability is %.2f",
+                   detection_event.wake_word->c_str(), (detection_event.average_probability / uint8_to_float_divisor),
+                   (detection_event.max_probability / uint8_to_float_divisor));
+          this->wake_word_detected_trigger_.trigger(*detection_event.wake_word);
+          if (this->stop_after_detection_) {
+            this->stop();
+          }
+        }
+      }
+      break;
+    }
+    case State::STOPPING:
+      xEventGroupSetBits(this->event_group_, EventGroupBits::COMMAND_STOP);
+      break;
+    case State::STOPPED:
+      break;
+  }
+}
+
+void MicroWakeWord::start() {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "Wake word detection can't start as the component hasn't been setup yet");
+    return;
+  }
+
+  if (this->is_failed()) {
+    ESP_LOGW(TAG, "Wake word component is marked as failed. Please check setup logs");
+    return;
+  }
+
+  if (this->is_running()) {
+    ESP_LOGW(TAG, "Wake word detection is already running");
+    return;
+  }
+
+  ESP_LOGD(TAG, "Starting wake word detection");
+
+  this->pending_start_ = true;
+  this->pending_stop_ = false;
+}
+
+void MicroWakeWord::stop() {
+  if (this->state_ == STOPPED)
+    return;
+
+  ESP_LOGD(TAG, "Stopping wake word detection");
+
+  this->pending_start_ = false;
+  this->pending_stop_ = true;
+}
+
+void MicroWakeWord::set_state_(State state) {
+  if (this->state_ != state) {
+    ESP_LOGD(TAG, "State changed from %s to %s", LOG_STR_ARG(micro_wake_word_state_to_string(this->state_)),
+             LOG_STR_ARG(micro_wake_word_state_to_string(state)));
+    this->state_ = state;
+  }
+}
+
+size_t MicroWakeWord::generate_features_(int16_t *audio_buffer, size_t samples_available,
+                                         int8_t features_buffer[PREPROCESSOR_FEATURE_SIZE]) {
+  size_t processed_samples = 0;
+  struct FrontendOutput frontend_output =
+      FrontendProcessSamples(&this->frontend_state_, audio_buffer, samples_available, &processed_samples);
+
+  for (size_t i = 0; i < frontend_output.size; ++i) {
+    // These scaling values are set to match the TFLite audio frontend int8 output.
+    // The feature pipeline outputs 16-bit signed integers in roughly a 0 to 670
+    // range. In training, these are then arbitrarily divided by 25.6 to get
+    // float values in the rough range of 0.0 to 26.0. This scaling is performed
+    // for historical reasons, to match up with the output of other feature
+    // generators.
+    // The process is then further complicated when we quantize the model. This
+    // means we have to scale the 0.0 to 26.0 real values to the -128 (INT8_MIN)
+    // to 127 (INT8_MAX) signed integer numbers.
+    // All this means that to get matching values from our integer feature
+    // output into the tensor input, we have to perform:
+    // input = (((feature / 25.6) / 26.0) * 256) - 128
+    // To simplify this and perform it in 32-bit integer math, we rearrange to:
+    // input = (feature * 256) / (25.6 * 26.0) - 128
+    constexpr int32_t value_scale = 256;
+    constexpr int32_t value_div = 666;  // 666 = 25.6 * 26.0 after rounding
+    int32_t value = ((frontend_output.values[i] * value_scale) + (value_div / 2)) / value_div;
+
+    value += INT8_MIN;  // Adds a -128; i.e., subtracts 128
+    features_buffer[i] = static_cast<int8_t>(clamp<int32_t>(value, INT8_MIN, INT8_MAX));
+  }
+
+  return processed_samples;
+}
+
+void MicroWakeWord::process_probabilities_() {
+#ifdef USE_MICRO_WAKE_WORD_VAD
+  DetectionEvent vad_state = this->vad_model_->determine_detected();
+
+  this->vad_state_ = vad_state.detected;  // atomic write, so thread safe
+#endif
+
+  for (auto &model : this->wake_word_models_) {
+    if (model->get_unprocessed_probability_status()) {
+      // Only detect wake words if there is a new probability since the last check
+      DetectionEvent wake_word_state = model->determine_detected();
+      if (wake_word_state.detected) {
+#ifdef USE_MICRO_WAKE_WORD_VAD
+        if (vad_state.detected) {
+#endif
+          xQueueSend(this->detection_queue_, &wake_word_state, portMAX_DELAY);
+
+          // Wake main loop immediately to process wake word detection
+          App.wake_loop_threadsafe();
+
+          model->reset_probabilities();
+#ifdef USE_MICRO_WAKE_WORD_VAD
+        } else {
+          wake_word_state.blocked_by_vad = true;
+          xQueueSend(this->detection_queue_, &wake_word_state, portMAX_DELAY);
+        }
+#endif
+      }
+    }
+  }
+}
+
+void MicroWakeWord::unload_models_() {
+  for (auto &model : this->wake_word_models_) {
+    model->unload_model();
+  }
+#ifdef USE_MICRO_WAKE_WORD_VAD
+  this->vad_model_->unload_model();
+#endif
+}
+
+bool MicroWakeWord::update_model_probabilities_(const int8_t audio_features[PREPROCESSOR_FEATURE_SIZE]) {
+  bool success = true;
+
+  for (auto &model : this->wake_word_models_) {
+    // Perform inference
+    success = success & model->perform_streaming_inference(audio_features);
+  }
+#ifdef USE_MICRO_WAKE_WORD_VAD
+  success = success & this->vad_model_->perform_streaming_inference(audio_features);
+#endif
+
+  return success;
+}
+
+}  // namespace micro_wake_word
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "preprocessor_settings.h"
+#include "streaming_model.h"
+
+#include "esphome/components/microphone/microphone_source.h"
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/ring_buffer.h"
+
+#ifdef USE_OTA_STATE_LISTENER
+#include "esphome/components/ota/ota_backend.h"
+#endif
+
+#include <freertos/event_groups.h>
+
+#include <frontend.h>
+#include <frontend_util.h>
+
+namespace esphome {
+namespace micro_wake_word {
+
+enum State {
+  STARTING,
+  DETECTING_WAKE_WORD,
+  STOPPING,
+  STOPPED,
+};
+
+class MicroWakeWord : public Component
+#ifdef USE_OTA_STATE_LISTENER
+    ,
+                      public ota::OTAGlobalStateListener
+#endif
+{
+ public:
+  void setup() override;
+  void loop() override;
+  float get_setup_priority() const override;
+  void dump_config() override;
+
+#ifdef USE_OTA_STATE_LISTENER
+  void on_ota_global_state(ota::OTAState state, float progress, uint8_t error, ota::OTAComponent *comp) override;
+#endif
+
+  void start();
+  void stop();
+
+  bool is_running() const { return this->state_ != State::STOPPED; }
+
+  void set_features_step_size(uint8_t step_size) { this->features_step_size_ = step_size; }
+
+  void set_microphone_source(microphone::MicrophoneSource *microphone_source) {
+    this->microphone_source_ = microphone_source;
+  }
+
+  void set_stop_after_detection(bool stop_after_detection) { this->stop_after_detection_ = stop_after_detection; }
+
+  Trigger<std::string> *get_wake_word_detected_trigger() { return &this->wake_word_detected_trigger_; }
+
+  /// @brief Registers a callback that receives every chunk of raw audio (int16 PCM, mono, 16 kHz) that
+  ///        microWakeWord feeds into its ring buffer. Used to tap the exact signal the models process so it
+  ///        can be captured for wake-word training data.
+  void add_audio_data_callback(std::function<void(const std::vector<uint8_t> &)> &&callback) {
+    this->audio_data_callbacks_.add(std::move(callback));
+  }
+
+  void add_wake_word_model(WakeWordModel *model);
+
+#ifdef USE_MICRO_WAKE_WORD_VAD
+  void add_vad_model(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size,
+                     size_t tensor_arena_size);
+
+  // Intended for the voice assistant component to fetch VAD status
+  bool get_vad_state() { return this->vad_state_; }
+#endif
+
+  // Intended for the voice assistant component to access which wake words are available
+  // Since these are pointers to the WakeWordModel objects, the voice assistant component can enable or disable them
+  std::vector<WakeWordModel *> get_wake_words();
+
+ protected:
+  microphone::MicrophoneSource *microphone_source_{nullptr};
+  Trigger<std::string> wake_word_detected_trigger_;
+  CallbackManager<void(const std::vector<uint8_t> &)> audio_data_callbacks_{};
+  State state_{State::STOPPED};
+
+  std::weak_ptr<RingBuffer> ring_buffer_;
+  std::vector<WakeWordModel *> wake_word_models_;
+
+#ifdef USE_MICRO_WAKE_WORD_VAD
+  std::unique_ptr<VADModel> vad_model_;
+  bool vad_state_{false};
+#endif
+
+  bool pending_start_{false};
+  bool pending_stop_{false};
+
+  bool stop_after_detection_;
+
+  uint8_t features_step_size_;
+
+  // Audio frontend handles generating spectrogram features
+  struct FrontendConfig frontend_config_;
+  struct FrontendState frontend_state_;
+
+  // Handles managing the stop/state of the inference task
+  EventGroupHandle_t event_group_;
+
+  // Used to send messages about the models' states to the main loop
+  QueueHandle_t detection_queue_;
+
+  static void inference_task(void *params);
+  TaskHandle_t inference_task_handle_{nullptr};
+
+  /// @brief Suspends the inference task
+  void suspend_task_();
+  /// @brief Resumes the inference task
+  void resume_task_();
+
+  void set_state_(State state);
+
+  /// @brief Generates spectrogram features from an input buffer of audio samples
+  /// @param audio_buffer (int16_t *) Buffer containing input audio samples
+  /// @param samples_available (size_t) Number of samples avaiable in the input buffer
+  /// @param features_buffer (int8_t *) Buffer to store generated features
+  /// @return (size_t) Number of samples processed from the input buffer
+  size_t generate_features_(int16_t *audio_buffer, size_t samples_available,
+                            int8_t features_buffer[PREPROCESSOR_FEATURE_SIZE]);
+
+  /// @brief Processes any new probabilities for each model. If any wake word is detected, it will send a DetectionEvent
+  /// to the detection_queue_.
+  void process_probabilities_();
+
+  /// @brief Deletes each model's TFLite interpreters and frees tensor arena memory.
+  void unload_models_();
+
+  /// @brief Runs an inference with each model using the new spectrogram features
+  /// @param audio_features (int8_t *) Buffer containing new spectrogram features
+  /// @return True if successful, false if any errors were encountered
+  bool update_model_probabilities_(const int8_t audio_features[PREPROCESSOR_FEATURE_SIZE]);
+};
+
+}  // namespace micro_wake_word
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/micro_wake_word/preprocessor_settings.h
+++ b/esphome/components/micro_wake_word/preprocessor_settings.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include <cstdint>
+
+namespace esphome {
+namespace micro_wake_word {
+
+// Settings for controlling the spectrogram feature generation by the preprocessor.
+// These must match the settings used when training a particular model.
+// All microWakeWord models have been trained with these specific paramters.
+
+// The number of features the audio preprocessor generates per slice
+static const uint8_t PREPROCESSOR_FEATURE_SIZE = 40;
+// Duration of each slice used as input into the preprocessor
+static const uint8_t FEATURE_DURATION_MS = 30;
+
+static const float FILTERBANK_LOWER_BAND_LIMIT = 125.0;
+static const float FILTERBANK_UPPER_BAND_LIMIT = 7500.0;
+
+static const uint8_t NOISE_REDUCTION_SMOOTHING_BITS = 10;
+static const float NOISE_REDUCTION_EVEN_SMOOTHING = 0.025;
+static const float NOISE_REDUCTION_ODD_SMOOTHING = 0.06;
+static const float NOISE_REDUCTION_MIN_SIGNAL_REMAINING = 0.05;
+
+static const bool PCAN_GAIN_CONTROL_ENABLE_PCAN = true;
+static const float PCAN_GAIN_CONTROL_STRENGTH = 0.95;
+static const float PCAN_GAIN_CONTROL_OFFSET = 80.0;
+static const uint8_t PCAN_GAIN_CONTROL_GAIN_BITS = 21;
+
+static const bool LOG_SCALE_ENABLE_LOG = true;
+static const uint8_t LOG_SCALE_SCALE_SHIFT = 6;
+}  // namespace micro_wake_word
+}  // namespace esphome
+
+#endif

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -1,0 +1,393 @@
+#include "streaming_model.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+static const char *const TAG = "micro_wake_word";
+
+namespace esphome {
+namespace micro_wake_word {
+
+void WakeWordModel::log_model_config() {
+  ESP_LOGCONFIG(TAG,
+                "    - Wake Word: %s\n"
+                "      Probability cutoff: %.2f\n"
+                "      Sliding window size: %d",
+                this->wake_word_.c_str(), this->probability_cutoff_ / 255.0f, this->sliding_window_size_);
+}
+
+void VADModel::log_model_config() {
+  ESP_LOGCONFIG(TAG,
+                "    - VAD Model\n"
+                "      Probability cutoff: %.2f\n"
+                "      Sliding window size: %d",
+                this->probability_cutoff_ / 255.0f, this->sliding_window_size_);
+}
+
+bool StreamingModel::load_model_() {
+  RAMAllocator<uint8_t> arena_allocator;
+
+  if (this->var_arena_ == nullptr) {
+    this->var_arena_ = arena_allocator.allocate(STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+    if (this->var_arena_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate the streaming model's variable tensor arena.");
+      return false;
+    }
+    this->ma_ = tflite::MicroAllocator::Create(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+    this->mrv_ = tflite::MicroResourceVariables::Create(this->ma_, 20);
+  }
+
+  const tflite::Model *model = tflite::GetModel(this->model_start_);
+  if (model->version() != TFLITE_SCHEMA_VERSION) {
+    ESP_LOGE(TAG, "Streaming model's schema is not supported");
+    return false;
+  }
+
+  // Probe for the actual required tensor arena size if not yet determined
+  if (!this->tensor_arena_size_probed_) {
+    size_t probed_size = this->probe_arena_size_();
+    if (probed_size > 0) {
+      ESP_LOGD(TAG, "Probed tensor arena size: %zu bytes", probed_size);
+      this->tensor_arena_size_ = probed_size;
+    } else {
+      ESP_LOGW(TAG, "Arena size probe failed, using manifest size: %zu bytes", this->tensor_arena_size_);
+    }
+    this->tensor_arena_size_probed_ = true;
+  }
+
+  if (this->tensor_arena_ == nullptr) {
+    this->tensor_arena_ = arena_allocator.allocate(this->tensor_arena_size_);
+    if (this->tensor_arena_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate the streaming model's tensor arena.");
+      return false;
+    }
+  }
+
+  if (this->interpreter_ == nullptr) {
+    this->interpreter_ =
+        make_unique<tflite::MicroInterpreter>(tflite::GetModel(this->model_start_), this->streaming_op_resolver_,
+                                              this->tensor_arena_, this->tensor_arena_size_, this->mrv_);
+    if (this->interpreter_->AllocateTensors() != kTfLiteOk) {
+      ESP_LOGE(TAG, "Failed to allocate tensors for the streaming model");
+      return false;
+    }
+
+    // Verify input tensor matches expected values
+    // Dimension 3 will represent the first layer stride, so skip it may vary
+    TfLiteTensor *input = this->interpreter_->input(0);
+    if ((input->dims->size != 3) || (input->dims->data[0] != 1) ||
+        (input->dims->data[2] != PREPROCESSOR_FEATURE_SIZE)) {
+      ESP_LOGE(TAG, "Streaming model tensor input dimensions has improper dimensions.");
+      return false;
+    }
+
+    if (input->type != kTfLiteInt8) {
+      ESP_LOGE(TAG, "Streaming model tensor input is not int8.");
+      return false;
+    }
+
+    // Verify output tensor matches expected values
+    TfLiteTensor *output = this->interpreter_->output(0);
+    if ((output->dims->size != 2) || (output->dims->data[0] != 1) || (output->dims->data[1] != 1)) {
+      ESP_LOGE(TAG, "Streaming model tensor output dimension is not 1x1.");
+      return false;
+    }
+
+    if (output->type != kTfLiteUInt8) {
+      ESP_LOGE(TAG, "Streaming model tensor output is not uint8.");
+      return false;
+    }
+  }
+
+  this->loaded_ = true;
+  this->reset_probabilities();
+  return true;
+}
+
+size_t StreamingModel::probe_arena_size_() {
+  RAMAllocator<uint8_t> arena_allocator;
+
+  // Try with the manifest size first, then escalates to 1.5, then 2x if it fails. Different platforms and different
+  // versions of the esp-nn library require different amounts of memory, so the manifest size may not always be correct,
+  // and probing allows us to find the actual required size for the current build and platform. Aligns test sizes to 16
+  // bytes.
+  size_t attempt_sizes[] = {(this->tensor_arena_size_ + 15) & ~15, (this->tensor_arena_size_ * 3 / 2 + 15) & ~15,
+                            (this->tensor_arena_size_ * 2 + 15) & ~15};
+
+  for (size_t attempt_size : attempt_sizes) {
+    uint8_t *probe_arena = arena_allocator.allocate(attempt_size);
+    if (probe_arena == nullptr) {
+      continue;
+    }
+
+    // Verify the model works at all with this arena size
+    auto probe_interpreter = make_unique<tflite::MicroInterpreter>(
+        tflite::GetModel(this->model_start_), this->streaming_op_resolver_, probe_arena, attempt_size, this->mrv_);
+
+    if (probe_interpreter->AllocateTensors() != kTfLiteOk) {
+      probe_interpreter.reset();
+      arena_allocator.deallocate(probe_arena, attempt_size);
+      this->ma_ = tflite::MicroAllocator::Create(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+      this->mrv_ = tflite::MicroResourceVariables::Create(this->ma_, 20);
+      continue;
+    }
+
+    // Try to shrink the arena. Start with arena_used_bytes() + 16 (rounded to 16-byte alignment).
+    // If that works, use it. Otherwise, try midpoints between that and the full size until one succeeds.
+    size_t lower = (probe_interpreter->arena_used_bytes() + 16 + 15) & ~15;
+    probe_interpreter.reset();
+    this->ma_ = tflite::MicroAllocator::Create(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+    this->mrv_ = tflite::MicroResourceVariables::Create(this->ma_, 20);
+
+    size_t upper = attempt_size;
+
+    while (lower < upper) {
+      auto test_interpreter = make_unique<tflite::MicroInterpreter>(
+          tflite::GetModel(this->model_start_), this->streaming_op_resolver_, probe_arena, lower, this->mrv_);
+
+      bool ok = test_interpreter->AllocateTensors() == kTfLiteOk;
+
+      test_interpreter.reset();
+      this->ma_ = tflite::MicroAllocator::Create(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+      this->mrv_ = tflite::MicroResourceVariables::Create(this->ma_, 20);
+
+      if (ok) {
+        // Found a working size smaller than the full arena
+        upper = lower + 16;  // Pad by 16 bytes to be safe for future allocations
+        break;
+      }
+
+      // Try the midpoint between current attempt and full size
+      lower = ((lower + upper) / 2 + 15) & ~15;
+    }
+
+    arena_allocator.deallocate(probe_arena, attempt_size);
+    return upper;
+  }
+
+  return 0;
+}
+
+void StreamingModel::unload_model() {
+  this->interpreter_.reset();
+
+  RAMAllocator<uint8_t> arena_allocator;
+
+  if (this->tensor_arena_ != nullptr) {
+    arena_allocator.deallocate(this->tensor_arena_, this->tensor_arena_size_);
+    this->tensor_arena_ = nullptr;
+  }
+
+  if (this->var_arena_ != nullptr) {
+    arena_allocator.deallocate(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+    this->var_arena_ = nullptr;
+  }
+
+  this->loaded_ = false;
+}
+
+bool StreamingModel::perform_streaming_inference(const int8_t features[PREPROCESSOR_FEATURE_SIZE]) {
+  if (this->enabled_ && !this->loaded_) {
+    // Model is enabled but isn't loaded
+    if (!this->load_model_()) {
+      return false;
+    }
+  }
+
+  if (!this->enabled_ && this->loaded_) {
+    // Model is disabled but still loaded
+    this->unload_model();
+    return true;
+  }
+
+  if (this->loaded_) {
+    TfLiteTensor *input = this->interpreter_->input(0);
+
+    uint8_t stride = this->interpreter_->input(0)->dims->data[1];
+    this->current_stride_step_ = this->current_stride_step_ % stride;
+
+    std::memmove(
+        (int8_t *) (tflite::GetTensorData<int8_t>(input)) + PREPROCESSOR_FEATURE_SIZE * this->current_stride_step_,
+        features, PREPROCESSOR_FEATURE_SIZE);
+    ++this->current_stride_step_;
+
+    if (this->current_stride_step_ >= stride) {
+      TfLiteStatus invoke_status = this->interpreter_->Invoke();
+      if (invoke_status != kTfLiteOk) {
+        ESP_LOGW(TAG, "Streaming interpreter invoke failed");
+        return false;
+      }
+
+      TfLiteTensor *output = this->interpreter_->output(0);
+
+      ++this->last_n_index_;
+      if (this->last_n_index_ == this->sliding_window_size_)
+        this->last_n_index_ = 0;
+      this->recent_streaming_probabilities_[this->last_n_index_] = output->data.uint8[0];  // probability;
+      this->unprocessed_probability_status_ = true;
+    }
+    if (this->recent_streaming_probabilities_[this->last_n_index_] < this->probability_cutoff_) {
+      // Only increment ignore windows if less than the probability cutoff; this forces the model to "cool-off" from a
+      // previous detection and calling ``reset_probabilities`` so it avoids duplicate detections
+      this->ignore_windows_ = std::min(this->ignore_windows_ + 1, 0);
+    }
+  }
+  return true;
+}
+
+void StreamingModel::reset_probabilities() {
+  for (auto &prob : this->recent_streaming_probabilities_) {
+    prob = 0;
+  }
+  this->ignore_windows_ = -MIN_SLICES_BEFORE_DETECTION;
+}
+
+WakeWordModel::WakeWordModel(const std::string &id, const uint8_t *model_start, uint8_t default_probability_cutoff,
+                             size_t sliding_window_average_size, const std::string &wake_word, size_t tensor_arena_size,
+                             bool default_enabled, bool internal_only) {
+  this->id_ = id;
+  this->model_start_ = model_start;
+  this->default_probability_cutoff_ = default_probability_cutoff;
+  this->probability_cutoff_ = default_probability_cutoff;
+  this->sliding_window_size_ = sliding_window_average_size;
+  this->recent_streaming_probabilities_.resize(sliding_window_average_size, 0);
+  this->wake_word_ = wake_word;
+  this->tensor_arena_size_ = tensor_arena_size;
+  this->register_streaming_ops_(this->streaming_op_resolver_);
+  this->current_stride_step_ = 0;
+  this->internal_only_ = internal_only;
+
+  this->pref_ = global_preferences->make_preference<bool>(fnv1_hash(id));
+  bool enabled;
+  if (this->pref_.load(&enabled)) {
+    // Use the enabled state loaded from flash
+    this->enabled_ = enabled;
+  } else {
+    // If no state saved, then use the default
+    this->enabled_ = default_enabled;
+  }
+};
+
+void WakeWordModel::enable() {
+  this->enabled_ = true;
+  if (!this->internal_only_) {
+    this->pref_.save(&this->enabled_);
+  }
+}
+
+void WakeWordModel::disable() {
+  this->enabled_ = false;
+  if (!this->internal_only_) {
+    this->pref_.save(&this->enabled_);
+  }
+}
+
+DetectionEvent WakeWordModel::determine_detected() {
+  DetectionEvent detection_event;
+  detection_event.wake_word = &this->wake_word_;
+  detection_event.max_probability = 0;
+  detection_event.average_probability = 0;
+
+  if ((this->ignore_windows_ < 0) || !this->enabled_) {
+    detection_event.detected = false;
+    return detection_event;
+  }
+
+  uint32_t sum = 0;
+  for (auto &prob : this->recent_streaming_probabilities_) {
+    detection_event.max_probability = std::max(detection_event.max_probability, prob);
+    sum += prob;
+  }
+
+  detection_event.average_probability = sum / this->sliding_window_size_;
+  detection_event.detected = sum > this->probability_cutoff_ * this->sliding_window_size_;
+
+  this->unprocessed_probability_status_ = false;
+  return detection_event;
+}
+
+VADModel::VADModel(const uint8_t *model_start, uint8_t default_probability_cutoff, size_t sliding_window_size,
+                   size_t tensor_arena_size) {
+  this->model_start_ = model_start;
+  this->default_probability_cutoff_ = default_probability_cutoff;
+  this->probability_cutoff_ = default_probability_cutoff;
+  this->sliding_window_size_ = sliding_window_size;
+  this->recent_streaming_probabilities_.resize(sliding_window_size, 0);
+  this->tensor_arena_size_ = tensor_arena_size;
+  this->register_streaming_ops_(this->streaming_op_resolver_);
+}
+
+DetectionEvent VADModel::determine_detected() {
+  DetectionEvent detection_event;
+  detection_event.max_probability = 0;
+  detection_event.average_probability = 0;
+
+  if (!this->enabled_) {
+    // We disabled the VAD model for some reason... so we shouldn't block wake words from being detected
+    detection_event.detected = true;
+    return detection_event;
+  }
+
+  uint32_t sum = 0;
+  for (auto &prob : this->recent_streaming_probabilities_) {
+    detection_event.max_probability = std::max(detection_event.max_probability, prob);
+    sum += prob;
+  }
+
+  detection_event.average_probability = sum / this->sliding_window_size_;
+  detection_event.detected = sum > (this->probability_cutoff_ * this->sliding_window_size_);
+
+  return detection_event;
+}
+
+bool StreamingModel::register_streaming_ops_(tflite::MicroMutableOpResolver<20> &op_resolver) {
+  if (op_resolver.AddCallOnce() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddVarHandle() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddReshape() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddReadVariable() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddStridedSlice() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddConcatenation() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddAssignVariable() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddConv2D() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddMul() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddAdd() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddMean() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddFullyConnected() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddLogistic() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddQuantize() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddDepthwiseConv2D() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddAveragePool2D() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddMaxPool2D() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddPad() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddPack() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddSplitV() != kTfLiteOk)
+    return false;
+
+  return true;
+}
+
+}  // namespace micro_wake_word
+}  // namespace esphome
+
+#endif

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "preprocessor_settings.h"
+
+#include "esphome/core/preferences.h"
+
+#include <tensorflow/lite/core/c/common.h>
+#include <tensorflow/lite/micro/micro_interpreter.h>
+#include <tensorflow/lite/micro/micro_mutable_op_resolver.h>
+
+namespace esphome {
+namespace micro_wake_word {
+
+static const uint8_t MIN_SLICES_BEFORE_DETECTION = 100;
+static const uint32_t STREAMING_MODEL_VARIABLE_ARENA_SIZE = 1024;
+
+struct DetectionEvent {
+  std::string *wake_word;
+  bool detected;
+  bool partially_detection;  // Set if the most recent probability exceed the threshold, but the sliding window average
+                             // hasn't yet
+  uint8_t max_probability;
+  uint8_t average_probability;
+  bool blocked_by_vad = false;
+};
+
+class StreamingModel {
+ public:
+  virtual void log_model_config() = 0;
+  virtual DetectionEvent determine_detected() = 0;
+
+  // Performs inference on the given features.
+  //  - If the model is enabled but not loaded, it will load it
+  //  - If the model is disabled but loaded, it will unload it
+  // Returns true if sucessful or false if there is an error
+  bool perform_streaming_inference(const int8_t features[PREPROCESSOR_FEATURE_SIZE]);
+
+  /// @brief Sets all recent_streaming_probabilities to 0 and resets the ignore window count
+  void reset_probabilities();
+
+  /// @brief Destroys the TFLite interpreter and frees the tensor and variable arenas' memory
+  void unload_model();
+
+  /// @brief Enable the model. The next performing_streaming_inference call will load it.
+  virtual void enable() { this->enabled_ = true; }
+
+  /// @brief Disable the model. The next performing_streaming_inference call will unload it.
+  virtual void disable() { this->enabled_ = false; }
+
+  /// @brief Return true if the model is enabled.
+  bool is_enabled() const { return this->enabled_; }
+
+  bool get_unprocessed_probability_status() const { return this->unprocessed_probability_status_; }
+
+  // Quantized probability cutoffs mapping 0.0 - 1.0 to 0 - 255
+  uint8_t get_default_probability_cutoff() const { return this->default_probability_cutoff_; }
+  uint8_t get_probability_cutoff() const { return this->probability_cutoff_; }
+  void set_probability_cutoff(uint8_t probability_cutoff) { this->probability_cutoff_ = probability_cutoff; }
+
+ protected:
+  /// @brief Allocates tensor and variable arenas and sets up the model interpreter
+  /// @return True if successful, false otherwise
+  bool load_model_();
+  /// @brief Probes the actual required tensor arena size by trial allocation.
+  /// Tries the manifest size first, then 2x if that fails.
+  /// @return The required arena size rounded up to 16-byte alignment, or 0 on failure.
+  size_t probe_arena_size_();
+  /// @brief Returns true if successfully registered the streaming model's TensorFlow operations
+  bool register_streaming_ops_(tflite::MicroMutableOpResolver<20> &op_resolver);
+
+  tflite::MicroMutableOpResolver<20> streaming_op_resolver_;
+
+  bool loaded_{false};
+  bool enabled_{true};
+  bool tensor_arena_size_probed_{false};
+  bool unprocessed_probability_status_{false};
+  uint8_t current_stride_step_{0};
+  int16_t ignore_windows_{-MIN_SLICES_BEFORE_DETECTION};
+
+  uint8_t default_probability_cutoff_;
+  uint8_t probability_cutoff_;
+  size_t sliding_window_size_;
+
+  size_t last_n_index_{0};
+  size_t tensor_arena_size_;
+  std::vector<uint8_t> recent_streaming_probabilities_;
+
+  const uint8_t *model_start_;
+  uint8_t *tensor_arena_{nullptr};
+  uint8_t *var_arena_{nullptr};
+  std::unique_ptr<tflite::MicroInterpreter> interpreter_;
+  tflite::MicroResourceVariables *mrv_{nullptr};
+  tflite::MicroAllocator *ma_{nullptr};
+};
+
+class WakeWordModel final : public StreamingModel {
+ public:
+  /// @brief Constructs a wake word model object
+  /// @param id (std::string) identifier for this model
+  /// @param model_start (const uint8_t *) pointer to the start of the model's TFLite FlatBuffer
+  /// @param default_probability_cutoff (uint8_t) probability cutoff for acceping the wake word has been said
+  /// @param sliding_window_average_size (size_t) the length of the sliding window computing the mean rolling
+  ///                                    probability
+  /// @param wake_word (std::string) Friendly name of the wake word
+  /// @param tensor_arena_size (size_t) Size in bytes for allocating the tensor arena
+  /// @param default_enabled (bool) If true, it will be enabled by default on first boot
+  /// @param internal_only (bool) If true, the model will not be exposed to HomeAssistant as an available model
+  WakeWordModel(const std::string &id, const uint8_t *model_start, uint8_t default_probability_cutoff,
+                size_t sliding_window_average_size, const std::string &wake_word, size_t tensor_arena_size,
+                bool default_enabled, bool internal_only);
+
+  void log_model_config() override;
+
+  /// @brief Checks for the wake word by comparing the mean probability in the sliding window with the probability
+  /// cutoff
+  /// @return True if wake word is detected, false otherwise
+  DetectionEvent determine_detected() override;
+
+  const std::string &get_id() const { return this->id_; }
+  const std::string &get_wake_word() const { return this->wake_word_; }
+
+  void add_trained_language(const std::string &language) { this->trained_languages_.push_back(language); }
+  const std::vector<std::string> &get_trained_languages() const { return this->trained_languages_; }
+
+  /// @brief Enable the model and save to flash. The next performing_streaming_inference call will load it.
+  void enable() override;
+
+  /// @brief Disable the model and save to flash. The next performing_streaming_inference call will unload it.
+  void disable() override;
+
+  bool get_internal_only() { return this->internal_only_; }
+
+ protected:
+  std::string id_;
+  std::string wake_word_;
+  std::vector<std::string> trained_languages_;
+
+  bool internal_only_;
+
+  ESPPreferenceObject pref_;
+};
+
+class VADModel final : public StreamingModel {
+ public:
+  VADModel(const uint8_t *model_start, uint8_t default_probability_cutoff, size_t sliding_window_size,
+           size_t tensor_arena_size);
+
+  void log_model_config() override;
+
+  /// @brief Checks for voice activity by comparing the max probability in the sliding window with the probability
+  /// cutoff
+  /// @return True if voice activity is detected, false otherwise
+  DetectionEvent determine_detected() override;
+};
+
+}  // namespace micro_wake_word
+}  // namespace esphome
+
+#endif

--- a/esphome/components/wake_audio_stream/__init__.py
+++ b/esphome/components/wake_audio_stream/__init__.py
@@ -1,0 +1,87 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation
+from esphome.automation import register_action, register_condition
+from esphome.const import CONF_ID, CONF_PORT
+
+AUTO_LOAD = ["socket"]
+CODEOWNERS = ["@constructorfleet"]
+
+CONF_IP_ADDRESS = "ip_address"
+CONF_BUFFER_DURATION = "buffer_duration"
+CONF_ENABLED_ON_BOOT = "enabled_on_boot"
+
+wake_audio_stream_ns = cg.esphome_ns.namespace("wake_audio_stream")
+WakeAudioStream = wake_audio_stream_ns.class_("WakeAudioStream", cg.Component)
+
+StartAction = wake_audio_stream_ns.class_(
+    "StartAction", automation.Action, cg.Parented.template(WakeAudioStream)
+)
+StopAction = wake_audio_stream_ns.class_(
+    "StopAction", automation.Action, cg.Parented.template(WakeAudioStream)
+)
+IsRunningCondition = wake_audio_stream_ns.class_(
+    "IsRunningCondition", automation.Condition, cg.Parented.template(WakeAudioStream)
+)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(WakeAudioStream),
+            cv.Required(CONF_IP_ADDRESS): cv.ipv4address,
+            cv.Optional(CONF_PORT, default=6056): cv.port,
+            cv.Optional(
+                CONF_BUFFER_DURATION, default="500ms"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_ENABLED_ON_BOOT, default=False): cv.boolean,
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    cv.only_on_esp32,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    octets = config[CONF_IP_ADDRESS].packed
+    cg.add(var.set_remote_ip(octets[0], octets[1], octets[2], octets[3]))
+    cg.add(var.set_remote_port(config[CONF_PORT]))
+    cg.add(var.set_buffer_duration_ms(config[CONF_BUFFER_DURATION].total_milliseconds))
+    cg.add(var.set_enabled(config[CONF_ENABLED_ON_BOOT]))
+
+
+WAKE_AUDIO_STREAM_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(WakeAudioStream)})
+
+
+@register_action(
+    "wake_audio_stream.start",
+    StartAction,
+    WAKE_AUDIO_STREAM_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def wake_audio_stream_start_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@register_action(
+    "wake_audio_stream.stop",
+    StopAction,
+    WAKE_AUDIO_STREAM_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def wake_audio_stream_stop_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@register_condition(
+    "wake_audio_stream.is_running", IsRunningCondition, WAKE_AUDIO_STREAM_ACTION_SCHEMA
+)
+async def wake_audio_stream_is_running_to_code(config, condition_id, template_arg, args):
+    var = cg.new_Pvariable(condition_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var

--- a/esphome/components/wake_audio_stream/wake_audio_stream.cpp
+++ b/esphome/components/wake_audio_stream/wake_audio_stream.cpp
@@ -1,0 +1,137 @@
+#include "wake_audio_stream.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/log.h"
+
+#include <cerrno>
+#include <cstring>
+
+namespace esphome {
+namespace wake_audio_stream {
+
+static const char *const TAG = "wake_audio_stream";
+
+// microWakeWord feeds mono int16 PCM at 16 kHz.
+static const size_t BYTES_PER_SECOND = 16000 * sizeof(int16_t);
+
+// Max UDP payload we send per datagram. Kept below a typical MTU to avoid IP fragmentation. Must be a
+// multiple of sizeof(int16_t) so we never split a sample across datagrams.
+static const size_t SEND_CHUNK_SIZE = 1024;
+
+float WakeAudioStream::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
+
+void WakeAudioStream::setup() {
+  size_t ring_bytes = BYTES_PER_SECOND * this->buffer_duration_ms_ / 1000;
+  // Round up to a whole number of send chunks so draining is clean.
+  ring_bytes = ((ring_bytes + SEND_CHUNK_SIZE - 1) / SEND_CHUNK_SIZE) * SEND_CHUNK_SIZE;
+  this->ring_buffer_ = RingBuffer::create(ring_bytes);
+  if (this->ring_buffer_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to allocate %u byte ring buffer", (unsigned) ring_bytes);
+    this->mark_failed();
+    return;
+  }
+  this->send_buffer_.resize(SEND_CHUNK_SIZE);
+}
+
+void WakeAudioStream::dump_config() {
+  ESP_LOGCONFIG(TAG, "Wake Audio Stream:");
+  ESP_LOGCONFIG(TAG, "  Destination: %u.%u.%u.%u:%u", this->remote_ip_[0], this->remote_ip_[1], this->remote_ip_[2],
+                this->remote_ip_[3], this->remote_port_);
+  ESP_LOGCONFIG(TAG, "  Buffer duration: %u ms", (unsigned) this->buffer_duration_ms_);
+  ESP_LOGCONFIG(TAG, "  Enabled on boot: %s", YESNO(this->enabled_));
+}
+
+bool WakeAudioStream::start_socket_() {
+  struct sockaddr_in server_addr;
+  memset(&server_addr, 0, sizeof(server_addr));
+  memset(&this->dest_addr_, 0, sizeof(this->dest_addr_));
+
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(this->remote_port_);
+  // s_addr is stored in network byte order, i.e. the octets laid out as [a, b, c, d] in memory.
+  memcpy(&server_addr.sin_addr.s_addr, this->remote_ip_, sizeof(this->remote_ip_));
+
+  memcpy(&this->dest_addr_, &server_addr, sizeof(server_addr));
+
+  this->socket_ = socket::socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+  if (this->socket_ == nullptr) {
+    ESP_LOGE(TAG, "Could not create socket");
+    return false;
+  }
+  int err = this->socket_->setblocking(false);
+  if (err != 0) {
+    ESP_LOGE(TAG, "Could not set non-blocking mode: errno %d", errno);
+    this->socket_ = nullptr;
+    return false;
+  }
+
+  this->socket_running_ = true;
+  return true;
+}
+
+void WakeAudioStream::stop_socket_() {
+  if (this->socket_ != nullptr) {
+    this->socket_->close();
+    this->socket_ = nullptr;
+  }
+  this->socket_running_ = false;
+}
+
+void WakeAudioStream::set_enabled(bool enabled) {
+  if (enabled == this->enabled_) {
+    return;
+  }
+  this->enabled_ = enabled;
+  if (enabled) {
+    ESP_LOGI(TAG, "Wake-word audio capture enabled -> %u.%u.%u.%u:%u", this->remote_ip_[0], this->remote_ip_[1],
+             this->remote_ip_[2], this->remote_ip_[3], this->remote_port_);
+  } else {
+    ESP_LOGI(TAG, "Wake-word audio capture disabled");
+    this->stop_socket_();
+    if (this->ring_buffer_ != nullptr) {
+      this->ring_buffer_->reset();
+    }
+  }
+}
+
+void WakeAudioStream::push_audio(const std::vector<uint8_t> &data) {
+  // Runs on the microphone task. Only buffer while enabled; the ring buffer is thread-safe and overwrites
+  // the oldest data if the main loop cannot drain it fast enough.
+  if (!this->enabled_ || this->ring_buffer_ == nullptr) {
+    return;
+  }
+  this->ring_buffer_->write(data.data(), data.size());
+}
+
+void WakeAudioStream::loop() {
+  if (!this->enabled_ || this->ring_buffer_ == nullptr) {
+    return;
+  }
+
+  if (!this->socket_running_) {
+    if (!this->start_socket_()) {
+      // Back off; retry on a later loop.
+      return;
+    }
+  }
+
+  while (this->ring_buffer_->available() >= SEND_CHUNK_SIZE) {
+    size_t read_bytes = this->ring_buffer_->read(this->send_buffer_.data(), SEND_CHUNK_SIZE, 0);
+    if (read_bytes == 0) {
+      break;
+    }
+    ssize_t sent = this->socket_->sendto(this->send_buffer_.data(), read_bytes, 0,
+                                         (struct sockaddr *) &this->dest_addr_, sizeof(this->dest_addr_));
+    if (sent < 0) {
+      // ENOMEM/EAGAIN just means the stack is momentarily busy; drop this chunk and try again next loop.
+      ESP_LOGV(TAG, "sendto failed: errno %d", errno);
+      break;
+    }
+  }
+}
+
+}  // namespace wake_audio_stream
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/wake_audio_stream/wake_audio_stream.h
+++ b/esphome/components/wake_audio_stream/wake_audio_stream.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/ring_buffer.h"
+
+#include "esphome/components/socket/socket.h"
+
+#include <memory>
+#include <vector>
+
+namespace esphome {
+namespace wake_audio_stream {
+
+/// Streams raw audio (int16 PCM, mono, 16 kHz) off-device over UDP so it can be recorded and labeled as
+/// wake-word training data. It is fed by microWakeWord's `on_audio_data` trigger, which delivers the exact
+/// audio the wake-word models process (so both detections and misses can be captured). Audio arrives on the
+/// microphone task; it is buffered in a thread-safe ring buffer and flushed to the socket from the main loop.
+class WakeAudioStream : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+  void set_remote_ip(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+    this->remote_ip_[0] = a;
+    this->remote_ip_[1] = b;
+    this->remote_ip_[2] = c;
+    this->remote_ip_[3] = d;
+  }
+  void set_remote_port(uint16_t port) { this->remote_port_ = port; }
+  void set_buffer_duration_ms(uint32_t duration_ms) { this->buffer_duration_ms_ = duration_ms; }
+
+  /// Enable or disable capture. Toggled from a switch/action.
+  void set_enabled(bool enabled);
+  bool is_running() const { return this->enabled_; }
+
+  /// Push a chunk of raw audio into the send buffer. Called from the microphone task via the trigger.
+  void push_audio(const std::vector<uint8_t> &data);
+
+ protected:
+  bool start_socket_();
+  void stop_socket_();
+
+  uint8_t remote_ip_[4]{0, 0, 0, 0};
+  uint16_t remote_port_{6056};
+  uint32_t buffer_duration_ms_{500};
+
+  bool enabled_{false};
+
+  std::unique_ptr<RingBuffer> ring_buffer_;
+  std::vector<uint8_t> send_buffer_;
+
+  std::unique_ptr<socket::Socket> socket_{nullptr};
+  struct sockaddr_storage dest_addr_;
+  bool socket_running_{false};
+};
+
+template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<WakeAudioStream> {
+ public:
+  void play(Ts... x) override { this->parent_->set_enabled(true); }
+};
+
+template<typename... Ts> class StopAction : public Action<Ts...>, public Parented<WakeAudioStream> {
+ public:
+  void play(Ts... x) override { this->parent_->set_enabled(false); }
+};
+
+template<typename... Ts> class IsRunningCondition : public Condition<Ts...>, public Parented<WakeAudioStream> {
+ public:
+  bool check(Ts... x) override { return this->parent_->is_running(); }
+};
+
+}  // namespace wake_audio_stream
+}  // namespace esphome
+
+#endif  // USE_ESP32


### PR DESCRIPTION
Vendor a patched micro_wake_word (stock ESPHome 2026.4.5 + an on_audio_data trigger) that emits the exact int16/16kHz/mono PCM the wake-word models process, including audio where no wake word fired (false negatives).

Add a wake_audio_stream component that buffers that audio and streams it as raw UDP datagrams to a training-data collector, gated by a "Capture wake-word audio" toggle switch. On detection, POST /wake_event to the collector over HTTP so the UDP path needs no MQTT broker.

Wire both into the local satellite1.yaml build and the voice_assistant package.