### PR TITLE
Feature/reverse iperf throughput

### DIFF
--- a/config/manufacturer_testing.yaml
+++ b/config/manufacturer_testing.yaml
@@ -45,16 +45,6 @@ api:
   encryption: !remove
   on_client_connected: !remove
   on_client_disconnected: !remove
-  actions:
-    - action: start_iperf_client
-      variables:
-        server: string
-        duration: int
-      then:
-        - iperf.start_client:
-            server: !lambda return server;
-            duration: !lambda return duration;
-
 iperf:
 
 wifi:

--- a/config/manufacturer_testing_api_actions.yaml
+++ b/config/manufacturer_testing_api_actions.yaml
@@ -17,6 +17,23 @@ api:
         - logger.log: "Reading XMOS firmware version via SPI"
         - lambda: id(satellite1_id).read_xmos_firmware();
 
+    - action: start_iperf_client
+      variables:
+        server: string
+        duration: int
+      then:
+        - iperf.start_client:
+            server: !lambda return server;
+            duration: !lambda return duration;
+
+    - action: start_iperf_server
+      then:
+        - iperf.start_server: {}
+
+    - action: stop_iperf
+      then:
+        - iperf.stop: {}
+
     - action: read_tas2780_voltages
       then:
         - logger.log: "Activating TAS2780 before supply-voltage read"

--- a/esphome/components/iperf/__init__.py
+++ b/esphome/components/iperf/__init__.py
@@ -14,6 +14,12 @@ Iperf = iperf_ns.class_("Iperf", cg.Component)
 StartClientAction = iperf_ns.class_(
     "IPerfStartClientAction", automation.Action, cg.Parented.template(Iperf)
 )
+StartServerAction = iperf_ns.class_(
+    "IPerfStartServerAction", automation.Action, cg.Parented.template(Iperf)
+)
+StopAction = iperf_ns.class_(
+    "IPerfStopAction", automation.Action, cg.Parented.template(Iperf)
+)
 
 CONF_SERVER = "server"
 CONF_HIGH_PERFORMANCE_NET = "high_performance_net"
@@ -50,6 +56,12 @@ IPERF_CLIENT_ACTION_SCHEMA = automation.maybe_simple_id(
     }
 )
 
+IPERF_SERVER_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(Iperf),
+    }
+)
+
 
 @automation.register_action(
     "iperf.start_client", StartClientAction, IPERF_CLIENT_ACTION_SCHEMA, synchronous=True
@@ -61,4 +73,20 @@ async def iperf_register_client_actions(config, action_id, template_arg, args):
     cg.add(var.set_server(server))
     duration = await cg.templatable(config[CONF_DURATION], args, cg.uint32)
     cg.add(var.set_duration(duration))
+    return var
+
+
+@automation.register_action(
+    "iperf.start_server", StartServerAction, IPERF_SERVER_ACTION_SCHEMA, synchronous=True
+)
+async def iperf_register_server_actions(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@automation.register_action("iperf.stop", StopAction, IPERF_SERVER_ACTION_SCHEMA, synchronous=True)
+async def iperf_register_stop_actions(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
     return var

--- a/esphome/components/iperf/automation.h
+++ b/esphome/components/iperf/automation.h
@@ -22,5 +22,15 @@ template<typename... Ts> class IPerfStartClientAction : public Action<Ts...>, pu
   }
 };
 
+template<typename... Ts> class IPerfStartServerAction : public Action<Ts...>, public Parented<Iperf> {
+ public:
+  void play(const Ts &...) override { this->parent_->start_server(); }
+};
+
+template<typename... Ts> class IPerfStopAction : public Action<Ts...>, public Parented<Iperf> {
+ public:
+  void play(const Ts &...) override { this->parent_->stop(); }
+};
+
 }  // namespace iperf
 }  // namespace esphome

--- a/esphome/components/iperf/idf_iperf.cpp
+++ b/esphome/components/iperf/idf_iperf.cpp
@@ -47,5 +47,27 @@ void Iperf::start_client() {
   }
 }
 
+void Iperf::start_server() {
+  iperf_cfg_t config = {};
+  config.flag = IPERF_FLAG_SERVER | IPERF_FLAG_TCP;
+  config.type = IPERF_IP_TYPE_IPV4;
+  config.sport = port_;
+  config.interval = interval_s_;
+  config.format = MBITS_PER_SEC;
+
+  ESP_LOGI(TAG, "Starting iperf server on port %u", port_);
+  const auto error = iperf_start(&config);
+  if (error != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to start iperf server: %d", static_cast<int>(error));
+  }
+}
+
+void Iperf::stop() {
+  const auto error = iperf_stop();
+  if (error != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to stop iperf: %d", static_cast<int>(error));
+  }
+}
+
 }  // namespace iperf
 }  // namespace esphome

--- a/esphome/components/iperf/idf_iperf.cpp
+++ b/esphome/components/iperf/idf_iperf.cpp
@@ -52,7 +52,8 @@ void Iperf::start_server() {
   config.flag = IPERF_FLAG_SERVER | IPERF_FLAG_TCP;
   config.type = IPERF_IP_TYPE_IPV4;
   config.sport = port_;
-  config.interval = interval_s_;
+  config.time = duration_s_;
+  config.interval = interval_s_ ? interval_s_ : IPERF_DEFAULT_INTERVAL;
   config.format = MBITS_PER_SEC;
 
   ESP_LOGI(TAG, "Starting iperf server on port %u", port_);

--- a/esphome/components/iperf/idf_iperf.h
+++ b/esphome/components/iperf/idf_iperf.h
@@ -11,6 +11,8 @@ class Iperf : public Component {
  public:
   float get_setup_priority() const override { return setup_priority::AFTER_CONNECTION + 10; }
   void start_client();
+  void start_server();
+  void stop();
 
   void set_remote_ip(const std::string &ip) { remote_ip_ = ip; }
   void set_duration(uint32_t duration) { duration_s_ = duration; }


### PR DESCRIPTION
- Add ESPHome actions to start and stop an ESP-IDF TCP iperf server.
- Expose start_iperf_server and stop_iperf through manufacturer-testing API actions.
- Configure the server duration explicitly so it remains active for the full test window.