### PR TITLE
fix: guard W5500 PSRAM patch

### DIFF
--- a/config/manufacturer_testing.yaml
+++ b/config/manufacturer_testing.yaml
@@ -40,6 +40,9 @@ esp32:
       # The ESP-IDF iperf task otherwise starves ESPHome's loop task during TCP sends.
       CONFIG_IPERF_TRAFFIC_TASK_PRIORITY: "1"
 
+ethernet:
+  require_w5500_psram_patch: true
+
 # TestOrbit connects without the production API encryption and must not have its
 # connection state overwrite explicit test-ring commands.
 api:

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -57,6 +57,8 @@ from esphome.core import (
 import esphome.final_validate as fv
 from esphome.types import ConfigType
 
+from .w5500_psram_patch import W5500PsramPatchError, ensure_w5500_psram_patch
+
 AUTO_LOAD = ["network"]
 LOGGER = logging.getLogger(__name__)
 
@@ -114,6 +116,8 @@ CONF_PHY_REGISTERS = "phy_registers"
 CONF_INTERFACE = "interface"
 
 CONF_CLOCK_SPEED = "clock_speed"
+CONF_REQUIRE_W5500_PSRAM_PATCH = "require_w5500_psram_patch"
+W5500_PSRAM_PATCH_IDF_VERSION = cv.Version(5, 5, 5)
 
 EthernetType = ethernet_ns.enum("EthernetType")
 ETHERNET_TYPES = {
@@ -287,6 +291,22 @@ def _validate(config):
         config[CONF_USE_ADDRESS] = use_address
 
     if CORE.is_esp32:
+        if config[CONF_REQUIRE_W5500_PSRAM_PATCH]:
+            if config[CONF_TYPE] != "W5500":
+                raise cv.Invalid(
+                    "'require_w5500_psram_patch' is only supported with type: W5500."
+                )
+            if not CORE.using_toolchain_esp_idf:
+                raise cv.Invalid(
+                    "'require_w5500_psram_patch' requires the native ESP-IDF framework."
+                )
+            from esphome.components.esp32 import idf_version
+
+            if idf_version() != W5500_PSRAM_PATCH_IDF_VERSION:
+                raise cv.Invalid(
+                    "'require_w5500_psram_patch' requires ESP-IDF "
+                    f"{W5500_PSRAM_PATCH_IDF_VERSION}, got {idf_version()}."
+                )
         if config[CONF_TYPE] in SPI_ETHERNET_TYPES:
             # ENC28J60 driver does not support polling mode - interrupt is required
             if config[CONF_TYPE] == "ENC28J60":
@@ -388,6 +408,7 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
         cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
         cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
+        cv.Optional(CONF_REQUIRE_W5500_PSRAM_PATCH, default=False): cv.boolean,
         cv.Optional(CONF_ON_CONNECT): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(single=True),
     }
@@ -522,11 +543,13 @@ CONFIG_SCHEMA = cv.All(
     _validate,
 )
 
+
 def _get_spi_config(spi_id):
     for spi_conf in fv.full_config.get().get(CONF_SPI, []):
         if spi_conf[CONF_ID] == spi_id:
             return spi_conf
     raise cv.Invalid(f"Unable to resolve SPI bus '{spi_id.id}' for ethernet")
+
 
 def _final_validate_spi(config):
     if not CORE.is_esp32:
@@ -580,8 +603,22 @@ def phy_register(address: int, value: int, page: int):
     )
 
 
+def _ensure_w5500_psram_patch() -> None:
+    try:
+        applied = ensure_w5500_psram_patch()
+    except W5500PsramPatchError as err:
+        raise cv.Invalid(str(err)) from err
+    if applied:
+        LOGGER.info("Applied W5500 PSRAM receive-buffer patch to ESP-IDF.")
+    else:
+        LOGGER.info("Verified W5500 PSRAM receive-buffer patch in ESP-IDF.")
+
+
 @coroutine_with_priority(CoroPriority.COMMUNICATION)
 async def to_code(config):
+    if config[CONF_REQUIRE_W5500_PSRAM_PATCH]:
+        _ensure_w5500_psram_patch()
+
     var = cg.new_Pvariable(config[CONF_ID])
 
     # Apply network priority before register_component (which emits the user's

