### PR TITLE
Features/gate DAC activation and select TAS power mode from supply rails

### DIFF
--- a/config/common/speaker.yaml
+++ b/config/common/speaker.yaml
@@ -88,7 +88,7 @@ select:
             return 0;
 
 script:
-  # Script to activate TAS2780
+  # The TAS must be active before it can measure PVDD and select its final power mode.
   - id: tas2780_ensure_active
     mode: single
     then:
@@ -96,25 +96,55 @@ script:
           condition:
             lambda: return !id(tas2780_active);
           then:
-            - logger.log:
-                format: "Activating TAS2780 with power mode %d"
-                args: ['id(pd_power_contract) >=9 ? 2 : 0']
             - tas2780.activate:
-                mode: !lambda 'return id(pd_power_contract) >=9 ? 2 : 0;'
-            - lambda: id(tas2780_active) = true;
+            - lambda: id(tas2780_active) = id(speaker_dac).is_active();
+
+  # Both DACs require the XMOS-provided I2S clocks before their outputs are selected.
+  - id: activate_audio_output
+    mode: restart
+    then:
+      - wait_until:
+          lambda: return id(xmos_audio_ready);
+      # A restored line-out selection is invalid when no jack is connected.
+      - if:
+          condition:
+            lambda: |-
+              return !id(audio_output_speaker_requested) && !id(line_out_sensor).state &&
+                     id(dac_proxy).active_dac == 1;
+          then:
+            - lambda: id(audio_output_speaker_requested) = true;
+      - if:
+          condition:
+            lambda: return id(audio_output_speaker_requested);
+          then:
+            - script.execute: tas2780_ensure_active
+            - script.wait: tas2780_ensure_active
+            - if:
+                condition:
+                  lambda: return id(tas2780_active);
+                then:
+                  - dac_proxy.activate_speaker:
+          else:
+            - dac_proxy.activate_line_out:
+
+  - id: activate_restored_audio_output
+    mode: restart
+    then:
+      - script.execute: activate_audio_output
 
   - id: activate_internal_speaker
     mode: single
     then:
       - logger.log: "Activating internal speaker"
-      - script.execute: tas2780_ensure_active
-      - dac_proxy.activate_speaker:
+      - lambda: id(audio_output_speaker_requested) = true;
+      - script.execute: activate_audio_output
 
   - id: activate_line_out
     mode: single
     then:
       - logger.log: "Activating line-out audio"
-      - dac_proxy.activate_line_out:
+      - lambda: id(audio_output_speaker_requested) = false;
+      - script.execute: activate_audio_output
 
 api:
   actions:

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -14,6 +14,8 @@ substitutions:
 
   esp32_fw_version: dev
   xmos_fw_version: "v1.0.3"
+  # Production configurations enable this; dashboard builds only wait for a responding XMOS.
+  xmos_auto_flash_on_boot: "false"
 
 globals:
   # Global initialisation variable. Initialized to true and set to false once everything is connected. Only used to have a smooth "plugging" experience
@@ -31,11 +33,15 @@ globals:
     type: int
     restore_value: no
     initial_value: '0'
-  # Global variable tracking the XMOS flasher status.
-  - id: pd_power_contract
-    type: int
+  # Audio outputs remain muted until the XMOS is responding after any required flash attempt.
+  - id: xmos_audio_ready
+    type: bool
     restore_value: no
-    initial_value: '0'
+    initial_value: 'false'
+  - id: audio_output_speaker_requested
+    type: bool
+    restore_value: no
+    initial_value: 'false'
 
 esphome:
   name: ${node_name}
@@ -55,11 +61,8 @@ esphome:
         - script.execute: control_leds
         - delay: 1s
 
-        # if line_out was used previously but is not available try speaker
-        - lambda: |
-            if( !id(line_out_sensor).state && id(dac_proxy).active_dac == 1){
-              id(dac_proxy).activate_speaker();
-            }
+        - lambda: id(audio_output_speaker_requested) = id(dac_proxy).active_dac == 0;
+        - script.execute: activate_restored_audio_output
 
         # If after 10 minutes, the device is still initializing (It did not yet connect to Home Assistant), turn off the init_in_progress variable and run the script to refresh the LED status
         - delay: 10min
