### PR TITLE
fix: refresh TAS supplies on PD changes

### DIFF
--- a/config/common/speaker.yaml
+++ b/config/common/speaker.yaml
@@ -88,16 +88,12 @@ select:
             return 0;
 
 script:
-  # The TAS must be active before it can measure PVDD and select its final power mode.
+  # TAS activation remeasures the supplies and selects the applicable power mode.
   - id: tas2780_ensure_active
     mode: single
     then:
-      - if:
-          condition:
-            lambda: return !id(tas2780_active);
-          then:
-            - tas2780.activate:
-            - lambda: id(tas2780_active) = id(speaker_dac).is_active();
+      - tas2780.activate:
+      - lambda: id(tas2780_active) = id(speaker_dac).is_active();
 
   # Both DACs require the XMOS-provided I2S clocks before their outputs are selected.
   - id: activate_audio_output
@@ -127,7 +123,7 @@ script:
           else:
             - dac_proxy.activate_line_out:
 
-  - id: activate_restored_audio_output
+  - id: refresh_audio_output
     mode: restart
     then:
       - script.execute: activate_audio_output

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -62,7 +62,7 @@ esphome:
         - delay: 1s
 
         - lambda: id(audio_output_speaker_requested) = id(dac_proxy).active_dac == 0;
-        - script.execute: activate_restored_audio_output
+        - script.execute: refresh_audio_output
 
         # If after 10 minutes, the device is still initializing (It did not yet connect to Home Assistant), turn off the init_in_progress variable and run the script to refresh the LED status
         - delay: 10min
@@ -111,7 +111,11 @@ fusb302b:
       - text_sensor.template.publish:
           id: pd_state_text
           state: !lambda 'return id(pd_fusb302b).contract;'
-      - script.execute: activate_restored_audio_output
+      - script.execute: refresh_audio_output
+
+  on_disconnect:
+    then:
+      - script.execute: refresh_audio_output
 
 http_request:
 
@@ -169,7 +173,7 @@ satellite1:
                     return id(satellite1_id).is_xmos_connected() && !id(xflash).in_progress();
                 then:
                   - lambda: id(xmos_audio_ready) = true;
-                  - script.execute: activate_restored_audio_output
+                  - script.execute: refresh_audio_output
 
 memory_flasher:
   - platform: satellite1


### PR DESCRIPTION
## Summary

- Refresh TAS2780 supply measurements and power-mode selection whenever speaker routing is refreshed.
- Handle PD disconnects through the same audio refresh path as accepted PD contracts.
- Rename `activate_restored_audio_output` to `refresh_audio_output` to reflect its broader role across boot, XMOS readiness, and PD source changes.
