### PR TITLE
Fix/spi status cache latency

### DIFF
--- a/esphome/components/satellite1/sat_gpio.cpp
+++ b/esphome/components/satellite1/sat_gpio.cpp
@@ -15,25 +15,11 @@ void Satellite1GPIOPin::digital_write(bool value) {
 }
 
 bool Satellite1GPIOPin::digital_read() {
-  DC_STATUS_REGISTER::register_id port_register;
-  switch (this->port_) {
-    case XMOSPort::INPUT_A:
-      port_register = DC_STATUS_REGISTER::GPIO_PORT_IN_A;
-      break;
-    case XMOSPort::INPUT_B:
-      port_register = DC_STATUS_REGISTER::GPIO_PORT_IN_B;
-      break;
-    case XMOSPort::OUTPUT_A:
-      port_register = DC_STATUS_REGISTER::GPIO_PORT_OUT_A;
-      break;
-    default:
-      ESP_LOGE(TAG, "Invalid port set.");
-      return 0;
-      break;
+  uint8_t port_value;
+  if (!this->parent_->get_cached_dc_status(this->port_register_, &port_value)) {
+    return false;
   }
-  this->parent_->request_status_register_update();
-  uint8_t port_value = this->parent_->get_dc_status(port_register);
-  return !!(port_value & (1 << this->pin_)) != this->inverted_;
+  return !!(port_value & this->pin_mask_) != this->inverted_;
 }
 
 }  // namespace satellite1

--- a/esphome/components/satellite1/sat_gpio.h
+++ b/esphome/components/satellite1/sat_gpio.h
@@ -27,6 +27,18 @@ class Satellite1GPIOPin : public GPIOPin, public Satellite1SPIService {
   void set_pin(XMOSPort port, uint8_t pin) {
     this->port_ = port;
     this->pin_ = pin;
+    this->pin_mask_ = 1 << pin;
+    switch (port) {
+      case XMOSPort::INPUT_A:
+        this->port_register_ = DC_STATUS_REGISTER::GPIO_PORT_IN_A;
+        break;
+      case XMOSPort::INPUT_B:
+        this->port_register_ = DC_STATUS_REGISTER::GPIO_PORT_IN_B;
+        break;
+      case XMOSPort::OUTPUT_A:
+        this->port_register_ = DC_STATUS_REGISTER::GPIO_PORT_OUT_A;
+        break;
+    }
   }
   void set_inverted(bool inverted) { this->inverted_ = inverted; }
   void set_flags(gpio::Flags flags) { this->flags_ = flags; }
@@ -35,6 +47,8 @@ class Satellite1GPIOPin : public GPIOPin, public Satellite1SPIService {
  protected:
   XMOSPort port_;
   uint8_t pin_;
+  DC_STATUS_REGISTER::register_id port_register_;
+  uint8_t pin_mask_;
   bool inverted_;
   gpio::Flags flags_;
 };

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -44,6 +44,11 @@ void Satellite1::loop() {
       }
       break;
     case SAT_XMOS_CONNECTED_STATE:
+      if (!this->status_refresh_attempted_ ||
+          static_cast<uint32_t>(millis() - this->status_refresh_timestamp_) >= STATUS_REFRESH_INTERVAL_MS) {
+        this->request_status_register_update();
+      }
+      break;
     case SAT_FLASH_CONNECTED_STATE:
       break;
   }
@@ -83,12 +88,31 @@ std::string Satellite1::status_string() {
 }
 
 bool Satellite1::request_status_register_update() {
-  bool ret = this->transfer(0, 0, NULL, 0);
-  uint8_t *arr = this->dc_status_register_;
-  return ret;
+  this->status_refresh_timestamp_ = millis();
+  this->status_refresh_attempted_ = true;
+  bool status_report_received = false;
+  if (!this->transfer(0, 0, nullptr, 0, &status_report_received)) {
+    return false;
+  }
+  if (!status_report_received) {
+    return false;
+  }
+  this->status_register_valid_ = true;
+  return true;
 }
 
-bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload, uint8_t payload_len) {
+bool Satellite1::get_cached_dc_status(DC_STATUS_REGISTER::register_id reg, uint8_t *value) {
+  assert(reg < DC_STATUS_REGISTER::REGISTER_LEN);
+  assert(value != nullptr);
+  if (!this->status_register_valid_) {
+    return false;
+  }
+  *value = this->dc_status_register_[reg];
+  return true;
+}
+
+bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload, uint8_t payload_len,
+                          bool *status_report_received) {
   if (this->spi_flash_direct_access_enabled_) {
     return false;
   }
@@ -96,8 +120,7 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
   uint8_t send_recv_buf[256 + 3] = {0};
   int status_report_dummies = std::max<int>(0, DC_STATUS_REGISTER::REGISTER_LEN - payload_len - 1);
 
-  int attempts = 3;
-  do {
+  for (int attempts = 3;; --attempts) {
     send_recv_buf[0] = resource_id;
     send_recv_buf[1] = command;
     send_recv_buf[2] = payload_len + !!(command & CONTROL_CMD_READ_BIT);
@@ -105,8 +128,11 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
     this->enable();
     this->transfer_array(&send_recv_buf[0], payload_len + 3 + status_report_dummies);
     this->disable();
+    if (send_recv_buf[0] != CONTROL_COMMAND_IGNORED_IN_DEVICE || attempts == 0) {
+      break;
+    }
     vTaskDelay(1);
-  } while (send_recv_buf[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE && attempts-- > 0);
+  }
 
   if (send_recv_buf[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE) {
     return false;
@@ -120,18 +146,23 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
   // Got status register report
   if (send_recv_buf[0] == DC_RESOURCE::CNTRL_ID && send_recv_buf[1] != DC_RET_STATUS::PAYLOAD_AVAILABLE) {
     memcpy(this->dc_status_register_, &send_recv_buf[2], DC_STATUS_REGISTER::REGISTER_LEN);
-    uint8_t *arr = this->dc_status_register_;
+    if (status_report_received != nullptr) {
+      *status_report_received = true;
+    }
   }
 
   if (command & CONTROL_CMD_READ_BIT) {
-    attempts = 3;
-    do {
+    vTaskDelay(1);
+    for (int attempts = 3;; --attempts) {
       memset(send_recv_buf, 0, payload_len + 3);
       this->enable();
       this->transfer_array(&send_recv_buf[0], payload_len + 3);
       this->disable();
+      if (send_recv_buf[0] != CONTROL_COMMAND_IGNORED_IN_DEVICE || attempts == 0) {
+        break;
+      }
       vTaskDelay(1);
-    } while (send_recv_buf[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE && attempts-- > 0);
+    }
 
     if (send_recv_buf[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE) {
       return false;

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -18,7 +18,9 @@ void Satellite1::setup() {
   }
 
   memset(this->xmos_fw_version, 0, 5);
-  this->dfu_get_fw_version_();
+  if (this->check_for_xmos_() && !this->status_register_valid_) {
+    this->request_status_register_update();
+  }
 }
 
 void Satellite1::dump_config() {
@@ -33,10 +35,13 @@ void Satellite1::loop() {
     case SAT_DETACHED_STATE:
       if (this->connection_attempts <= MAX_CONNECTION_ATTEMPTS && (millis() - this->last_attempt_timestamp_) > 1000) {
         if (this->connection_attempts == MAX_CONNECTION_ATTEMPTS) {
+          ESP_LOGW(TAG, "XMOS did not respond after %u connection attempts",
+                   static_cast<unsigned>(MAX_CONNECTION_ATTEMPTS));
           this->state_callback_.call();
         } else if (this->check_for_xmos_()) {
           this->state = SAT_XMOS_CONNECTED_STATE;
           this->connection_attempts = 0;
+          ESP_LOGI(TAG, "XMOS Firmware Version: %s", this->status_string().c_str());
           this->state_callback_.call();
         }
         this->last_attempt_timestamp_ = millis();
@@ -46,7 +51,7 @@ void Satellite1::loop() {
     case SAT_XMOS_CONNECTED_STATE:
       if (!this->status_refresh_attempted_ ||
           static_cast<uint32_t>(millis() - this->status_refresh_timestamp_) >= STATUS_REFRESH_INTERVAL_MS) {
-        this->request_status_register_update();
+        this->request_status_register_update(false);
       }
       break;
     case SAT_FLASH_CONNECTED_STATE:
@@ -87,17 +92,16 @@ std::string Satellite1::status_string() {
   }
 }
 
-bool Satellite1::request_status_register_update() {
+bool Satellite1::request_status_register_update(bool retry) {
   this->status_refresh_timestamp_ = millis();
   this->status_refresh_attempted_ = true;
   bool status_report_received = false;
-  if (!this->transfer(0, 0, nullptr, 0, &status_report_received)) {
+  if (!this->transfer(0, 0, nullptr, 0, &status_report_received, retry)) {
     return false;
   }
   if (!status_report_received) {
     return false;
   }
-  this->status_register_valid_ = true;
   return true;
 }
 
@@ -112,7 +116,7 @@ bool Satellite1::get_cached_dc_status(DC_STATUS_REGISTER::register_id reg, uint8
 }
 
 bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload, uint8_t payload_len,
-                          bool *status_report_received) {
+                          bool *status_report_received, bool retry) {
   if (this->spi_flash_direct_access_enabled_) {
     return false;
   }
@@ -120,7 +124,7 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
   uint8_t send_recv_buf[256 + 3] = {0};
   int status_report_dummies = std::max<int>(0, DC_STATUS_REGISTER::REGISTER_LEN - payload_len - 1);
 
-  for (int attempts = 3;; --attempts) {
+  for (int attempts = retry ? 3 : 0;; --attempts) {
     send_recv_buf[0] = resource_id;
     send_recv_buf[1] = command;
     send_recv_buf[2] = payload_len + !!(command & CONTROL_CMD_READ_BIT);
@@ -146,6 +150,7 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
   // Got status register report
   if (send_recv_buf[0] == DC_RESOURCE::CNTRL_ID && send_recv_buf[1] != DC_RET_STATUS::PAYLOAD_AVAILABLE) {
     memcpy(this->dc_status_register_, &send_recv_buf[2], DC_STATUS_REGISTER::REGISTER_LEN);
+    this->status_register_valid_ = true;
     if (status_report_received != nullptr) {
       *status_report_received = true;
     }
@@ -153,7 +158,7 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
 
   if (command & CONTROL_CMD_READ_BIT) {
     vTaskDelay(1);
-    for (int attempts = 3;; --attempts) {
+    for (int attempts = retry ? 3 : 0;; --attempts) {
       memset(send_recv_buf, 0, payload_len + 3);
       this->enable();
       this->transfer_array(&send_recv_buf[0], payload_len + 3);
@@ -194,7 +199,6 @@ bool Satellite1::dfu_get_fw_version_() {
   }
 
   memcpy(this->xmos_fw_version, version_resp, 5);
-  ESP_LOGI(TAG, "XMOS Firmware Version: %s ", this->status_string().c_str());
 
   return true;
 }

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -21,6 +21,7 @@ static const uint8_t GPIO_SERVICER_RESID_PORT_OUT_A = 221;
 static const uint8_t DFU_CONTROLLER_SERVICER_RESID = 240;
 
 static const uint8_t MAX_CONNECTION_ATTEMPTS = 3;
+static const uint32_t STATUS_REFRESH_INTERVAL_MS = 20;
 
 namespace DC_RESOURCE {
 enum dc_resource_enum {
@@ -61,7 +62,7 @@ enum Satellite1State : uint8_t {
 
 class Satellite1 : public Component,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
-                                         spi::DATA_RATE_1KHZ> {
+                                         spi::DATA_RATE_200KHZ> {
  public:
   Satellite1State state{SAT_DETACHED_STATE};
   uint8_t xmos_fw_version[5];
@@ -98,6 +99,8 @@ class Satellite1 : public Component,
    * @param payload      Pointer to the buffer containing the data to be sent. For read commands,
    *                     this buffer is updated with the response from the device.
    * @param payload_len  Length of the payload buffer in bytes.
+   * @param status_report_received Optional output set when this transfer copied a controller
+   *                                status-register report.
    *
    * @return             A boolean value indicating the success or failure of the operation:
    *                     - `true`: The operation was successful. The payload buffer and/or status
@@ -110,7 +113,8 @@ class Satellite1 : public Component,
    *   a status report (resource ID matches `DC_RESOURCE::CNTRL_ID`), the internal status register
    *   is updated.
    */
-  bool transfer(uint8_t resource_id, uint8_t command, uint8_t *payload, uint8_t payload_len);
+  bool transfer(uint8_t resource_id, uint8_t command, uint8_t *payload, uint8_t payload_len,
+                bool *status_report_received = nullptr);
 
   /**
    * @brief Requests an update to the XMOS device controller's status registers.
@@ -125,6 +129,10 @@ class Satellite1 : public Component,
    *                       issues or ignored commands.
    */
   bool request_status_register_update();
+
+  /// Returns false until a controller status-register report has been cached.
+  /// @param value Non-null output pointer for the cached register value.
+  bool get_cached_dc_status(DC_STATUS_REGISTER::register_id reg, uint8_t *value);
 
   /**
    * @brief Retrieves the cached value of a specific status register.
@@ -160,8 +168,11 @@ class Satellite1 : public Component,
   CallbackManager<void()> state_callback_{};
 
   uint32_t last_attempt_timestamp_{0};
+  uint32_t status_refresh_timestamp_{0};
 
   uint8_t dc_status_register_[DC_STATUS_REGISTER::REGISTER_LEN];
+  bool status_register_valid_{false};
+  bool status_refresh_attempted_{false};
   bool spi_flash_direct_access_enabled_{false};
 
   GPIOPin *xmos_rst_pin_{nullptr};

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -61,8 +61,8 @@ enum Satellite1State : uint8_t {
 };
 
 class Satellite1 : public Component,
-                   public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
-                                         spi::DATA_RATE_200KHZ> {
+                   public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
+                                         spi::DATA_RATE_8MHZ> {
  public:
   Satellite1State state{SAT_DETACHED_STATE};
   uint8_t xmos_fw_version[5];

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -101,6 +101,7 @@ class Satellite1 : public Component,
    * @param payload_len  Length of the payload buffer in bytes.
    * @param status_report_received Optional output set when this transfer copied a controller
    *                                status-register report.
+   * @param retry        Whether ignored commands should be retried.
    *
    * @return             A boolean value indicating the success or failure of the operation:
    *                     - `true`: The operation was successful. The payload buffer and/or status
@@ -114,7 +115,7 @@ class Satellite1 : public Component,
    *   is updated.
    */
   bool transfer(uint8_t resource_id, uint8_t command, uint8_t *payload, uint8_t payload_len,
-                bool *status_report_received = nullptr);
+                bool *status_report_received = nullptr, bool retry = true);
 
   /**
    * @brief Requests an update to the XMOS device controller's status registers.
@@ -128,7 +129,7 @@ class Satellite1 : public Component,
    *                     - `false`: The update request failed, potentially due to communication
    *                       issues or ignored commands.
    */
-  bool request_status_register_update();
+  bool request_status_register_update(bool retry = true);
 
   /// Returns false until a controller status-register report has been cached.
   /// @param value Non-null output pointer for the cached register value.

--- a/esphome/components/satellite1/satellite1.py
+++ b/esphome/components/satellite1/satellite1.py
@@ -50,7 +50,7 @@ SAT1_CONFIG_SCHEMA = (
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(XMOSNoResponseStateTrigger),
         }),
 
-    }).extend(spi_device_schema(True, "1Hz"))
+    }).extend(spi_device_schema(True, "8MHz", "MODE3"))
 )
 
 
@@ -92,4 +92,3 @@ async def erase_memory_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_SATELLITE1])
     return var
-


### PR DESCRIPTION
## Summary

- Cache XMOS controller status reports and refresh them every 20 ms from the Satellite1 component loop.
- Make Satellite1 GPIO reads cache-only, removing SPI transfers, clock checks, and port selection from the hot path.
- Precompute each GPIO pin's status-register mapping and bit mask during setup.
- Preserve the last valid XMOS status report across transient refresh failures.
- Replace unbounded-looking retry loops with bounded retry loops while preserving retry timing.
- Set Satellite1's default SPI configuration to the XMOS-compatible Mode 3 / 8 MHz values.

closes #542 