@@ -108,8 +111,7 @@ fusb302b:
       - text_sensor.template.publish:
           id: pd_state_text
           state: !lambda 'return id(pd_fusb302b).contract;'
-      - lambda: id(pd_power_contract) = id(pd_fusb302b).contract_voltage;
-      - script.execute: tas2780_ensure_active
+      - script.execute: activate_restored_audio_output
 
 http_request:
 
@@ -130,15 +132,44 @@ satellite1:
 
   on_xmos_no_response:
     then:
+      - lambda: id(xmos_audio_ready) = false;
       - text_sensor.template.publish:
           id: xmos_firmware_version_text
           state: !lambda 'return id(satellite1_id).status_string();'
+      - if:
+          condition:
+            - lambda: return ${xmos_auto_flash_on_boot};
+            - lambda: return id(init_in_progress);
+            - lambda: return id(xflash).has_image_embedded();
+            - lambda: return !id(xflash).flash_attempted_this_boot();
+          then:
+            - memory_flasher.write_embedded_image:
 
   on_xmos_connected:
     then:
+      - lambda: id(xmos_audio_ready) = false;
       - text_sensor.template.publish:
           id: xmos_firmware_version_text
           state: !lambda 'return id(satellite1_id).status_string();'
+      - delay: 1s
+      - script.execute: control_leds
+      - if:
+          condition:
+            - lambda: return ${xmos_auto_flash_on_boot};
+            - lambda: return id(init_in_progress);
+            - lambda: return id(xflash).has_image_embedded();
+            - lambda: return !id(xflash).match_embedded(id(satellite1_id).xmos_fw_version);
+            - lambda: return !id(xflash).flash_attempted_this_boot();
+          then:
+            - memory_flasher.write_embedded_image:
+          else:
+            - if:
+                condition:
+                  lambda: |-
+                    return id(satellite1_id).is_xmos_connected() && !id(xflash).in_progress();
+                then:
+                  - lambda: id(xmos_audio_ready) = true;
+                  - script.execute: activate_restored_audio_output
 
 memory_flasher:
   - platform: satellite1
@@ -150,6 +181,9 @@ memory_flasher:
 
     on_flashing_start:
       then:
+        - lambda: id(xmos_audio_ready) = false;
+        - tas2780.deactivate:
+        - lambda: id(tas2780_active) = false;
         - lambda: id(xmos_flashing_state) = 1;
         - script.execute: control_leds
 
@@ -164,16 +198,6 @@ memory_flasher:
         - lambda: id(xmos_flashing_state) = 2;
         - script.execute: control_leds
         - lambda: id(xmos_flashing_state) = 0;
-        - if:
-            condition:
-              lambda: |-
-                return id(pd_fusb302b).contract_voltage >= 9;
-            then:
-              - tas2780.activate:
-                  mode: 2
-            else:
-              - tas2780.activate:
-                  mode: 0
 
     on_flashing_failed:
       then:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -4,6 +4,7 @@ substitutions:
 
   # set this version by GHA at build time
   esp32_fw_version: dev
+  xmos_auto_flash_on_boot: "true"
 
 packages:
   # This is an inline package to prefix the on_client_connected with the wait_until action
@@ -24,28 +25,6 @@ packages:
       on_connect:
         - delay: 5s  # Gives time for improv results to be transmitted
         - ble.disable:
-
-    satellite1:
-      on_xmos_no_response:
-        then:
-          - if:
-              condition:
-                - lambda: return id(init_in_progress);
-                - lambda: return id(xflash).has_image_embedded();
-              then:
-                - memory_flasher.write_embedded_image:
-
-      on_xmos_connected:
-        then:
-          - delay: 1s
-          - script.execute: control_leds
-          - if:
-              condition:
-                - lambda: return id(init_in_progress);
-                - lambda: return id(xflash).has_image_embedded();
-                - lambda: return !id(xflash).match_embedded( id(satellite1_id).xmos_fw_version );
-              then:
-                - memory_flasher.write_embedded_image:
 
   home-assistant-voice: !include satellite1.base.yaml
 

