### PR TITLE
fix: preserve speaker start requests while stopping

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -137,7 +137,14 @@ void I2SAudioSpeaker::loop() {
     }
 
     this->stop_i2s_channel_();
-    xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
+    // A new source can request startup while the old speaker task stops.
+    // Preserve that request rather than clearing it with the stale task state.
+    const EventBits_t bits_before_clear =
+        xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
+    if (bits_before_clear & SpeakerEventGroupBits::COMMAND_START) {
+      ESP_LOGD(TAG, "Start requested while stopping; keeping the request");
+      xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);
+    }
     this->status_clear_error();
 
     this->state_ = speaker::STATE_STOPPED;


### PR DESCRIPTION
### Summary
Ports the upstream ESPHome I2S speaker race fix:
- https://github.com/esphome/esphome/pull/19027
- Upstream commit: 50ca38119873fc717db2ec00ef9b614d5539921b
A COMMAND_START request can arrive while the previous I2S speaker task is stopping. The stale-task cleanup cleared all event bits, discarding that new request and leaving the speaker silent.

### Changes
- Capture the bits returned by xEventGroupClearBits().
- Restore COMMAND_START when it was pending during cleanup.
- Add a debug log for the preserved request.