--- a/esphome/components/ethernet/patches/esp-idf-5.5.5-w5500-psram-rx-buffer.patch
+++ b/esphome/components/ethernet/patches/esp-idf-5.5.5-w5500-psram-rx-buffer.patch
@@ -1,0 +1,12 @@
+diff --git a/components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c b/components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c
+--- a/components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c
++++ b/components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c
+@@ -683,7 +683,7 @@ static esp_err_t emac_w5500_receive(esp_eth_mac_t *mac, uint8_t **buf, uint32_t
+          copy_len = rx_len > *length ? *length : rx_len;
+          // runt frames are not forwarded by W5500 (tested on target), but check the length anyway since it could be corrupted at SPI bus
+          ESP_GOTO_ON_FALSE(copy_len >= ETH_MIN_PACKET_SIZE - ETH_CRC_LEN, ESP_ERR_INVALID_SIZE, err, TAG, "invalid frame length %" PRIu32, copy_len);
+-        *buf = malloc(copy_len);
++        *buf = heap_caps_malloc(copy_len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+          if (*buf != NULL) {
+              emac_w5500_auto_buf_info_t *buff_info = (emac_w5500_auto_buf_info_t *)*buf;
+              buff_info->offset = offset;

--- a/esphome/components/ethernet/patches/esp-idf-5.5.5-w5500-psram-rx-buffer.patch
+++ b/esphome/components/ethernet/patches/esp-idf-5.5.5-w5500-psram-rx-buffer.patch
@@ -2,11 +2,11 @@ diff --git a/components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c b/components/e
 --- a/components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c
 +++ b/components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c
 @@ -683,7 +683,7 @@ static esp_err_t emac_w5500_receive(esp_eth_mac_t *mac, uint8_t **buf, uint32_t
-          copy_len = rx_len > *length ? *length : rx_len;
-          // runt frames are not forwarded by W5500 (tested on target), but check the length anyway since it could be corrupted at SPI bus
-          ESP_GOTO_ON_FALSE(copy_len >= ETH_MIN_PACKET_SIZE - ETH_CRC_LEN, ESP_ERR_INVALID_SIZE, err, TAG, "invalid frame length %" PRIu32, copy_len);
+         copy_len = rx_len > *length ? *length : rx_len;
+         // runt frames are not forwarded by W5500 (tested on target), but check the length anyway since it could be corrupted at SPI bus
+         ESP_GOTO_ON_FALSE(copy_len >= ETH_MIN_PACKET_SIZE - ETH_CRC_LEN, ESP_ERR_INVALID_SIZE, err, TAG, "invalid frame length %" PRIu32, copy_len);
 -        *buf = malloc(copy_len);
 +        *buf = heap_caps_malloc(copy_len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-          if (*buf != NULL) {
-              emac_w5500_auto_buf_info_t *buff_info = (emac_w5500_auto_buf_info_t *)*buf;
-              buff_info->offset = offset;
+         if (*buf != NULL) {
+             emac_w5500_auto_buf_info_t *buff_info = (emac_w5500_auto_buf_info_t *)*buf;
+             buff_info->offset = offset;

--- a/esphome/components/ethernet/w5500_psram_patch.py
+++ b/esphome/components/ethernet/w5500_psram_patch.py
@@ -10,6 +10,11 @@ import subprocess
 W5500_PSRAM_PATCH = (
     Path(__file__).parent / "patches" / "esp-idf-5.5.5-w5500-psram-rx-buffer.patch"
 )
+W5500_SOURCE = Path("components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c")
+UNPATCHED_ALLOCATION = "*buf = malloc(copy_len);"
+PATCHED_ALLOCATION = (
+    "*buf = heap_caps_malloc(copy_len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);"
+)
 
 
 class W5500PsramPatchError(RuntimeError):
@@ -17,13 +22,11 @@ class W5500PsramPatchError(RuntimeError):
 
 
 def _run_patch(
-    idf_path: Path, *, reverse: bool = False, dry_run: bool = False
+    idf_path: Path, *, dry_run: bool = False
 ) -> subprocess.CompletedProcess[bytes]:
     command = ["patch", "--batch", "--forward"]
     if dry_run:
         command.append("--dry-run")
-    if reverse:
-        command.append("-R")
     command.extend(["-p1", "-d", str(idf_path)])
     return subprocess.run(
         command,
@@ -44,15 +47,32 @@ def ensure_w5500_psram_patch(idf_path: Path | None = None) -> bool:
             )
         idf_path = Path(idf_path_value)
 
+    source_path = idf_path / W5500_SOURCE
+    if not source_path.is_file():
+        raise W5500PsramPatchError(f"Missing ESP-IDF W5500 source: {source_path}")
     if not W5500_PSRAM_PATCH.is_file():
         raise W5500PsramPatchError(f"Missing W5500 PSRAM patch: {W5500_PSRAM_PATCH}")
+
+    source = source_path.read_text(encoding="utf-8")
+    if PATCHED_ALLOCATION in source:
+        if UNPATCHED_ALLOCATION not in source:
+            return False
+        raise W5500PsramPatchError(
+            "The active ESP-IDF W5500 source has conflicting receive-buffer "
+            "allocations. Use a clean ESP-IDF 5.5.5 framework."
+        )
+    if UNPATCHED_ALLOCATION not in source:
+        raise W5500PsramPatchError(
+            "The active ESP-IDF W5500 source has an unknown receive-buffer "
+            "allocation. Use a clean ESP-IDF 5.5.5 framework."
+        )
 
     try:
         if _run_patch(idf_path, dry_run=True).returncode == 0:
             if _run_patch(idf_path).returncode == 0:
-                return True
-        elif _run_patch(idf_path, reverse=True, dry_run=True).returncode == 0:
-            return False
+                source = source_path.read_text(encoding="utf-8")
+                if PATCHED_ALLOCATION in source and UNPATCHED_ALLOCATION not in source:
+                    return True
     except OSError as err:
         raise W5500PsramPatchError("The system 'patch' command is required.") from err
 

--- a/esphome/components/ethernet/w5500_psram_patch.py
+++ b/esphome/components/ethernet/w5500_psram_patch.py
@@ -41,11 +41,15 @@ def ensure_w5500_psram_patch(idf_path: Path | None = None) -> bool:
     """Apply the patch and return whether it changed the framework source."""
     if idf_path is None:
         idf_path_value = os.environ.get("IDF_PATH")
-        if not idf_path_value:
-            raise W5500PsramPatchError(
-                "IDF_PATH is required to identify the native ESP-IDF framework."
-            )
-        idf_path = Path(idf_path_value)
+        if idf_path_value:
+            idf_path = Path(idf_path_value)
+        else:
+            from esphome.const import KEY_CORE, KEY_FRAMEWORK_VERSION
+            from esphome.core import CORE
+            from esphome.espidf.framework import _get_framework_path
+
+            version = str(CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION])
+            idf_path = _get_framework_path(version)
 
     source_path = idf_path / W5500_SOURCE
     if not source_path.is_file():

--- a/esphome/components/ethernet/w5500_psram_patch.py
+++ b/esphome/components/ethernet/w5500_psram_patch.py
@@ -1,0 +1,62 @@
+"""Apply the required ESP-IDF 5.5.5 W5500 receive-buffer patch."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+
+W5500_PSRAM_PATCH = (
+    Path(__file__).parent / "patches" / "esp-idf-5.5.5-w5500-psram-rx-buffer.patch"
+)
+
+
+class W5500PsramPatchError(RuntimeError):
+    """The active ESP-IDF source cannot safely receive the required patch."""
+
+
+def _run_patch(
+    idf_path: Path, *, reverse: bool = False, dry_run: bool = False
+) -> subprocess.CompletedProcess[bytes]:
+    command = ["patch", "--batch", "--forward"]
+    if dry_run:
+        command.append("--dry-run")
+    if reverse:
+        command.append("-R")
+    command.extend(["-p1", "-d", str(idf_path)])
+    return subprocess.run(
+        command,
+        input=W5500_PSRAM_PATCH.read_bytes(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def ensure_w5500_psram_patch(idf_path: Path | None = None) -> bool:
+    """Apply the patch and return whether it changed the framework source."""
+    if idf_path is None:
+        idf_path_value = os.environ.get("IDF_PATH")
+        if not idf_path_value:
+            raise W5500PsramPatchError(
+                "IDF_PATH is required to identify the native ESP-IDF framework."
+            )
+        idf_path = Path(idf_path_value)
+
+    if not W5500_PSRAM_PATCH.is_file():
+        raise W5500PsramPatchError(f"Missing W5500 PSRAM patch: {W5500_PSRAM_PATCH}")
+
+    try:
+        if _run_patch(idf_path, dry_run=True).returncode == 0:
+            if _run_patch(idf_path).returncode == 0:
+                return True
+        elif _run_patch(idf_path, reverse=True, dry_run=True).returncode == 0:
+            return False
+    except OSError as err:
+        raise W5500PsramPatchError("The system 'patch' command is required.") from err
+
+    raise W5500PsramPatchError(
+        "The active ESP-IDF source does not match the expected W5500 PSRAM "
+        "patch state. Use a clean ESP-IDF 5.5.5 framework."
+    )

--- a/tests/test_w5500_psram_patch.py
+++ b/tests/test_w5500_psram_patch.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "esphome"
+    / "components"
+    / "ethernet"
+    / "w5500_psram_patch.py"
+)
+SPEC = importlib.util.spec_from_file_location("w5500_psram_patch", MODULE_PATH)
+assert SPEC and SPEC.loader
+w5500_psram_patch = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(w5500_psram_patch)
+
+
+def _unpatched_source() -> str:
+    patch_lines = w5500_psram_patch.W5500_PSRAM_PATCH.read_text(
+        encoding="utf-8"
+    ).splitlines()
+    hunk_start = next(i for i, line in enumerate(patch_lines) if line.startswith("@@"))
+    source_lines = [
+        line[1:]
+        for line in patch_lines[hunk_start + 1 :]
+        if line.startswith((" ", "-"))
+    ]
+    return "\n" * 682 + "\n".join(source_lines) + "\n"
+
+
+class W5500PsramPatchTest(unittest.TestCase):
+    def _idf_tree(self) -> tuple[Path, Path]:
+        path = Path(self.temporary_directory)
+        target = path / "components/esp_eth/src/spi/w5500/esp_eth_mac_w5500.c"
+        target.parent.mkdir(parents=True)
+        return path, target
+
+    def setUp(self) -> None:
+        self.temporary_directory = self.enterContext(tempfile.TemporaryDirectory())
+
+    def test_applies_patch_once_and_accepts_verified_state(self) -> None:
+        idf_path, target = self._idf_tree()
+        target.write_text(_unpatched_source(), encoding="utf-8")
+
+        dry_run = w5500_psram_patch._run_patch(idf_path, dry_run=True)
+        self.assertEqual(dry_run.returncode, 0, dry_run.stdout.decode())
+        self.assertTrue(w5500_psram_patch.ensure_w5500_psram_patch(idf_path))
+        self.assertIn("heap_caps_malloc", target.read_text(encoding="utf-8"))
+        self.assertFalse(w5500_psram_patch.ensure_w5500_psram_patch(idf_path))
+
+    def test_rejects_unknown_framework_source(self) -> None:
+        idf_path, target = self._idf_tree()
+        target.write_text("unknown framework source\n", encoding="utf-8")
+
+        with self.assertRaises(w5500_psram_patch.W5500PsramPatchError):
+            w5500_psram_patch.ensure_w5500_psram_patch(idf_path)

--- a/tests/test_w5500_psram_patch.py
+++ b/tests/test_w5500_psram_patch.py
@@ -58,3 +58,13 @@ class W5500PsramPatchTest(unittest.TestCase):
 
         with self.assertRaises(w5500_psram_patch.W5500PsramPatchError):
             w5500_psram_patch.ensure_w5500_psram_patch(idf_path)
+
+    def test_rejects_source_with_both_allocation_modes(self) -> None:
+        idf_path, target = self._idf_tree()
+        target.write_text(
+            _unpatched_source() + w5500_psram_patch.PATCHED_ALLOCATION + "\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaises(w5500_psram_patch.W5500PsramPatchError):
+            w5500_psram_patch.ensure_w5500_psram_patch(idf_path)


### PR DESCRIPTION
## Summary

Ensure native ESP-IDF 5.5.5 W5500 builds use the PSRAM receive-buffer allocation required for reliable Ethernet RX throughput.

- Add `require_w5500_psram_patch` for W5500 manufacturer-test builds.
- Validate the guard is limited to native ESP-IDF 5.5.5 W5500 configurations.
- Apply and verify the checked-in W5500 PSRAM receive-buffer patch before compilation.
- Correct the patch hunk so it applies to ESP-IDF 5.5.5.
