### PR TITLE
Fix ESP-IDF logging format warnings

### DIFF
--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -2,6 +2,8 @@
 
 #ifdef USE_ESP32
 
+#include <cinttypes>
+
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -23,7 +25,7 @@ void I2SAudioBase::dump_i2s_settings() const {
   } else {
     ESP_LOGCONFIG(TAG, "I2S-Writer (%s):", init_str.c_str());
   }
-  ESP_LOGCONFIG(TAG, "  sample-rate: %d slot_mode: %d slot_mask: %d slot_bit_width: %d", this->sample_rate_,
+  ESP_LOGCONFIG(TAG, "  sample-rate: %" PRIu32 " slot_mode: %d slot_mask: %d slot_bit_width: %d", this->sample_rate_,
                 this->slot_mode_, this->std_slot_mask_, this->slot_bit_width_);
   ESP_LOGCONFIG(TAG, "  use_apll: %s", this->use_apll_ ? "yes" : "no");
 }

--- a/esphome/components/memory_flasher/memory_flasher.cpp
+++ b/esphome/components/memory_flasher/memory_flasher.cpp
@@ -33,7 +33,7 @@ bool MemoryFlasher::http_get_md5_() {
     return false;
   }
   if (length < MD5_SIZE) {
-    ESP_LOGE(TAG, "MD5 file must be %u bytes; %u bytes reported by HTTP server. Aborting", MD5_SIZE, length);
+    ESP_LOGE(TAG, "MD5 file must be %hhu bytes; %zu bytes reported by HTTP server. Aborting", MD5_SIZE, length);
     container->end();
     return false;
   }
@@ -47,7 +47,7 @@ bool MemoryFlasher::http_get_md5_() {
   }
   container->end();
 
-  ESP_LOGV(TAG, "Read len: %u, MD5 expected: %u", read_len, MD5_SIZE);
+  ESP_LOGV(TAG, "Read len: %d, MD5 expected: %hhu", read_len, MD5_SIZE);
   return read_len == MD5_SIZE;
 }
 
