### PR TITLE
Migrate from esphome::RingBuffer to ring_buffer::RingBuffer

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -535,7 +535,7 @@ esp_err_t I2SAudioSpeaker::allocate_buffers_(size_t data_buffer_size, size_t rin
 
   if (this->audio_ring_buffer_.use_count() == 0) {
     // Allocate ring buffer. Uses a shared_ptr to ensure it isn't improperly deallocated.
-    this->audio_ring_buffer_ = RingBuffer::create(ring_buffer_size);
+    this->audio_ring_buffer_ = ring_buffer::RingBuffer::create(ring_buffer_size);
   }
 
   if (this->audio_ring_buffer_ == nullptr) {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -10,11 +10,11 @@
 
 #include "esphome/components/audio/audio.h"
 #include "esphome/components/speaker/speaker.h"
+#include "esphome/components/ring_buffer/ring_buffer.h"
 
 #include "esphome/core/component.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/helpers.h"
-#include "esphome/core/ring_buffer.h"
 
 namespace esphome {
 namespace i2s_audio {
@@ -114,7 +114,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   EventGroupHandle_t event_group_{nullptr};
 
   uint8_t *data_buffer_{nullptr};
-  std::shared_ptr<esphome::RingBuffer> audio_ring_buffer_;
+  std::shared_ptr<ring_buffer::RingBuffer> audio_ring_buffer_;
 
   uint32_t buffer_duration_ms_;
 


### PR DESCRIPTION
The RingBuffer integration has moved upstream from core to a dedicated component.
This PR updates the i2s_audio/speaker component to use the new component version.