--- a/esphome/components/memory_flasher/automation.h
+++ b/esphome/components/memory_flasher/automation.h
@@ -53,8 +53,8 @@ class FlashingStartedTrigger : public Trigger<> {
  public:
   explicit FlashingStartedTrigger(MemoryFlasher *xflash) {
     xflash->add_on_state_callback([this, xflash]() {
-      if (xflash->state == FLASHER_ERASING && this->last_reported_ != FLASHER_ERASING) {
-        this->last_reported_ = FLASHER_ERASING;
+      if (xflash->state == FLASHER_INITIALIZING && this->last_reported_ != FLASHER_INITIALIZING) {
+        this->last_reported_ = FLASHER_INITIALIZING;
         this->trigger();
       } else {
         this->last_reported_ = xflash->state;

--- a/esphome/components/memory_flasher/memory_flasher.h
+++ b/esphome/components/memory_flasher/memory_flasher.h
@@ -130,6 +130,8 @@ class MemoryFlasher : public Component {
 
   virtual bool flash_accessible() { return false; }
   bool has_image_embedded() { return this->embedded_image_.length > 0; }
+  bool flash_attempted_this_boot() const { return this->flash_attempted_this_boot_; }
+  bool in_progress() const { return this->state != FLASHER_IDLE; }
 
   bool match_embedded(uint8_t to_compare[5]) { return memcmp(this->embedded_image_.version.bytes, to_compare, 5) == 0; }
 
@@ -173,6 +175,7 @@ class MemoryFlasher : public Component {
   std::string password_{};
   std::string username_{};
   std::string url_{};
+  bool flash_attempted_this_boot_{false};
 };
 
 }  // namespace memory_flasher

--- a/esphome/components/satellite1/audio_dac/dac_proxy.cpp
+++ b/esphome/components/satellite1/audio_dac/dac_proxy.cpp
@@ -28,7 +28,6 @@ void DACProxy::setup() {
     }
     ESP_LOGD(TAG, "   active dac: %d", this->restore_state_.dac_output);
     this->active_dac = (DacOutput) this->restore_state_.dac_output;
-    this->activate();
   } else {
     ESP_LOGW(TAG, "Preferences not found, using default settings");
     this->active_dac = LINE_OUT;
@@ -43,6 +42,13 @@ void DACProxy::setup() {
     if (this->tas2780_) {
       this->tas2780_->set_volume(this->restore_state_.speaker_volume);
     }
+  }
+  // XMOS owns the I2S clocks. Keep both paths muted until audio routing is released.
+  if (this->pcm5122_) {
+    this->pcm5122_->set_mute_on();
+  }
+  if (this->tas2780_) {
+    this->tas2780_->set_mute_on();
   }
   this->setup_was_called_ = true;
   this->defer([this]() { this->state_callback_.call(); });

--- a/esphome/components/satellite1/memory_flasher/xmos_flashing.cpp
+++ b/esphome/components/satellite1/memory_flasher/xmos_flashing.cpp
@@ -116,6 +116,7 @@ void XMOSFlasher::erase_memory() {
 
   this->requested_action = ACTION_FULL_ERASE;
   this->state = FLASHER_INITIALIZING;
+  this->publish();
 }
 
 void XMOSFlasher::flash_remote_image() {
@@ -131,6 +132,8 @@ void XMOSFlasher::flash_remote_image() {
     return;
   }
 
+  this->flash_attempted_this_boot_ = true;
+
   if (this->md5_expected_.empty() && !this->http_get_md5_()) {
     ESP_LOGE(TAG, "Couldn't receive expected md5 sum.");
     this->error_code = MD5_INVALID;
@@ -140,6 +143,7 @@ void XMOSFlasher::flash_remote_image() {
 
   this->requested_action = ACTION_FLASH_REMOTE_IMAGE;
   this->state = FLASHER_INITIALIZING;
+  this->publish();
 }
 
 void XMOSFlasher::flash_embedded_image() {
@@ -155,9 +159,12 @@ void XMOSFlasher::flash_embedded_image() {
     return;
   }
 
+  this->flash_attempted_this_boot_ = true;
+
   this->md5_expected_ = this->embedded_image_.md5;
   this->requested_action = ACTION_FLASH_EMBEDDED_IMAGE;
   this->state = FLASHER_INITIALIZING;
+  this->publish();
 }
 
 bool XMOSFlasher::read_JEDECID_() {

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -155,6 +155,7 @@ class Satellite1 : public Component,
   }
 
   void set_spi_flash_direct_access_mode(bool enable);
+  bool is_xmos_connected() const { return this->state == SAT_XMOS_CONNECTED_STATE; }
 
   void set_xmos_rst_pin(GPIOPin *xmos_rst_pin) { this->xmos_rst_pin_ = xmos_rst_pin; }
   template<typename F> void add_on_state_callback(F &&callback) {

--- a/esphome/components/tas2780/audio_dac.py
+++ b/esphome/components/tas2780/audio_dac.py
@@ -3,7 +3,7 @@ from esphome.components import i2c
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components.audio_dac import AudioDac, audio_dac_ns
-from esphome.const import CONF_ID, CONF_MODE, CONF_CHANNEL
+from esphome.const import CONF_ID, CONF_CHANNEL
 
 CODEOWNERS = ["@gnumpi"]
 DEPENDENCIES = ["i2c"]
@@ -46,7 +46,6 @@ CONFIG_SCHEMA = (
 TAS2780_ACTION_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.use_id(tas2780),
-        cv.Optional(CONF_MODE, default=2) : cv.templatable(cv.int_range(min=0, max=3)),
     }
 )
 
@@ -61,9 +60,6 @@ async def tas2780_action(config, action_id, template_arg, args):
 async def tas2780_activate_action(config, action_id, template_arg, args):
     tas2780 = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, tas2780)
-    mode_ = config.get(CONF_MODE)
-    template_ = await cg.templatable(mode_, args, cg.uint8)
-    cg.add(var.set_mode(template_))
     return var
 
 

--- a/esphome/components/tas2780/automation.h
+++ b/esphome/components/tas2780/automation.h
@@ -15,15 +15,7 @@ template<typename... Ts> class ResetAction : public Action<Ts...>, public Parent
 template<typename... Ts> class ActivateAction : public Action<Ts...> {
  public:
   ActivateAction(TAS2780 *parent) : parent_(parent) {}
-  TEMPLATABLE_VALUE(uint8_t, mode)
-
-  void play(const Ts &...x) override {
-    if (this->mode_.has_value()) {
-      this->parent_->activate(this->mode_.value(x...));
-    } else {
-      this->parent_->activate();
-    }
-  }
+  void play(const Ts &...x) override { this->parent_->activate(); }
 
  protected:
   TAS2780 *parent_;

--- a/esphome/components/tas2780/tas2780.cpp
+++ b/esphome/components/tas2780/tas2780.cpp
@@ -332,19 +332,39 @@ void TAS2780::init() {
   this->update_register();
 }
 
-void TAS2780::activate(uint8_t power_mode) {
-  ESP_LOGD(TAG, "Activating TAS2780 (PWR_MODE:%d)", power_mode);
+void TAS2780::activate() {
+  constexpr uint8_t bootstrap_power_mode = 2;
+  ESP_LOGD(TAG, "Activating TAS2780 in bootstrap PWR_MODE:%d", bootstrap_power_mode);
   // clear interrupt latches
   this->reg(TAS2780_INT_CLK_CFG) = 0x19 | (1 << 2);
-  if (power_mode != this->power_mode_) {
-    this->power_mode_ = power_mode;
+  if (bootstrap_power_mode != this->power_mode_) {
+    this->power_mode_ = bootstrap_power_mode;
     this->init();
     this->write_mute_();
   }
-  // activate
   this->reg(TAS2780_MODE_CTRL) =
       (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__ACTIVE;
   this->enable_loop();
+
+  // The TAS SAR ADC only provides valid supply measurements while active.
+  delay(100);
+  float pvdd_voltage;
+  if (!this->read_pvdd_voltage_(&pvdd_voltage)) {
+    ESP_LOGE(TAG, "Couldn't read PVDD; returning TAS2780 to software shutdown");
+    this->deactivate();
+    return;
+  }
+
+  const uint8_t selected_power_mode = pvdd_voltage >= 9.0f ? 2 : 0;
+  ESP_LOGD(TAG, "PVDD: %.3f V; selecting PWR_MODE:%d", pvdd_voltage, selected_power_mode);
+  if (selected_power_mode != this->power_mode_) {
+    this->power_mode_ = selected_power_mode;
+    this->init();
+    this->write_mute_();
+    this->reg(TAS2780_MODE_CTRL) =
+        (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__ACTIVE;
+  }
+  this->active_ = true;
 }
 
 void TAS2780::deactivate() {
@@ -353,11 +373,33 @@ void TAS2780::deactivate() {
   this->reg(TAS2780_MODE_CTRL) =
       (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__SFTW_SHTDWN;
   this->disable_loop();
+  this->active_ = false;
 }
 
 void TAS2780::reset() {
   this->init();
-  this->activate(this->power_mode_);
+  this->activate();
+}
+
+bool TAS2780::read_adc12_(uint8_t msb_reg, uint8_t lsb_reg, uint16_t *raw) {
+  uint8_t msb;
+  uint8_t lsb;
+  if (!this->write_byte(TAS2780_PAGE_SELECT, 0x00) || !this->read_byte(msb_reg, &msb) ||
+      !this->read_byte(lsb_reg, &lsb)) {
+    ESP_LOGE(TAG, "TAS2780 I2C ADC read failed for registers 0x%02X/0x%02X", msb_reg, lsb_reg);
+    return false;
+  }
+  *raw = (static_cast<uint16_t>(msb) << 4) | (lsb >> 4);
+  return true;
+}
+
+bool TAS2780::read_pvdd_voltage_(float *voltage) {
+  uint16_t raw;
+  if (!this->read_adc12_(TAS2780_PVDD_MSB, TAS2780_PVDD_LSB, &raw)) {
+    return false;
+  }
+  *voltage = static_cast<float>(raw) / 64.0f;
+  return true;
 }
 
 void TAS2780::set_power_mode_(const uint8_t power_mode) {

--- a/esphome/components/tas2780/tas2780.cpp
+++ b/esphome/components/tas2780/tas2780.cpp
@@ -148,6 +148,7 @@ static const uint8_t TAS2780_INT_LDO = 0x36;      // Internal LDO Setting
 static const uint8_t TAS2780_SDOUT_HIZ_1 = 0x3D;  // Slots Control
 static const uint8_t TAS2780_SDOUT_HIZ_2 = 0x3E;  // Slots Control
 static const uint8_t TAS2780_SDOUT_HIZ_3 = 0x3F;  // Slots Control
+
 static const uint8_t TAS2780_SDOUT_HIZ_4 = 0x40;  // Slots Control
 static const uint8_t TAS2780_SDOUT_HIZ_5 = 0x41;  // Slots Control
 static const uint8_t TAS2780_SDOUT_HIZ_6 = 0x42;  // Slots Control
@@ -156,6 +157,12 @@ static const uint8_t TAS2780_SDOUT_HIZ_8 = 0x44;  // Slots Control
 static const uint8_t TAS2780_SDOUT_HIZ_9 = 0x45;  // Slots Control
 static const uint8_t TAS2780_TG_EN = 0x47;        // Thermal Detection Enable
 static const uint8_t TAS2780_EDGE_CTRL = 0x4C;    // Slew rate control
+
+static constexpr float TAS2780_POWER_MODE2_MIN_PVDD = 7.4f;
+static constexpr float TAS2780_EXTERNAL_VBAT1S_MIN = 2.9f;
+static constexpr float TAS2780_EXTERNAL_VBAT1S_MAX = 5.5f;
+static const uint8_t TAS2780_PVDD_UVLO_MODE0 = 0x03;  // 2.76 V
+static const uint8_t TAS2780_PVDD_UVLO_MODE2 = 0x11;  // 7.40 V
 
 /* PAGE 0x04*/
 static const uint8_t TAS2780_DG_DC_VAL1 = 0x08;    // Diagnostic DC Level
@@ -309,10 +316,8 @@ void TAS2780::init() {
   // this->reg(TAS2780_CHNL_0) = 0xA1;
   this->set_power_mode_(this->power_mode_);
 
-  // When Y bridge is used (eg. PWR_MODE1) PVDD UVLO threshold needs to be set 2.5 V above VBAT1S level.
-  //  UVLO = 1.753V + val * 0.332V
-  // this->reg(TAS2780_PVDD_UVLO) = 0x12; //PVDD UVLO set to 7.73V
-  this->reg(TAS2780_PVDD_UVLO) = 0x03;  // PVDD UVLO set to 2.76V
+  // PWR_MODE2 requires PVDD to remain at least 2.5 V above its 4.8 V internal VBAT1S LDO.
+  this->reg(TAS2780_PVDD_UVLO) = this->power_mode_ == 2 ? TAS2780_PVDD_UVLO_MODE2 : TAS2780_PVDD_UVLO_MODE0;
 
   // Set interrupt masks
   this->reg(TAS2780_PAGE_SELECT) = 0x00;
@@ -333,7 +338,7 @@ void TAS2780::init() {
 }
 
 void TAS2780::activate() {
-  constexpr uint8_t bootstrap_power_mode = 2;
+  constexpr uint8_t bootstrap_power_mode = 0;
   ESP_LOGD(TAG, "Activating TAS2780 in bootstrap PWR_MODE:%d", bootstrap_power_mode);
   // clear interrupt latches
   this->reg(TAS2780_INT_CLK_CFG) = 0x19 | (1 << 2);
@@ -343,27 +348,37 @@ void TAS2780::activate() {
     this->write_mute_();
   }
   this->reg(TAS2780_MODE_CTRL) =
-      (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__ACTIVE;
+      (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__ACTIVE_MUTED;
   this->enable_loop();
 
   // The TAS SAR ADC only provides valid supply measurements while active.
   delay(100);
-  float pvdd_voltage;
-  if (!this->read_pvdd_voltage_(&pvdd_voltage)) {
-    ESP_LOGE(TAG, "Couldn't read PVDD; returning TAS2780 to software shutdown");
+  SupplyVoltages voltages;
+  if (!this->read_supply_voltages_(&voltages)) {
+    ESP_LOGE(TAG, "Couldn't read supply voltages; returning TAS2780 to software shutdown");
     this->deactivate();
     return;
   }
 
-  const uint8_t selected_power_mode = pvdd_voltage >= 9.0f ? 2 : 0;
-  ESP_LOGD(TAG, "PVDD: %.3f V; selecting PWR_MODE:%d", pvdd_voltage, selected_power_mode);
+  // External VBAT1S from 2.7 V through 2.9 V requires separate OCP programming.
+  uint8_t selected_power_mode;
+  if (voltages.pvdd >= TAS2780_POWER_MODE2_MIN_PVDD) {
+    selected_power_mode = 2;
+  } else if (voltages.vbat1s > TAS2780_EXTERNAL_VBAT1S_MIN && voltages.vbat1s <= TAS2780_EXTERNAL_VBAT1S_MAX) {
+    selected_power_mode = 0;
+  } else {
+    ESP_LOGW(TAG, "No valid TAS2780 power mode for VBAT1S %.3f V and PVDD %.3f V", voltages.vbat1s, voltages.pvdd);
+    this->deactivate();
+    return;
+  }
+  ESP_LOGD(TAG, "Selecting PWR_MODE:%d", selected_power_mode);
   if (selected_power_mode != this->power_mode_) {
     this->power_mode_ = selected_power_mode;
     this->init();
     this->write_mute_();
-    this->reg(TAS2780_MODE_CTRL) =
-        (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__ACTIVE;
   }
+  this->reg(TAS2780_MODE_CTRL) =
+      (TAS2780_MODE_CTRL_BOP_SRC__PVDD_UVLO & ~TAS2780_MODE_CTRL_MODE_MASK) | TAS2780_MODE_CTRL_MODE__ACTIVE;
   this->active_ = true;
 }
 
@@ -393,12 +408,19 @@ bool TAS2780::read_adc12_(uint8_t msb_reg, uint8_t lsb_reg, uint16_t *raw) {
   return true;
 }
 
-bool TAS2780::read_pvdd_voltage_(float *voltage) {
-  uint16_t raw;
-  if (!this->read_adc12_(TAS2780_PVDD_MSB, TAS2780_PVDD_LSB, &raw)) {
+bool TAS2780::read_supply_voltages_(SupplyVoltages *voltages) {
+  uint16_t vbat_raw;
+  uint16_t pvdd_raw;
+  if (!this->write_byte(TAS2780_PAGE_SELECT, 0x00) || !this->read_byte(TAS2780_MODE_CTRL, &voltages->mode_ctrl) ||
+      !this->read_adc12_(TAS2780_VBAT_MSB, TAS2780_VBAT_LSB, &vbat_raw) ||
+      !this->read_adc12_(TAS2780_PVDD_MSB, TAS2780_PVDD_LSB, &pvdd_raw)) {
+    ESP_LOGE(TAG, "TAS2780 I2C supply read failed");
     return false;
   }
-  *voltage = static_cast<float>(raw) / 64.0f;
+  voltages->vbat1s = static_cast<float>(vbat_raw) / 128.0f;
+  voltages->pvdd = static_cast<float>(pvdd_raw) / 64.0f;
+  ESP_LOGD(TAG, "MODE_CTRL: 0x%02X; VBAT1S: %.3f V; PVDD: %.3f V", voltages->mode_ctrl, voltages->vbat1s,
+           voltages->pvdd);
   return true;
 }
 

--- a/esphome/components/tas2780/tas2780.h
+++ b/esphome/components/tas2780/tas2780.h
@@ -19,8 +19,9 @@ class TAS2780 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
 
   void init();
   void reset();
-  void activate(uint8_t power_mode = 2);
+  void activate();
   void deactivate();
+  bool is_active() const { return this->active_; }
   void update_register();
   void log_error_states();
 
@@ -38,10 +39,13 @@ class TAS2780 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
 
  protected:
   void set_power_mode_(const uint8_t power_mode);
+  bool read_adc12_(uint8_t msb_reg, uint8_t lsb_reg, uint16_t *raw);
+  bool read_pvdd_voltage_(float *voltage);
   bool write_mute_();
   bool write_volume_();
 
   float volume_{0};
+  bool active_{false};
   uint8_t power_mode_{2};
   uint8_t amp_level_{8};
   float vol_range_min_{.3};

--- a/esphome/components/tas2780/tas2780.h
+++ b/esphome/components/tas2780/tas2780.h
@@ -38,9 +38,15 @@ class TAS2780 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
   void set_selected_channel(ChannelSelect channel) { this->selected_channel_ = channel; }
 
  protected:
+  struct SupplyVoltages {
+    uint8_t mode_ctrl;
+    float vbat1s;
+    float pvdd;
+  };
+
   void set_power_mode_(const uint8_t power_mode);
   bool read_adc12_(uint8_t msb_reg, uint8_t lsb_reg, uint16_t *raw);
-  bool read_pvdd_voltage_(float *voltage);
+  bool read_supply_voltages_(SupplyVoltages *voltages);
   bool write_mute_();
   bool write_volume_();
 


### PR DESCRIPTION
## Summary

- Gate DAC routing until the XMOS is connected, ready, and not being flashed.
- Keep both DAC outputs muted during startup; restore the selected output only through the shared readiness-gated routing script.
- Prevent TAS2780 activation during XMOS flashing and resume routing only after a successful XMOS-ready resolution.
- Select TAS2780 power mode from measured supply rails instead of the negotiated PD voltage:
  - use `PWR_MODE2` when PVDD is at least 7.4 V;
  - otherwise use `PWR_MODE0` when external VBAT1S is available;
  - retain software shutdown when neither mode is valid.
- Configure PVDD UVLO per selected TAS power mode and log MODE_CTRL, VBAT1S, and PVDD during activation.

closes #346 