@@ -98,7 +98,7 @@ bool HttpImageReader::deinit_reader() {
 
 int HttpImageReader::read_image_block(uint8_t *buffer, size_t block_size) {
   int bytes_read = this->container_->read(buffer, block_size);
-  ESP_LOGVV(TAG, "bytes_read_ = %u, body_length_ = %u, bufsize = %i", this->container_->get_bytes_read(),
+  ESP_LOGVV(TAG, "bytes_read_ = %zu, body_length_ = %zu, bufsize = %d", this->container_->get_bytes_read(),
             this->container_->content_length, bytes_read);
   return bytes_read;
 }

--- a/esphome/components/satellite1/light/led_ring.cpp
+++ b/esphome/components/satellite1/light/led_ring.cpp
@@ -10,13 +10,13 @@ void LEDRing::setup() {
   this->buffer_size_ = this->size() * 3;
   this->buf_ = allocator.allocate(this->buffer_size_);
   if (this->buf_ == nullptr) {
-    esph_log_e(TAG, "Failed to allocate buffer of size %u", this->buffer_size_);
+    esph_log_e(TAG, "Failed to allocate buffer of size %zu", this->buffer_size_);
     this->mark_failed();
     return;
   }
   this->effect_data_ = allocator.allocate(this->size());
   if (this->effect_data_ == nullptr) {
-    esph_log_e(TAG, "Failed to allocate effect data of size %u", this->num_leds_);
+    esph_log_e(TAG, "Failed to allocate effect data of size %d", this->num_leds_);
     this->mark_failed();
     return;
   }

--- a/esphome/components/satellite1/memory_flasher/xmos_flashing.cpp
+++ b/esphome/components/satellite1/memory_flasher/xmos_flashing.cpp
@@ -258,7 +258,7 @@ bool XMOSFlasher::chip_erase_() {
 
 bool XMOSFlasher::write_page_(uint32_t byte_addr, uint8_t *buffer) {
   if ((byte_addr & (FLASH_PAGE_SIZE - 1)) != 0) {
-    ESP_LOGE(TAG, "Address needs to be page aligned (%d).", FLASH_PAGE_SIZE);
+    ESP_LOGE(TAG, "Address needs to be page aligned (%zu).", FLASH_PAGE_SIZE);
     return false;
   }
   if (!this->enable_writing_()) {

--- a/esphome/components/satellite1/runtime_testing/spi_error_rate.cpp
+++ b/esphome/components/satellite1/runtime_testing/spi_error_rate.cpp
@@ -1,5 +1,7 @@
 #include "testing.h"
 
+#include <cinttypes>
+
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -76,8 +78,8 @@ void SPIErrorRate::report() {
   uint32_t elapsed_time = (millis() - this->start_time_);
 
   ESP_LOGD(
-      TAG, "Frames: %d, bytes/sec: %4.2f, error_rate: %4.2f incorrect: %d (failed: %d)", this->frames_received_,
-      this->frames_received_ * this->bytes_per_frame_ * 1000. / elapsed_time,
+      TAG, "Frames: %" PRIu32 ", bytes/sec: %4.2f, error_rate: %4.2f incorrect: %" PRIu32 " (failed: %" PRIu32 ")",
+      this->frames_received_, this->frames_received_ * this->bytes_per_frame_ * 1000. / elapsed_time,
       this->frames_received_ ? 1. * this->incorrect_bytes_ / (this->bytes_per_frame_ * this->frames_received_) : 0.,
       this->incorrect_bytes_, this->ignored_cmds_);
 }

--- a/esphome/components/satellite1_radar/ld2410_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2410_handler.cpp
@@ -492,12 +492,15 @@ void LD2410Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
   uint8_t status = buf[8];
 
   if (status != 0) {
-    ESP_LOGW(TAG_LD2410, "Command 0x%04X failed (status=%u)", cmd_word, status);
+    ESP_LOGW(TAG_LD2410, "Command 0x%04X failed (status=%u)", static_cast<unsigned int>(cmd_word),
+             static_cast<unsigned int>(status));
   }
 
   if (cmd_word == 0x01A0 && status == 0 && len >= 18) {
     char ver[32];
-    snprintf(ver, sizeof(ver), "V%u.%02X.%02X%02X%02X%02X", buf[13], buf[12], buf[17], buf[16], buf[15], buf[14]);
+    snprintf(ver, sizeof(ver), "V%u.%02X.%02X%02X%02X%02X", static_cast<unsigned int>(buf[13]),
+             static_cast<unsigned int>(buf[12]), static_cast<unsigned int>(buf[17]), static_cast<unsigned int>(buf[16]),
+             static_cast<unsigned int>(buf[15]), static_cast<unsigned int>(buf[14]));
     if (version_text_sensor != nullptr)
       version_text_sensor->publish_state(ver);
     ESP_LOGI(TAG_LD2410, "Firmware version: %s", ver);
@@ -526,7 +529,8 @@ void LD2410Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
 
     save_backend_config_();
 
-    ESP_LOGI(TAG_LD2410, "Parameters: max_move=%u max_still=%u", max_move, max_still);
+    ESP_LOGI(TAG_LD2410, "Parameters: max_move=%u max_still=%u", static_cast<unsigned int>(max_move),
+             static_cast<unsigned int>(max_still));
   }
 
   if (cmd_word == 0x0162) {

--- a/esphome/components/satellite1_radar/ld2450_handler.cpp
+++ b/esphome/components/satellite1_radar/ld2450_handler.cpp
@@ -486,12 +486,15 @@ void LD2450Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
   mark_tx_ack_(cmd_word, status);
 
   if (status != 0) {
-    ESP_LOGW(TAG_LD2450, "Command 0x%04X failed (status=%u)", cmd_word, status);
+    ESP_LOGW(TAG_LD2450, "Command 0x%04X failed (status=%u)", static_cast<unsigned int>(cmd_word),
+             static_cast<unsigned int>(status));
   }
 
   if (cmd_word == 0x01A0 && status == 0 && len >= 20) {
     char ver[32];
-    snprintf(ver, sizeof(ver), "V%u.%02X.%02X%02X%02X%02X", buf[13], buf[12], buf[17], buf[16], buf[15], buf[14]);
+    snprintf(ver, sizeof(ver), "V%u.%02X.%02X%02X%02X%02X", static_cast<unsigned int>(buf[13]),
+             static_cast<unsigned int>(buf[12]), static_cast<unsigned int>(buf[17]), static_cast<unsigned int>(buf[16]),
+             static_cast<unsigned int>(buf[15]), static_cast<unsigned int>(buf[14]));
     if (version_text_sensor != nullptr)
       version_text_sensor->publish_state(ver);
     fw_version_received_ = true;
@@ -501,7 +504,9 @@ void LD2450Handler::handle_ack_frame_(const uint8_t *buf, size_t len) {
 
   if (cmd_word == 0x01A5 && status == 0 && len >= 16) {
     char mac[20];
-    snprintf(mac, sizeof(mac), "%02X:%02X:%02X:%02X:%02X:%02X", buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]);
+    snprintf(mac, sizeof(mac), "%02X:%02X:%02X:%02X:%02X:%02X", static_cast<unsigned int>(buf[10]),
+             static_cast<unsigned int>(buf[11]), static_cast<unsigned int>(buf[12]), static_cast<unsigned int>(buf[13]),
+             static_cast<unsigned int>(buf[14]), static_cast<unsigned int>(buf[15]));
     ESP_LOGI(TAG_LD2450, "BT MAC: %s", mac);
   }
 
@@ -577,7 +582,8 @@ bool LD2450Handler::consume_tx_ack_(uint16_t expected_cmd, uint8_t &status_out) 
   tx_ack_pending_ = false;
 
   if (ack_cmd != expected_cmd) {
-    ESP_LOGD(TAG_LD2450, "Ignoring ACK for 0x%04X while waiting for 0x%04X", ack_cmd, expected_cmd);
+    ESP_LOGD(TAG_LD2450, "Ignoring ACK for 0x%04X while waiting for 0x%04X", static_cast<unsigned int>(ack_cmd),
+             static_cast<unsigned int>(expected_cmd));
     return false;
   }
 
@@ -588,7 +594,7 @@ bool LD2450Handler::consume_tx_ack_(uint16_t expected_cmd, uint8_t &status_out) 
 void LD2450Handler::mark_command_failed_(uint16_t cmd_word, const char *reason) {
   last_failed_cmd_ = cmd_word;
   ack_failure_count_++;
-  ESP_LOGW(TAG_LD2450, "Command 0x%04X failed (%s)", cmd_word, reason);
+  ESP_LOGW(TAG_LD2450, "Command 0x%04X failed (%s)", static_cast<unsigned int>(cmd_word), reason);
 }
 
 uint16_t LD2450Handler::command_word_(const QueuedCommand &queued) const {
@@ -691,8 +697,9 @@ void LD2450Handler::step_command_tx_() {
         }
         if (tx_retry_count_ < COMMAND_MAX_RETRIES) {
           tx_retry_count_++;
-          ESP_LOGW(TAG_LD2450, "Enable config ACK failed (status=%u), retry %u/%u", ack_status, tx_retry_count_,
-                   COMMAND_MAX_RETRIES);
+          ESP_LOGW(TAG_LD2450, "Enable config ACK failed (status=%u), retry %u/%u",
+                   static_cast<unsigned int>(ack_status), static_cast<unsigned int>(tx_retry_count_),
+                   static_cast<unsigned int>(COMMAND_MAX_RETRIES));
           send_enable_config_();
           return;
         }
@@ -708,7 +715,8 @@ void LD2450Handler::step_command_tx_() {
         ack_timeout_count_++;
         if (tx_retry_count_ < COMMAND_MAX_RETRIES) {
           tx_retry_count_++;
-          ESP_LOGW(TAG_LD2450, "Enable config ACK timeout, retry %u/%u", tx_retry_count_, COMMAND_MAX_RETRIES);
+          ESP_LOGW(TAG_LD2450, "Enable config ACK timeout, retry %u/%u", static_cast<unsigned int>(tx_retry_count_),
+                   static_cast<unsigned int>(COMMAND_MAX_RETRIES));
           send_enable_config_();
           return;
         }
@@ -729,8 +737,9 @@ void LD2450Handler::step_command_tx_() {
         }
         if (tx_retry_count_ < COMMAND_MAX_RETRIES) {
           tx_retry_count_++;
-          ESP_LOGW(TAG_LD2450, "Command ACK failed (cmd=0x%04X status=%u), retry %u/%u", tx_expected_ack_cmd_,
-                   ack_status, tx_retry_count_, COMMAND_MAX_RETRIES);
+          ESP_LOGW(TAG_LD2450, "Command ACK failed (cmd=0x%04X status=%u), retry %u/%u",
+                   static_cast<unsigned int>(tx_expected_ack_cmd_), static_cast<unsigned int>(ack_status),
+                   static_cast<unsigned int>(tx_retry_count_), static_cast<unsigned int>(COMMAND_MAX_RETRIES));
           send_enable_config_();
           return;
         }
@@ -746,8 +755,9 @@ void LD2450Handler::step_command_tx_() {
         ack_timeout_count_++;
         if (tx_retry_count_ < COMMAND_MAX_RETRIES) {
           tx_retry_count_++;
-          ESP_LOGW(TAG_LD2450, "Command ACK timeout (cmd=0x%04X), retry %u/%u", tx_expected_ack_cmd_, tx_retry_count_,
-                   COMMAND_MAX_RETRIES);
+          ESP_LOGW(TAG_LD2450, "Command ACK timeout (cmd=0x%04X), retry %u/%u",
+                   static_cast<unsigned int>(tx_expected_ack_cmd_), static_cast<unsigned int>(tx_retry_count_),
+                   static_cast<unsigned int>(COMMAND_MAX_RETRIES));
           send_enable_config_();
           return;
         }
@@ -763,7 +773,7 @@ void LD2450Handler::step_command_tx_() {
     case TxState::WAIT_DISABLE_ACK:
       if (consume_tx_ack_(tx_expected_ack_cmd_, ack_status)) {
         if (ack_status != 0)
-          ESP_LOGW(TAG_LD2450, "Disable config ACK failed (status=%u)", ack_status);
+          ESP_LOGW(TAG_LD2450, "Disable config ACK failed (status=%u)", static_cast<unsigned int>(ack_status));
         config_session_open_ = false;
         if (drop_active_after_disable_) {
           drop_active_command_("command ack retries exhausted");


### PR DESCRIPTION
Fixes pre-existing variadic logging format mismatches exposed by ESPHome 2026.7's direct ESP-IDF toolchain.

- Corrects integer, size, and byte format specifiers in local I2S, flasher, Satellite1, and radar components.
- Uses portable `PRIu32` and `%zu` formats where applicable.
- Preserves existing logging output and firmware behavior.
