### PR TITLE
feat: suppress automatic LEDs in manufacturer tests

### DIFF
--- a/config/common/led_ring.yaml
+++ b/config/common/led_ring.yaml
@@ -499,46 +499,48 @@ script:
           }
           if (id(xmos_flashing_state) > 0) {
             id(control_leds_xmos_flasher_state_update).execute();
-          } else if (id(improv_ble_in_progress)) {
-            id(control_leds_improv_ble_state).execute();
-          } else if (id(test_instructions) > 0) {
-            id(control_leds_test_instructions).execute();
-          } else if (id(init_in_progress)) {
-            id(control_leds_init_state).execute();
-          } else if (!id(wifi_id).is_connected() || !id(api_id).is_connected()){
-            id(control_leds_no_ha_connection_state).execute();
-          } else if (id(volume_buttons_touched)) {
-            id(control_leds_volume_buttons_touched).execute();
-          } else if (id(btn_action).state) {
-            id(control_leds_action_button_touched).execute();
-          } else if (id(jack_plugged_recently)) {
-            id(control_leds_jack_plugged_recently).execute();
-          } else if (id(jack_unplugged_recently)) {
-            id(control_leds_jack_unplugged_recently).execute();
-          } else if (id(warning)) {
-            id(control_leds_warning).execute();
-          } else if (id(timer_ringing).state) {
-            id(control_leds_timer_ringing).execute();
-          } else if (id(voice_assistant_phase) == ${voice_assist_waiting_for_command_phase_id}) {
-            id(control_leds_voice_assistant_waiting_for_command_phase).execute();
-          } else if (id(voice_assistant_phase) == ${voice_assist_listening_for_command_phase_id}) {
-            id(control_leds_voice_assistant_listening_for_command_phase).execute();
-          } else if (id(voice_assistant_phase) == ${voice_assist_thinking_phase_id}) {
-            id(control_leds_voice_assistant_thinking_phase).execute();
-          } else if (id(voice_assistant_phase) == ${voice_assist_replying_phase_id}) {
-            id(control_leds_voice_assistant_replying_phase).execute();
-          } else if (id(voice_assistant_phase) == ${voice_assist_error_phase_id}) {
-            id(control_leds_voice_assistant_error_phase).execute();
-          } else if (id(voice_assistant_phase) == ${voice_assist_not_ready_phase_id}) {
-            id(control_leds_voice_assistant_not_ready_phase).execute();
-          } else if (id(is_timer_active)) {
-            id(control_leds_timer_ticking).execute();
-          } else if (id(master_mute_switch).state) {
-            id(control_leds_muted_or_silent).execute();
-          } else if (id(external_media_player).volume == 0.0f || id(external_media_player).is_muted()) {
-            id(control_leds_muted_or_silent).execute();
-          } else if (id(voice_assistant_phase) == ${voice_assist_idle_phase_id}) {
-            id(control_leds_voice_assistant_idle_phase).execute();
+          } else if (${internal_led_automation}) {
+            if (id(improv_ble_in_progress)) {
+              id(control_leds_improv_ble_state).execute();
+            } else if (id(test_instructions) > 0) {
+              id(control_leds_test_instructions).execute();
+            } else if (id(init_in_progress)) {
+              id(control_leds_init_state).execute();
+            } else if (!id(wifi_id).is_connected() || !id(api_id).is_connected()){
+              id(control_leds_no_ha_connection_state).execute();
+            } else if (id(volume_buttons_touched)) {
+              id(control_leds_volume_buttons_touched).execute();
+            } else if (id(btn_action).state) {
+              id(control_leds_action_button_touched).execute();
+            } else if (id(jack_plugged_recently)) {
+              id(control_leds_jack_plugged_recently).execute();
+            } else if (id(jack_unplugged_recently)) {
+              id(control_leds_jack_unplugged_recently).execute();
+            } else if (id(warning)) {
+              id(control_leds_warning).execute();
+            } else if (id(timer_ringing).state) {
+              id(control_leds_timer_ringing).execute();
+            } else if (id(voice_assistant_phase) == ${voice_assist_waiting_for_command_phase_id}) {
+              id(control_leds_voice_assistant_waiting_for_command_phase).execute();
+            } else if (id(voice_assistant_phase) == ${voice_assist_listening_for_command_phase_id}) {
+              id(control_leds_voice_assistant_listening_for_command_phase).execute();
+            } else if (id(voice_assistant_phase) == ${voice_assist_thinking_phase_id}) {
+              id(control_leds_voice_assistant_thinking_phase).execute();
+            } else if (id(voice_assistant_phase) == ${voice_assist_replying_phase_id}) {
+              id(control_leds_voice_assistant_replying_phase).execute();
+            } else if (id(voice_assistant_phase) == ${voice_assist_error_phase_id}) {
+              id(control_leds_voice_assistant_error_phase).execute();
+            } else if (id(voice_assistant_phase) == ${voice_assist_not_ready_phase_id}) {
+              id(control_leds_voice_assistant_not_ready_phase).execute();
+            } else if (id(is_timer_active)) {
+              id(control_leds_timer_ticking).execute();
+            } else if (id(master_mute_switch).state) {
+              id(control_leds_muted_or_silent).execute();
+            } else if (id(external_media_player).volume == 0.0f || id(external_media_player).is_muted()) {
+              id(control_leds_muted_or_silent).execute();
+            } else if (id(voice_assistant_phase) == ${voice_assist_idle_phase_id}) {
+              id(control_leds_voice_assistant_idle_phase).execute();
+            }
           }
 
   # Script executed during Improv BLE

--- a/config/manufacturer_testing.yaml
+++ b/config/manufacturer_testing.yaml
@@ -2,6 +2,7 @@ substitutions:
   node_name: satellite1
   friendly_name: Satellite1 Manufacturer Testing
   log_level: debug
+  internal_led_automation: "false"
   # build_esphome_firmware.sh replaces these with the locally built XMOS test
   # image and checksum. The defaults retain standalone config validation.
   xmos_fw_bin: https://raw.githubusercontent.com/FutureProofHomes/Documentation/refs/heads/main/assets/firmware/xmos/${xmos_fw_version}/satellite1_firmware_fixed_delay.factory.bin

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -14,6 +14,7 @@ substitutions:
 
   esp32_fw_version: dev
   xmos_fw_version: "v1.0.3"
+  internal_led_automation: "true"
 
 globals:
   # Global initialisation variable. Initialized to true and set to false once everything is connected. Only used to have a smooth "plugging" experience


### PR DESCRIPTION
### Summary
Disable automatic LED-ring state patterns in manufacturer test firmware.
Manufacturer tests control the LED ring explicitly. Automatic patterns for Improv, initialization, connectivity, voice-assistant state, mute, timers, and button events can otherwise overwrite those test-controlled states.

### Changes
- Add internal_led_automation, enabled by default in satellite1.base.yaml.
- Override it to false in manufacturer_testing.yaml.
- Gate the automatic LED dispatcher behind that substitution.
- Keep XMOS flashing feedback outside the gate so its progress/error state remains visible.

### Scope
- Production/default firmware behavior is unchanged.
- Explicit manufacturer LED actions remain available.