### PR TITLE
fix(components): drop stale dump_summary overrides for ESPHome 2026.7

### DIFF
--- a/esphome/components/pcm5122/pcm_gpio.h
+++ b/esphome/components/pcm5122/pcm_gpio.h
@@ -13,7 +13,6 @@ class PCMGPIOPin : public GPIOPin, public Parented<PCM5122> {
   void pin_mode(gpio::Flags flags) override {}
   bool digital_read() override;
   void digital_write(bool value) override;
-  std::string dump_summary() const override { return ""; };
 
   void set_pin(uint8_t pin) { this->pin_ = pin; }
   void set_inverted(bool inverted) { this->inverted_ = inverted; }

--- a/esphome/components/satellite1/sat_gpio.h
+++ b/esphome/components/satellite1/sat_gpio.h
@@ -23,7 +23,6 @@ class Satellite1GPIOPin : public GPIOPin, public Satellite1SPIService {
   void pin_mode(gpio::Flags flags) override {}
   bool digital_read() override;
   void digital_write(bool value) override;
-  std::string dump_summary() const override { return ""; };
 
   void set_pin(XMOSPort port, uint8_t pin) {
     this->port_ = port;


### PR DESCRIPTION
ESPHome 2026.7.0 removed the deprecated `std::string GPIOPin::dump_summary()` overload. The buffer form replaced it in 2026.1, and the header said the old one would be removed in 2026.7.0, which happened on schedule. The overrides in `pcm5122/pcm_gpio.h` and `satellite1/sat_gpio.h` still use the old signature, so any build against 2026.7 fails:

```
error: 'std::string esphome::pcm5122::PCMGPIOPin::dump_summary() const' marked 'override', but does not override
error: 'std::string esphome::satellite1::Satellite1GPIOPin::dump_summary() const' marked 'override', but does not override
```

I compiled the dashboard import config with esphome 2026.7.3 against develop with and without this change: develop fails with the two errors above, this branch compiles clean.

Removing the overrides is also safe on 2026.6.x. The base class default writes an empty summary, which is exactly what these overrides did.

CI does not catch this because `requirements.txt` pins esphome 2026.6.5, which still has the backward compat bridge. The Home Assistant add-on ships 2026.7.x, so anyone compiling from the dashboard builds against that instead. Whether to bump the pin is a separate question from this PR.

I flashed the result OTA to a Satellite1 through the HA add-on (2026.7.3); the device boots and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
